### PR TITLE
mockup(experiment): single-sidebar + breadcrumb stepper IA — A/B variant

### DIFF
--- a/mockups/tadaify-mvp/app-dashboard-v2.html
+++ b/mockups/tadaify-mvp/app-dashboard-v2.html
@@ -1,0 +1,4458 @@
+<!DOCTYPE html>
+<!--
+  type: mockup
+  project: tadaify
+  title: Dashboard variant — single sidebar + breadcrumb stepper (A/B against app-dashboard.html)
+  created_at: 2026-04-25
+  author: orchestrator-opus-4.7
+  status: draft-for-review
+  baseline: app-dashboard.html (latest on main)
+
+  Experiment: collapse Design's secondary left rail into expandable
+  sub-items inside the main sidebar. Add a breadcrumb-style stepper
+  (prev / current / next) at the top of each Design sub-section for
+  sequential walkthrough. Everything else identical.
+
+  Goal: A/B comparison. User picks one IA + applies winning variant
+  back to app-dashboard.html in a follow-up.
+
+  All locked DECs respected (same as app-dashboard.html base):
+  DEC-019, DEC-WORDMARK-01, DEC-PRICELOCK-01/02, DEC-MULTIPAGE-01,
+  DEC-LAYOUT-01, DEC-CREATOR-API-01, DEC-AI-QUOTA-LADDER-01,
+  DEC-AI-FEATURES-ROADMAP-01, DEC-ANIMATIONS-SPLIT-01,
+  DEC-WALLPAPER-ANIM-01, DEC-PINNED-MSG-01, DEC-CUSTOM-DOMAIN-NAV-01,
+  DEC-OPT-BADGE, DEC-CUSTOM-DOMAIN-PROVIDER-01,
+  DEC-CUSTOM-DOMAIN-VALIDATION-01.
+
+  Anti-patterns: AP-001 / AP-013 / AP-017 / AP-031 — all enforced.
+
+  URL state (extends app-dashboard.html):
+    ?handle=alexandra (default)
+    ?tab=pages|page|design|insights|shop|settings (default page)
+    ?subtab=theme|profile|background|text|buttons|animations|colors|footer (default background)
+    ?device=mobile|tablet|desktop (default mobile)
+    ?state=ready|empty (default ready)
+    ?nav=expanded — auto-expand Design accordion on load when on a Design sub-tab (default behavior)
+-->
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dashboard v2 (single-nav A/B) — tadaify</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@400;500;600;700&family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&family=Playfair+Display:wght@500;600&family=Fraunces:opsz,wght@9..144,500;9..144,600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="./shared/tokens.css">
+  <style>
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body {
+      background: var(--bg);
+      color: var(--fg);
+      font-family: var(--font-sans);
+      min-height: 100vh;
+    }
+    button { font-family: inherit; cursor: pointer; }
+    a { color: inherit; text-decoration: none; }
+
+    /* --------------------------------------------------------------
+       Wordmark — ta / da! / ify
+       -------------------------------------------------------------- */
+    .wm { font-family: var(--font-display); font-weight: 600; letter-spacing: -0.02em; }
+    .wm .ta  { color: var(--wm-ta); }
+    .wm .da  { color: var(--wm-da); }
+    .wm .ify { color: var(--wm-ify); }
+
+    /* --------------------------------------------------------------
+       Shared atoms
+       -------------------------------------------------------------- */
+    .chip {
+      display: inline-flex; align-items: center; gap: 6px;
+      padding: 3px 9px; border-radius: 999px;
+      font-size: 11px; font-weight: 600; line-height: 1;
+      background: var(--bg-muted); color: var(--fg-muted);
+      white-space: nowrap;
+    }
+    .chip.live    { background: var(--success-bg); color: #065F46; }
+    .chip.hidden  { background: var(--bg-sunken); color: var(--fg-muted); }
+    .chip.pro     {
+      background: linear-gradient(135deg, rgba(245,158,11,0.15), rgba(245,158,11,0.08));
+      color: var(--brand-warm-dark);
+      border: 1px solid rgba(245,158,11,0.3);
+    }
+    .chip.verified { background: rgba(99,102,241,0.12); color: var(--brand-primary); }
+
+    .btn {
+      font-family: var(--font-sans); font-weight: 500; font-size: 14px;
+      border-radius: 10px; padding: 9px 16px;
+      border: 1px solid transparent; cursor: pointer;
+      display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+      transition: all .15s ease;
+      line-height: 1.2;
+    }
+    .btn-primary { background: var(--brand-primary); color: #fff; }
+    .btn-primary:hover { background: var(--brand-primary-hover); }
+    .btn-ghost   { background: var(--bg-elevated); color: var(--fg); border-color: var(--border-strong); }
+    .btn-ghost:hover { background: var(--bg-muted); }
+    .btn-sm      { padding: 6px 12px; font-size: 13px; border-radius: 8px; }
+
+    .iconbtn {
+      display: inline-flex; align-items: center; justify-content: center;
+      width: 32px; height: 32px; border-radius: 8px;
+      background: transparent; border: 1px solid transparent; color: var(--fg-muted);
+      transition: all .12s ease;
+    }
+    .iconbtn:hover { background: var(--bg-muted); color: var(--fg); }
+    .iconbtn svg { width: 16px; height: 16px; }
+
+    [data-tip] { position: relative; }
+    [data-tip]::after {
+      content: attr(data-tip);
+      position: absolute; left: 50%; bottom: calc(100% + 6px);
+      transform: translateX(-50%) translateY(4px);
+      background: var(--bg-dark); color: #fff;
+      font-size: 11px; font-weight: 500;
+      padding: 5px 9px; border-radius: 6px;
+      white-space: nowrap; pointer-events: none;
+      opacity: 0; transition: opacity .12s ease, transform .12s ease;
+      z-index: 200;
+    }
+    [data-tip]:hover::after { opacity: 1; transform: translateX(-50%) translateY(0); }
+
+    /* Social icon swatches */
+    .social-ig  { background: linear-gradient(135deg,#833AB4 0%,#C13584 40%,#E1306C 70%,#F77737 100%); }
+    .social-tt  { background: #000; }
+    .social-yt  { background: #FF0000; }
+    .social-x   { background: #000; }
+    .social-sp  { background: #1DB954; }
+    .social-em  { background: #4B5563; }
+
+    /* --------------------------------------------------------------
+       Top app bar
+       -------------------------------------------------------------- */
+    .appbar {
+      position: sticky; top: 0; z-index: 40;
+      background: var(--bg-elevated);
+      border-bottom: 1px solid var(--border);
+      padding: 10px 16px;
+      display: flex; align-items: center; gap: 14px;
+      box-shadow: 0 1px 0 rgba(17,24,39,0.02);
+    }
+    .appbar .brand { display: flex; align-items: center; gap: 10px; }
+    .appbar .brand .wm { font-size: 20px; }
+    .appbar .env {
+      display: none;
+      font-size: 11px; color: var(--fg-subtle);
+      text-transform: uppercase; letter-spacing: 0.08em;
+      padding: 4px 8px; border-radius: 6px; background: var(--bg-muted);
+    }
+    @media (min-width: 900px) { .appbar .env { display: inline-block; } }
+    .appbar .spacer { flex: 1; }
+    .appbar .handle-pill {
+      display: inline-flex; align-items: center; gap: 8px;
+      padding: 6px 12px; border: 1px solid var(--border); border-radius: 999px;
+      background: var(--bg);
+      font-size: 13px; color: var(--fg-muted);
+    }
+    .appbar .handle-pill b { color: var(--fg); font-weight: 600; }
+    .appbar .handle-pill .live-dot {
+      width: 7px; height: 7px; border-radius: 50%;
+      background: var(--success);
+      box-shadow: 0 0 0 3px rgba(16,185,129,0.18);
+    }
+    .appbar .handle-pill .hide-sm { display: none; }
+    @media (min-width: 640px) { .appbar .handle-pill .hide-sm { display: inline; } }
+    .appbar .avatar-mini {
+      width: 32px; height: 32px; border-radius: 50%;
+      background: var(--hero-gradient);
+      display: flex; align-items: center; justify-content: center;
+      color: #fff; font-weight: 600; font-size: 13px;
+      font-family: var(--font-display);
+      flex-shrink: 0;
+    }
+    /* Theme toggle — replaces avatar in top-right */
+    .appbar .theme-toggle { position: relative; }
+    .appbar .theme-toggle svg {
+      width: 18px; height: 18px;
+      transition: opacity .2s ease, transform .3s cubic-bezier(.2,.8,.2,1);
+    }
+    .appbar .theme-icon-moon { position: absolute; opacity: 0; transform: rotate(-30deg) scale(0.6); }
+    body.dark-mode .appbar .theme-icon-sun  { opacity: 0; transform: rotate(30deg) scale(0.6); }
+    body.dark-mode .appbar .theme-icon-moon { opacity: 1; transform: rotate(0) scale(1); }
+
+    /* --------------------------------------------------------------
+       Grid layout: sidebar / main / preview
+       -------------------------------------------------------------- */
+    .layout {
+      display: grid;
+      grid-template-columns: 1fr;
+      min-height: calc(100vh - 54px);
+    }
+    @media (min-width: 720px) {
+      .layout { grid-template-columns: 72px 1fr; }
+    }
+    @media (min-width: 1180px) {
+      .layout { grid-template-columns: 240px 1fr 400px; }
+    }
+
+    /* --------------------------------------------------------------
+       Sidebar
+       -------------------------------------------------------------- */
+    aside.side {
+      display: none;
+      background: var(--bg-elevated);
+      border-right: 1px solid var(--border);
+      padding: 18px 10px 18px;
+      flex-direction: column; gap: 8px;
+      position: sticky; top: 54px; align-self: start;
+      height: calc(100vh - 54px);
+      overflow-y: auto;
+    }
+    @media (min-width: 720px) { aside.side { display: flex; } }
+
+    .side-user {
+      display: flex; align-items: center; gap: 10px;
+      padding: 8px; border-radius: 10px;
+      border: 1px solid var(--border);
+      background: var(--bg);
+    }
+    .side-user .av {
+      width: 34px; height: 34px; border-radius: 50%;
+      background: var(--hero-gradient);
+      display: flex; align-items: center; justify-content: center;
+      color: #fff; font-family: var(--font-display); font-weight: 600; font-size: 15px;
+      flex-shrink: 0;
+    }
+    .side-user .utxt { min-width: 0; flex: 1; }
+    .side-user .uname { font-size: 13px; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .side-user .uhandle { font-size: 11px; color: var(--fg-muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .side-user .chevron { color: var(--fg-subtle); }
+
+    .nav-group { display: flex; flex-direction: column; gap: 2px; padding-top: 8px; }
+    .nav-group + .nav-group {
+      border-top: 1px solid var(--border); padding-top: 8px; margin-top: 4px;
+    }
+    .nav-label {
+      font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em;
+      color: var(--fg-subtle); font-weight: 600;
+      padding: 6px 10px 2px;
+    }
+    .nav-item {
+      display: flex; align-items: center; gap: 12px;
+      width: 100%; padding: 9px 10px; border-radius: 9px;
+      font-size: 13.5px; font-weight: 500;
+      background: transparent; border: 0; color: var(--fg);
+      text-align: left; transition: background .12s ease, color .12s ease;
+    }
+    .nav-item svg { width: 17px; height: 17px; flex-shrink: 0; color: var(--fg-muted); }
+    .nav-item:hover { background: var(--bg-muted); }
+    .nav-item.active {
+      background: rgba(99,102,241,0.10);
+      color: var(--brand-primary);
+    }
+    .nav-item.active svg { color: var(--brand-primary); }
+    .nav-item .nav-count {
+      margin-left: auto;
+      font-size: 11px; font-weight: 600;
+      padding: 1px 7px; border-radius: 999px;
+      background: var(--bg-muted); color: var(--fg-muted);
+    }
+    .nav-item.active .nav-count {
+      background: rgba(99,102,241,0.15); color: var(--brand-primary);
+    }
+    .nav-divider {
+      border-top: 1px solid var(--border);
+      margin: 6px 0;
+    }
+    .nav-add-page {
+      padding-left: 22px !important;
+      cursor: not-allowed !important;
+      opacity: 0.55;
+      font-style: italic;
+    }
+    .nav-add-page .nav-icon {
+      width: 17px; height: 17px; flex-shrink: 0;
+      color: var(--fg-subtle);
+      display: flex; align-items: center; justify-content: center;
+      font-size: 14px; font-weight: 500;
+    }
+    .nav-add-page .nav-pill {
+      margin-left: auto;
+      font-size: 10px; font-weight: 600;
+      padding: 1px 6px; border-radius: 99px;
+      background: var(--bg-muted); color: var(--fg-subtle);
+      white-space: nowrap;
+    }
+    .nav-add-page:hover { background: transparent !important; }
+
+    /* --------------------------------------------------------------
+       V2 — Sidebar accordion: Design parent + collapsible sub-items
+       (replaces the secondary left rail in app-dashboard.html)
+       -------------------------------------------------------------- */
+    .nav-design-parent {
+      position: relative;
+    }
+    .nav-design-parent .nav-caret {
+      margin-left: auto; flex-shrink: 0;
+      width: 14px; height: 14px;
+      color: var(--fg-subtle);
+      transition: transform .18s ease;
+    }
+    .nav-design-parent[aria-expanded="true"] .nav-caret { transform: rotate(90deg); }
+    .nav-design-parent[aria-expanded="true"] {
+      background: var(--bg-muted);
+      color: var(--fg);
+    }
+    .nav-design-parent[aria-expanded="true"].active {
+      background: rgba(99,102,241,0.10);
+      color: var(--brand-primary);
+    }
+
+    .nav-sub-list {
+      display: none;
+      flex-direction: column; gap: 1px;
+      margin: 2px 0 4px 0;
+      padding-left: 8px;
+      border-left: 1px solid var(--border);
+      margin-left: 17px; /* aligns under parent icon */
+    }
+    .nav-sub-list[data-expanded="true"] { display: flex; }
+
+    .nav-sub-item {
+      display: flex; align-items: center; gap: 9px;
+      width: 100%; padding: 6px 10px; border-radius: 7px;
+      font-size: 12.5px; font-weight: 500;
+      background: transparent; border: 0; color: var(--fg-muted);
+      text-align: left; transition: background .12s ease, color .12s ease;
+      cursor: pointer;
+    }
+    .nav-sub-item svg { width: 14px; height: 14px; flex-shrink: 0; color: var(--fg-subtle); }
+    .nav-sub-item:hover { background: var(--bg-muted); color: var(--fg); }
+    .nav-sub-item.active {
+      background: rgba(99,102,241,0.10);
+      color: var(--brand-primary);
+      font-weight: 600;
+    }
+    .nav-sub-item.active svg { color: var(--brand-primary); }
+
+    /* Tablet rail — icons only */
+    @media (min-width: 720px) and (max-width: 1179px) {
+      aside.side { padding: 14px 8px; }
+      .side-user .utxt, .side-user .chevron { display: none; }
+      .nav-label { display: none; }
+      .nav-item { justify-content: center; padding: 10px 6px; }
+      .nav-item > span.label, .nav-item .nav-count { display: none; }
+      .nav-item svg { width: 20px; height: 20px; }
+      /* On tablet the accordion expands to a tooltip-like flyout instead of inline list */
+      .nav-design-parent .nav-caret { display: none; }
+      .nav-sub-list { display: none !important; }
+    }
+
+    /* --------------------------------------------------------------
+       V2 — Breadcrumb stepper (top of Design sub-section content)
+       -------------------------------------------------------------- */
+    .design-stepper {
+      display: none; /* shown only when tab=design */
+      align-items: center; justify-content: space-between;
+      gap: 8px;
+      padding: 10px 14px;
+      background: linear-gradient(180deg, rgba(99,102,241,0.06), rgba(99,102,241,0.03));
+      border: 1px solid rgba(99,102,241,0.18);
+      border-radius: 12px;
+      margin-bottom: 18px;
+      position: relative;
+    }
+    .layout[data-tab="design"] .design-stepper { display: flex; }
+
+    .stepper-cell {
+      display: flex; align-items: center; gap: 7px;
+      padding: 7px 12px; border-radius: 8px;
+      background: transparent; border: 0;
+      font-size: 13px; font-weight: 500; color: var(--fg-muted);
+      cursor: pointer;
+      transition: background .12s ease, color .12s ease;
+      min-width: 0;
+    }
+    .stepper-cell:hover:not(:disabled) {
+      background: rgba(255,255,255,0.7);
+      color: var(--fg);
+    }
+    .stepper-cell:disabled {
+      opacity: 0.35; cursor: default;
+    }
+    .stepper-cell svg.chev {
+      width: 13px; height: 13px; color: currentColor; flex-shrink: 0;
+    }
+    .stepper-cell.is-current {
+      background: rgba(255,255,255,0.85);
+      color: var(--brand-primary);
+      font-weight: 700;
+      font-size: 13.5px;
+      box-shadow: 0 1px 2px rgba(99,102,241,0.10);
+      flex: 1; justify-content: center;
+      position: relative;
+    }
+    .stepper-cell.is-current .step-spark {
+      width: 6px; height: 6px; border-radius: 50%;
+      background: var(--brand-primary);
+      box-shadow: 0 0 0 3px rgba(99,102,241,0.18);
+      flex-shrink: 0;
+    }
+    .stepper-cell.is-current::after {
+      content: '';
+      width: 0; height: 0;
+      border-left: 4px solid transparent;
+      border-right: 4px solid transparent;
+      border-top: 4px solid currentColor;
+      margin-left: 6px;
+      opacity: 0.55;
+      flex-shrink: 0;
+    }
+    .stepper-divider {
+      width: 1px; height: 18px; background: rgba(99,102,241,0.20); flex-shrink: 0;
+    }
+
+    /* Stepper dropdown — full picker of all 8 sub-tabs */
+    .stepper-dropdown {
+      display: none;
+      position: absolute; top: calc(100% + 6px); left: 50%; transform: translateX(-50%);
+      min-width: 220px;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      box-shadow: 0 8px 24px rgba(15, 23, 42, 0.12);
+      padding: 6px;
+      z-index: 20;
+    }
+    .stepper-dropdown[data-open="true"] { display: block; }
+    .stepper-dropdown-item {
+      display: flex; align-items: center; gap: 9px;
+      width: 100%; padding: 8px 10px; border-radius: 7px;
+      background: transparent; border: 0;
+      font-size: 13px; font-weight: 500; color: var(--fg);
+      text-align: left; cursor: pointer;
+      transition: background .12s ease;
+    }
+    .stepper-dropdown-item:hover { background: var(--bg-muted); }
+    .stepper-dropdown-item.is-current {
+      background: rgba(99,102,241,0.10);
+      color: var(--brand-primary); font-weight: 600;
+    }
+    .stepper-dropdown-item .radio-dot {
+      width: 14px; height: 14px; border-radius: 50%;
+      border: 1.5px solid var(--border);
+      flex-shrink: 0;
+      display: flex; align-items: center; justify-content: center;
+    }
+    .stepper-dropdown-item.is-current .radio-dot {
+      border-color: var(--brand-primary);
+    }
+    .stepper-dropdown-item.is-current .radio-dot::after {
+      content: ''; width: 7px; height: 7px; border-radius: 50%;
+      background: var(--brand-primary);
+    }
+
+    /* Mobile stepper — collapse to single label + chevrons */
+    @media (max-width: 719px) {
+      .design-stepper { padding: 8px 10px; }
+      .stepper-cell:not(.is-current):not(.stepper-arrow) { display: none; }
+      .stepper-divider { display: none; }
+      .stepper-arrow {
+        padding: 7px 9px;
+      }
+      .stepper-arrow .stepper-arrow-label { display: none; }
+    }
+
+    /* --------------------------------------------------------------
+       Main content shell
+       -------------------------------------------------------------- */
+    main.content {
+      padding: 24px 20px 100px;
+      min-width: 0;
+    }
+    @media (min-width: 720px) { main.content { padding: 28px 28px 40px; } }
+    .page-head {
+      display: flex; align-items: flex-end; justify-content: space-between;
+      gap: 16px; flex-wrap: wrap;
+      padding-bottom: 18px; border-bottom: 1px solid var(--border);
+    }
+    .page-head h1 {
+      font-family: var(--font-display); font-weight: 600;
+      font-size: 30px; margin: 0; letter-spacing: -0.01em;
+    }
+    .page-head .sub {
+      color: var(--fg-muted); font-size: 13.5px; margin-top: 4px;
+      display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+    }
+    .page-head .sub .dot { width: 3px; height: 3px; border-radius: 50%; background: var(--fg-subtle); }
+    .page-head .actions { display: flex; gap: 8px; }
+
+    /* Welcome banner (ready state) */
+    .welcome-banner {
+      margin-top: 22px;
+      background: linear-gradient(135deg, rgba(99,102,241,0.06), rgba(245,158,11,0.06));
+      border: 1px solid rgba(99,102,241,0.15);
+      border-radius: 14px;
+      padding: 14px 18px;
+      display: flex; align-items: center; gap: 14px;
+      font-size: 13.5px;
+    }
+    .welcome-banner .wb-ic { font-size: 22px; line-height: 1; }
+    .welcome-banner b { font-family: var(--font-display); font-weight: 600; font-size: 15px; }
+    .welcome-banner .wb-body { flex: 1; color: var(--fg-muted); }
+    .welcome-banner .wb-close {
+      background: transparent; border: 0; color: var(--fg-muted);
+      font-size: 18px; padding: 4px;
+    }
+
+    /* --------------------------------------------------------------
+       PAGE panel — profile card + socials + chips + blocks
+       -------------------------------------------------------------- */
+    .profile-card {
+      margin-top: 22px;
+      background: var(--bg-elevated);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      padding: 18px 20px;
+      display: flex; align-items: flex-start; gap: 18px;
+      flex-wrap: wrap;
+    }
+    .profile-card .pc-av-wrap { position: relative; flex-shrink: 0; }
+    .profile-card .pc-av {
+      width: 72px; height: 72px; border-radius: 50%;
+      background: var(--hero-gradient);
+      display: flex; align-items: center; justify-content: center;
+      color: #fff; font-family: var(--font-display); font-weight: 600; font-size: 30px;
+      cursor: pointer;
+      box-shadow: 0 4px 14px rgba(99,102,241,0.18);
+      transition: transform .15s ease;
+    }
+    .profile-card .pc-av:hover { transform: scale(1.03); }
+    .profile-card .pc-av-cam {
+      position: absolute; right: -2px; bottom: -2px;
+      width: 26px; height: 26px; border-radius: 50%;
+      background: var(--bg-elevated);
+      border: 1px solid var(--border);
+      display: flex; align-items: center; justify-content: center;
+      color: var(--fg-muted);
+      pointer-events: none;
+    }
+    .profile-card .pc-body { flex: 1; min-width: 0; }
+    .profile-card .pc-head {
+      display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+    }
+    .profile-card .pc-name {
+      font-family: var(--font-display); font-weight: 600; font-size: 22px;
+      letter-spacing: -0.01em;
+    }
+    .profile-card .pc-bio {
+      font-size: 14px; color: var(--fg); margin-top: 4px; line-height: 1.45;
+    }
+    .profile-card .pc-handle {
+      font-size: 12.5px; color: var(--brand-primary); font-weight: 500; margin-top: 4px;
+    }
+    .profile-card .pc-socials {
+      display: flex; align-items: center; gap: 6px;
+      margin-top: 10px; flex-wrap: wrap;
+    }
+    .pc-social {
+      width: 28px; height: 28px; border-radius: 7px;
+      display: flex; align-items: center; justify-content: center;
+      color: #fff; transition: transform .12s ease;
+      cursor: pointer; border: 0;
+    }
+    .pc-social:hover { transform: translateY(-1px); }
+    .pc-social svg { width: 15px; height: 15px; }
+    .pc-social-add {
+      width: 28px; height: 28px; border-radius: 7px;
+      border: 1px dashed var(--border-strong);
+      background: transparent; color: var(--fg-muted);
+      display: flex; align-items: center; justify-content: center;
+      font-size: 15px; line-height: 1;
+    }
+    .pc-social-add:hover { border-color: var(--brand-primary); color: var(--brand-primary); }
+    .profile-card .pc-edit {
+      align-self: flex-start;
+      display: inline-flex; align-items: center; gap: 6px;
+      padding: 6px 10px; border-radius: 8px;
+      background: var(--bg); border: 1px solid var(--border);
+      color: var(--fg-muted); font-size: 12.5px; font-weight: 500;
+    }
+    .profile-card .pc-edit:hover { background: var(--bg-muted); color: var(--fg); }
+    .profile-card .pc-edit svg { width: 13px; height: 13px; }
+
+    /* Expanded profile editor */
+    .profile-editor {
+      flex-basis: 100%;
+      margin-top: 14px; padding-top: 16px;
+      border-top: 1px dashed var(--border);
+      display: none; flex-direction: column; gap: 12px;
+    }
+    .profile-card.is-editing .profile-editor { display: flex; }
+    .profile-editor .field { display: flex; flex-direction: column; gap: 5px; }
+    .profile-editor .field label {
+      font-size: 12px; color: var(--fg-muted); font-weight: 500;
+      text-transform: uppercase; letter-spacing: 0.04em;
+    }
+    .profile-editor input,
+    .profile-editor textarea {
+      font-family: var(--font-sans); font-size: 14px;
+      padding: 9px 12px; border-radius: 9px;
+      border: 1px solid var(--border-strong);
+      background: var(--bg-elevated); color: var(--fg);
+      outline: none; transition: border-color .12s ease, box-shadow .12s ease;
+    }
+    .profile-editor input:focus,
+    .profile-editor textarea:focus {
+      border-color: var(--brand-primary);
+      box-shadow: 0 0 0 3px rgba(99,102,241,0.15);
+    }
+    .profile-editor textarea { resize: vertical; min-height: 60px; }
+    .profile-editor .pe-row {
+      display: grid; grid-template-columns: 1fr; gap: 10px;
+    }
+    @media (min-width: 640px) { .profile-editor .pe-row { grid-template-columns: 2fr 1fr; } }
+    .profile-editor .counter { font-size: 11px; color: var(--fg-subtle); }
+    .profile-editor .pe-actions { display: flex; gap: 8px; justify-content: flex-end; }
+
+    /* Quick action chips (above blocks) */
+    .quick-chips {
+      display: flex; gap: 8px; flex-wrap: wrap;
+      margin-top: 22px;
+    }
+    .qchip {
+      display: inline-flex; align-items: center; gap: 6px;
+      padding: 7px 13px; border-radius: 999px;
+      border: 1px solid var(--border); background: var(--bg-elevated);
+      font-size: 12.5px; font-weight: 500; color: var(--fg-muted);
+    }
+    .qchip:hover { border-color: var(--border-strong); color: var(--fg); background: var(--bg-muted); }
+    .qchip svg { width: 13px; height: 13px; }
+
+    .collection-inline {
+      display: none; margin-top: 8px;
+      background: var(--bg-elevated); border: 1px solid var(--brand-primary);
+      border-radius: 10px; padding: 10px 12px;
+      align-items: center; gap: 8px;
+    }
+    .collection-inline.open { display: flex; }
+    .collection-inline input {
+      flex: 1; border: 0; outline: none;
+      font-size: 14px; padding: 4px 0;
+      background: transparent;
+    }
+
+    /* Block rows */
+    .blocks { margin-top: 14px; display: flex; flex-direction: column; gap: 10px; }
+    .section-label {
+      display: flex; align-items: center; gap: 10px;
+      font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em;
+      color: var(--fg-subtle); font-weight: 600;
+      margin: 18px 2px 4px;
+    }
+    .section-label::after {
+      content: ""; flex: 1; height: 1px; background: var(--border);
+    }
+
+    .block {
+      display: flex; align-items: center; gap: 12px;
+      background: var(--bg-elevated); border: 1px solid var(--border);
+      border-radius: 14px; padding: 12px 14px;
+      transition: border-color .15s ease, box-shadow .15s ease;
+    }
+    .block:hover { border-color: var(--border-strong); box-shadow: 0 1px 3px rgba(17,24,39,0.04); }
+    .block .grip {
+      width: 16px; color: var(--fg-subtle); cursor: grab;
+      display: flex; align-items: center; justify-content: center;
+      font-size: 14px; line-height: 1; flex-shrink: 0;
+    }
+    .block .ic {
+      width: 38px; height: 38px; border-radius: 10px;
+      display: flex; align-items: center; justify-content: center;
+      color: #fff; flex-shrink: 0;
+    }
+    .block .ic svg { width: 19px; height: 19px; }
+    .block .meta { flex: 1; min-width: 0; }
+    .block .meta .t { font-weight: 600; font-size: 14px; color: var(--fg); }
+    .block .meta .u {
+      font-size: 12.5px; color: var(--fg-muted);
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    }
+    .block .stat {
+      display: none;
+      font-size: 11.5px; color: var(--fg-muted);
+      text-align: right; line-height: 1.3;
+    }
+    @media (min-width: 820px) { .block .stat { display: block; } }
+    .block .stat b {
+      color: var(--fg); font-weight: 600; font-size: 14px;
+      display: block; font-family: var(--font-display);
+    }
+    .block .tools { display: flex; align-items: center; gap: 2px; flex-shrink: 0; }
+
+    /* Toggle switch */
+    .toggle {
+      position: relative; display: inline-block;
+      width: 36px; height: 20px;
+      background: var(--bg-sunken); border-radius: 999px;
+      cursor: pointer; transition: background .15s ease;
+      flex-shrink: 0;
+    }
+    .toggle::after {
+      content: ""; position: absolute; top: 2px; left: 2px;
+      width: 16px; height: 16px; border-radius: 50%;
+      background: #fff;
+      box-shadow: 0 1px 2px rgba(0,0,0,0.15);
+      transition: left .15s ease;
+    }
+    .toggle.on { background: var(--brand-primary); }
+    .toggle.on::after { left: 18px; }
+
+    .block.is-off { opacity: 0.55; }
+    .block.is-off .ic { filter: saturate(0.3); }
+
+    /* Add block dashed */
+    .add-block {
+      margin-top: 14px;
+      display: flex; align-items: center; justify-content: center; gap: 8px;
+      width: 100%; padding: 14px;
+      border: 2px dashed var(--border-strong);
+      border-radius: 14px;
+      background: transparent;
+      color: var(--fg-muted); font-weight: 500; font-size: 14px;
+      transition: all .15s ease;
+    }
+    .add-block:hover {
+      border-color: var(--brand-primary); color: var(--brand-primary);
+      background: rgba(99,102,241,0.04);
+    }
+    .add-block svg { width: 18px; height: 18px; }
+
+    /* Empty-state 3 quick-start cards */
+    .empty-cards {
+      margin-top: 22px;
+      display: grid; gap: 12px;
+      grid-template-columns: 1fr;
+    }
+    @media (min-width: 640px) { .empty-cards { grid-template-columns: repeat(3, 1fr); } }
+    .empty-card {
+      background: var(--bg-elevated);
+      border: 1px solid var(--border);
+      border-radius: 14px; padding: 20px;
+      cursor: pointer; transition: all .15s ease;
+      text-align: left;
+      display: flex; flex-direction: column; gap: 6px;
+    }
+    .empty-card:hover {
+      border-color: var(--brand-primary);
+      box-shadow: 0 2px 10px rgba(99,102,241,0.1);
+      transform: translateY(-1px);
+    }
+    .empty-card .ec-ic {
+      width: 38px; height: 38px; border-radius: 10px;
+      background: rgba(99,102,241,0.1); color: var(--brand-primary);
+      display: flex; align-items: center; justify-content: center;
+      margin-bottom: 4px;
+    }
+    .empty-card .ec-title { font-family: var(--font-display); font-weight: 600; font-size: 16px; }
+    .empty-card .ec-body { font-size: 13px; color: var(--fg-muted); }
+
+    /* Archive list */
+    .archive-list {
+      display: none;
+      margin-top: 12px;
+      background: var(--bg-muted); border: 1px dashed var(--border-strong);
+      border-radius: 12px; padding: 14px 16px;
+    }
+    .archive-list.open { display: block; }
+    .archive-list h4 {
+      font-family: var(--font-sans); font-size: 12px;
+      text-transform: uppercase; letter-spacing: 0.06em;
+      color: var(--fg-muted); margin: 0 0 10px; font-weight: 600;
+    }
+    .archive-row {
+      display: flex; align-items: center; gap: 10px;
+      padding: 8px 0; font-size: 13px; color: var(--fg-muted);
+      border-bottom: 1px solid var(--border);
+    }
+    .archive-row:last-child { border-bottom: 0; }
+    .archive-row .ar-ic {
+      width: 22px; height: 22px; border-radius: 6px;
+      background: var(--bg-elevated); color: var(--fg-subtle);
+      display: flex; align-items: center; justify-content: center;
+      font-size: 11px;
+    }
+    .archive-row .spacer { flex: 1; }
+    .archive-row button {
+      background: transparent; border: 0; font-size: 12px;
+      color: var(--brand-primary); font-weight: 500;
+    }
+
+    /* Add-block slide-in panel */
+    .add-panel {
+      display: none;
+      position: fixed; top: 54px; right: 0; bottom: 0;
+      width: min(380px, 100vw);
+      background: var(--bg-elevated);
+      border-left: 1px solid var(--border);
+      box-shadow: -8px 0 24px rgba(17,24,39,0.08);
+      z-index: 35;
+      padding: 22px 22px 32px;
+      overflow-y: auto;
+      animation: slideIn .2s ease;
+    }
+    .add-panel.open { display: block; }
+    @keyframes slideIn {
+      from { transform: translateX(12px); opacity: 0; }
+      to   { transform: translateX(0); opacity: 1; }
+    }
+    .add-panel-head {
+      display: flex; align-items: center; justify-content: space-between;
+      margin-bottom: 14px;
+    }
+    .add-panel-head h3 {
+      font-family: var(--font-display); font-size: 22px; margin: 0;
+    }
+    .add-categories {
+      display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px;
+    }
+    .cat-tile {
+      padding: 14px 12px; border-radius: 12px;
+      background: var(--bg); border: 1px solid var(--border);
+      text-align: left; transition: all .15s ease;
+      cursor: pointer;
+      display: flex; flex-direction: column; gap: 6px;
+    }
+    .cat-tile:hover {
+      border-color: var(--brand-primary); background: rgba(99,102,241,0.04);
+    }
+    .cat-tile .ct-ic {
+      width: 32px; height: 32px; border-radius: 9px;
+      background: var(--bg-elevated); border: 1px solid var(--border);
+      display: flex; align-items: center; justify-content: center;
+      color: var(--brand-primary);
+    }
+    .cat-tile .ct-name { font-size: 13.5px; font-weight: 600; }
+    .cat-tile .ct-sub { font-size: 11.5px; color: var(--fg-muted); line-height: 1.3; }
+    .cat-more {
+      margin-top: 12px; width: 100%;
+      padding: 10px; border-radius: 10px;
+      background: transparent; border: 1px dashed var(--border-strong);
+      color: var(--fg-muted); font-size: 13px; font-weight: 500;
+    }
+    .cat-more:hover {
+      color: var(--brand-primary); border-color: var(--brand-primary);
+    }
+    .add-more-categories { display: none; margin-top: 10px; }
+    .add-more-categories.open {
+      display: grid; grid-template-columns: repeat(2,1fr); gap: 10px;
+    }
+
+    /* --------------------------------------------------------------
+       DESIGN panel — sub-nav + tiles
+       -------------------------------------------------------------- */
+    .design-wrap {
+      margin-top: 22px;
+      display: grid; grid-template-columns: 1fr; gap: 20px;
+    }
+    /* V2: single-column — secondary rail collapsed into sidebar accordion.
+       The 860px breakpoint that adds a 180px left rail is intentionally REMOVED. */
+
+    /* V2: hide the legacy .design-subnav (its function is replaced by the
+       sidebar accordion + breadcrumb stepper). Markup is preserved for diff
+       parity but visually + interactively suppressed. */
+    .design-subnav {
+      display: none !important;
+    }
+    .sub-item {
+      display: flex; align-items: center; gap: 10px;
+      padding: 9px 12px; border-radius: 9px;
+      background: transparent; border: 0;
+      font-size: 13.5px; font-weight: 500; color: var(--fg-muted);
+      text-align: left; white-space: nowrap;
+      transition: background .12s ease, color .12s ease;
+    }
+    .sub-item svg { width: 16px; height: 16px; color: var(--fg-subtle); flex-shrink: 0; }
+    .sub-item:hover { background: var(--bg-muted); color: var(--fg); }
+    .sub-item.active { background: rgba(99,102,241,0.10); color: var(--brand-primary); }
+    .sub-item.active svg { color: var(--brand-primary); }
+
+    .design-panel { display: none; flex-direction: column; gap: 22px; min-width: 0; }
+    .design-panel.active { display: flex; }
+
+    .field-group { display: flex; flex-direction: column; gap: 8px; }
+    .field-group > label.fg-label {
+      font-size: 13px; font-weight: 600; color: var(--fg);
+    }
+    .field-group > .fg-help {
+      font-size: 12px; color: var(--fg-muted); margin-top: -4px; line-height: 1.4;
+    }
+
+    /* Tile grid (theme / wallpaper) */
+    .tile-grid {
+      display: grid; gap: 12px;
+      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    }
+    .tile {
+      position: relative;
+      border-radius: 12px; overflow: hidden;
+      border: 2px solid var(--border);
+      cursor: pointer;
+      aspect-ratio: 1 / 1;
+      background: var(--bg-muted);
+      transition: border-color .15s ease, transform .15s ease;
+    }
+    .tile:hover { transform: translateY(-1px); }
+    .tile.selected {
+      border-color: var(--brand-primary);
+      box-shadow: 0 0 0 3px rgba(99,102,241,0.15);
+    }
+    .tile .tile-label {
+      position: absolute; left: 0; right: 0; bottom: 0;
+      background: rgba(11,15,30,0.55); color: #fff;
+      font-size: 11.5px; font-weight: 500;
+      padding: 5px 8px;
+      text-align: center;
+      backdrop-filter: blur(4px);
+    }
+    .tile .pro-badge {
+      position: absolute; top: 6px; right: 6px;
+      display: inline-flex; align-items: center; gap: 3px;
+      padding: 2px 6px; border-radius: 999px;
+      background: rgba(17,24,39,0.78); color: #fff;
+      font-size: 9.5px; font-weight: 600; letter-spacing: 0.02em;
+    }
+
+    /* Theme preset thumbnails */
+    .theme-minimal  { background: linear-gradient(180deg,#fff 55%, #F3F4F6 100%); }
+    .theme-minimal::before {
+      content: ""; position: absolute; inset: 18% 22% 18% 22%;
+      background: #111827; border-radius: 6px;
+    }
+    .theme-bold     { background: #6366F1; }
+    .theme-bold::before {
+      content: ""; position: absolute; inset: 25% 18% 25% 18%;
+      background: #fff; border-radius: 8px;
+    }
+    .theme-editorial{ background: #F8F5EE; }
+    .theme-editorial::before {
+      content: "Aa"; position: absolute; inset: 0;
+      display: flex; align-items: center; justify-content: center;
+      font-family: 'Fraunces', serif; font-size: 42px; font-weight: 600; color: #1F1B16;
+    }
+    .theme-playful  { background: linear-gradient(135deg,#F59E0B,#EC4899); }
+    .theme-playful::before {
+      content: ""; position: absolute; width: 40%; height: 14%;
+      top: 28%; left: 30%; background: #fff; border-radius: 999px;
+      box-shadow: 0 26px 0 #fff, 0 52px 0 #fff;
+    }
+    .theme-dark     { background: #0B0F1E; }
+    .theme-dark::before {
+      content: ""; position: absolute; inset: 22% 18% 22% 18%;
+      background: rgba(255,255,255,0.08); border: 1px solid rgba(255,255,255,0.2);
+      border-radius: 8px;
+    }
+    .theme-sunset   { background: linear-gradient(180deg,#FCA5A5 0%,#F59E0B 55%, #7C3AED 100%); }
+    .theme-ocean    { background: linear-gradient(180deg,#A7F3D0 0%,#3B82F6 70%,#1E3A8A 100%); }
+    .theme-nord     { background: #ECEFF4; }
+    .theme-nord::before {
+      content: ""; position: absolute; inset: 30% 20% 30% 20%;
+      background: #5E81AC; border-radius: 6px;
+    }
+
+    /* Wallpaper tiles */
+    .wp-fill     { background: #6366F1; }
+    .wp-gradient { background: linear-gradient(135deg,#6366F1,#F59E0B 70%,#FCA5A5); }
+    .wp-blur     {
+      background:
+        radial-gradient(circle at 20% 30%, #8B5CF6, transparent 40%),
+        radial-gradient(circle at 80% 60%, #F59E0B, transparent 50%),
+        radial-gradient(circle at 40% 80%, #6366F1, transparent 45%),
+        #fff;
+    }
+    .wp-pattern  {
+      background-color: #6366F1;
+      background-image:
+        linear-gradient(rgba(255,255,255,0.16) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255,255,255,0.16) 1px, transparent 1px);
+      background-size: 14px 14px;
+    }
+    .wp-image    {
+      background: linear-gradient(135deg,#94A3B8,#64748B);
+    }
+    .wp-image::before {
+      content: "▭"; position: absolute; inset: 0;
+      display: flex; align-items: center; justify-content: center;
+      color: rgba(255,255,255,0.75); font-size: 28px;
+    }
+    .wp-video    { background: linear-gradient(135deg,#0F172A,#334155); }
+    .wp-video::before {
+      content: "▶"; position: absolute; inset: 0;
+      display: flex; align-items: center; justify-content: center;
+      color: rgba(255,255,255,0.75); font-size: 22px;
+    }
+
+    /* Segmented picker */
+    .segmented {
+      display: inline-flex; align-items: stretch;
+      padding: 4px; gap: 2px; border-radius: 10px;
+      background: var(--bg-muted); border: 1px solid var(--border);
+    }
+    .segmented .seg {
+      padding: 7px 14px; border-radius: 7px;
+      background: transparent; border: 0;
+      font-size: 13px; font-weight: 500; color: var(--fg-muted);
+      display: inline-flex; align-items: center; gap: 6px;
+      transition: all .12s ease;
+    }
+    .segmented .seg:hover { color: var(--fg); }
+    .segmented .seg.active {
+      background: var(--bg-elevated); color: var(--fg);
+      box-shadow: 0 1px 2px rgba(17,24,39,0.06);
+    }
+    .segmented .seg svg { width: 15px; height: 15px; }
+    .segmented.narrow .seg { padding: 6px 10px; font-size: 12.5px; }
+
+    /* Color input row */
+    .color-input {
+      display: flex; align-items: center; gap: 10px;
+      background: var(--bg-elevated);
+      border: 1px solid var(--border-strong);
+      border-radius: 10px;
+      padding: 8px 12px;
+      max-width: 360px;
+    }
+    .color-input input {
+      font-family: var(--font-mono); font-size: 14px;
+      border: 0; outline: none; background: transparent;
+      flex: 1; color: var(--fg);
+    }
+    .color-input .swatch {
+      width: 22px; height: 22px; border-radius: 50%;
+      border: 1px solid var(--border);
+      flex-shrink: 0;
+    }
+
+    /* Toggle row */
+    .toggle-row {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 14px; border-radius: 10px;
+      background: var(--bg-elevated); border: 1px solid var(--border);
+    }
+    .toggle-row .tr-body { flex: 1; }
+    .toggle-row .tr-title { font-weight: 500; font-size: 14px; }
+    .toggle-row .tr-sub { font-size: 12px; color: var(--fg-muted); margin-top: 2px; }
+
+    /* Button style preview tiles */
+    .btn-style-grid {
+      display: grid; gap: 10px;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    }
+    .btn-style-tile {
+      padding: 20px 14px;
+      border-radius: 12px;
+      border: 2px solid var(--border);
+      background: var(--bg);
+      display: flex; flex-direction: column; align-items: center; gap: 8px;
+      cursor: pointer;
+      transition: border-color .15s ease;
+    }
+    .btn-style-tile:hover { border-color: var(--border-strong); }
+    .btn-style-tile.selected { border-color: var(--brand-primary); }
+    .bst-preview {
+      width: 100%; height: 30px;
+      display: flex; align-items: center; justify-content: center;
+      font-size: 12px; font-weight: 500;
+    }
+    .bst-preview.fill    { background: #6366F1; color: #fff; border-radius: 10px; }
+    .bst-preview.outline { background: transparent; border: 2px solid #6366F1; color: #6366F1; border-radius: 10px; }
+    .bst-preview.soft    { background: rgba(99,102,241,0.12); color: #6366F1; border-radius: 10px; }
+    .bst-preview.hard    { background: #6366F1; color: #fff; border-radius: 2px; }
+    .bst-preview.round   { background: #6366F1; color: #fff; border-radius: 999px; }
+    .bst-preview.shadow  { background: #fff; color: #111827; border-radius: 10px; border: 1px solid #E5E7EB; box-shadow: 0 4px 0 #6366F1; }
+    .bst-label { font-size: 12px; color: var(--fg-muted); font-weight: 500; }
+
+    /* Font picker list */
+    .font-list {
+      display: grid; gap: 8px;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    }
+    .font-tile {
+      padding: 14px 16px; border-radius: 10px;
+      border: 2px solid var(--border); background: var(--bg-elevated);
+      cursor: pointer; text-align: left;
+      display: flex; flex-direction: column; gap: 3px;
+    }
+    .font-tile:hover { border-color: var(--border-strong); }
+    .font-tile.selected { border-color: var(--brand-primary); }
+    .font-tile .ft-preview { font-size: 22px; line-height: 1.1; color: var(--fg); }
+    .font-tile .ft-name {
+      font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em;
+      color: var(--fg-muted); font-family: var(--font-sans); font-weight: 600;
+    }
+
+    /* Footer panel (no "Powered by" toggle — AP-001) */
+    .footer-option {
+      display: flex; gap: 12px; align-items: flex-start;
+      padding: 14px; border-radius: 10px;
+      border: 2px solid var(--border); background: var(--bg-elevated);
+      cursor: pointer;
+    }
+    .footer-option.selected {
+      border-color: var(--brand-primary); background: rgba(99,102,241,0.03);
+    }
+    .footer-option .fo-radio {
+      width: 18px; height: 18px; border-radius: 50%;
+      border: 2px solid var(--border-strong); flex-shrink: 0;
+      margin-top: 2px;
+      display: flex; align-items: center; justify-content: center;
+    }
+    .footer-option.selected .fo-radio { border-color: var(--brand-primary); }
+    .footer-option.selected .fo-radio::after {
+      content: ""; width: 8px; height: 8px; border-radius: 50%;
+      background: var(--brand-primary);
+    }
+    .footer-option .fo-body { flex: 1; }
+    .footer-option .fo-body .fo-title { font-weight: 600; font-size: 14px; }
+    .footer-option .fo-body .fo-sub { font-size: 12.5px; color: var(--fg-muted); margin-top: 2px; }
+    .footer-option textarea {
+      margin-top: 10px; width: 100%;
+      font-family: var(--font-sans); font-size: 13px;
+      padding: 8px 10px; border-radius: 8px; border: 1px solid var(--border-strong);
+      background: var(--bg); color: var(--fg);
+      outline: none; resize: vertical; min-height: 40px;
+    }
+
+    .footer-tadaify-note {
+      font-size: 12px; color: var(--fg-muted);
+      margin-top: 14px; padding: 10px 14px;
+      background: rgba(245,158,11,0.05);
+      border-left: 3px solid var(--brand-warm); border-radius: 6px;
+      line-height: 1.4;
+    }
+    .footer-tadaify-note strong {
+      color: var(--brand-warm-dark); font-weight: 600;
+    }
+
+    /* Placeholder tabs */
+    .placeholder-panel {
+      margin-top: 40px;
+      text-align: center; padding: 60px 20px;
+      background: var(--bg-elevated);
+      border: 1px dashed var(--border-strong);
+      border-radius: 18px;
+    }
+    .placeholder-panel .ph-ic { font-size: 44px; margin-bottom: 10px; line-height: 1; }
+    .placeholder-panel h3 { font-family: var(--font-display); font-size: 22px; margin: 0 0 6px; }
+    .placeholder-panel p {
+      font-size: 14px; color: var(--fg-muted); margin: 0;
+      max-width: 380px; margin-left: auto; margin-right: auto;
+      line-height: 1.5;
+    }
+
+    /* --------------------------------------------------------------
+       RIGHT preview column
+       -------------------------------------------------------------- */
+    aside.preview {
+      display: none;
+      border-left: 1px solid var(--border);
+      background: linear-gradient(180deg, #F4F5FA 0%, #EEF0F8 100%);
+      padding: 20px 16px 40px;
+      position: sticky; top: 54px;
+      align-self: start;
+      height: calc(100vh - 54px);
+      overflow-y: auto;
+    }
+    @media (min-width: 1180px) { aside.preview { display: block; } }
+
+    .preview-head {
+      display: flex; align-items: center; justify-content: space-between;
+      gap: 10px; margin-bottom: 14px; flex-wrap: wrap;
+    }
+    .preview-head h3 {
+      font-family: var(--font-sans); font-size: 11px;
+      text-transform: uppercase; letter-spacing: 0.08em; color: var(--fg-subtle);
+      font-weight: 600; margin: 0;
+    }
+    .preview-head .refresh {
+      background: transparent; border: 0; color: var(--fg-muted); font-size: 12px;
+      display: inline-flex; align-items: center; gap: 4px;
+    }
+
+    .device-toggle {
+      margin: 0 auto 14px; display: flex; justify-content: center;
+    }
+
+    .preview-stage {
+      display: flex; align-items: center; justify-content: center;
+      padding: 10px 0 18px;
+      min-height: 580px;
+    }
+    .preview-frame {
+      position: relative;
+      transition: width .25s ease, height .25s ease, border-radius .25s ease;
+      flex-shrink: 0;
+    }
+
+    /* Mobile frame */
+    .preview-frame.is-mobile {
+      width: 280px; height: 576px;
+      background: #0b0f1e;
+      border-radius: 36px; padding: 10px;
+      box-shadow: 0 30px 70px rgba(17,24,39,0.22), 0 0 0 1px rgba(0,0,0,0.04);
+    }
+    .preview-frame.is-mobile .pv-notch {
+      position: absolute; top: 14px; left: 50%; transform: translateX(-50%);
+      width: 80px; height: 18px;
+      background: #0b0f1e; border-radius: 999px; z-index: 2;
+    }
+
+    /* Tablet frame */
+    .preview-frame.is-tablet {
+      width: 340px; height: 450px;
+      background: #0b0f1e;
+      border-radius: 20px; padding: 14px;
+      box-shadow: 0 30px 70px rgba(17,24,39,0.22);
+    }
+
+    /* Desktop frame */
+    .preview-frame.is-desktop {
+      width: 380px; height: 260px;
+      background: #0b0f1e;
+      border-radius: 12px 12px 6px 6px;
+      padding: 22px 6px 6px;
+      box-shadow: 0 30px 70px rgba(17,24,39,0.22);
+    }
+    .preview-frame.is-desktop .pv-chrome {
+      position: absolute; top: 0; left: 0; right: 0; height: 22px;
+      display: flex; align-items: center; gap: 5px; padding: 0 10px;
+    }
+    .preview-frame.is-desktop .pv-chrome .dot {
+      width: 8px; height: 8px; border-radius: 50%;
+    }
+    .preview-frame.is-desktop .pv-chrome .dot.r { background: #FF5F57; }
+    .preview-frame.is-desktop .pv-chrome .dot.y { background: #FEBC2E; }
+    .preview-frame.is-desktop .pv-chrome .dot.g { background: #28C840; }
+    .preview-frame.is-desktop .pv-chrome .url {
+      flex: 1; margin-left: 20px; height: 14px; border-radius: 4px;
+      background: rgba(255,255,255,0.1);
+      display: flex; align-items: center; padding: 0 8px;
+      font-size: 9px; color: rgba(255,255,255,0.55);
+      font-family: var(--font-mono);
+    }
+
+    .pv-inner {
+      width: 100%; height: 100%;
+      border-radius: 26px;
+      overflow: hidden;
+      display: flex; flex-direction: column;
+      position: relative;
+      background: var(--pv-bg, linear-gradient(180deg, #fff 0%, #F8F9FC 100%));
+      color: var(--pv-fg, #111827);
+    }
+    .preview-frame.is-tablet .pv-inner { border-radius: 8px; }
+    .preview-frame.is-desktop .pv-inner { border-radius: 4px; }
+
+    .pv-body {
+      padding: 22px 18px;
+      display: flex; flex-direction: column; align-items: center; gap: 10px;
+      flex: 1; overflow-y: auto;
+    }
+    .preview-frame.is-desktop .pv-body {
+      max-width: 260px; margin: 0 auto; padding: 14px;
+    }
+    .pv-avatar {
+      width: 60px; height: 60px; border-radius: 50%;
+      background: var(--hero-gradient);
+      display: flex; align-items: center; justify-content: center;
+      font-family: var(--font-display); color: #fff; font-size: 26px; font-weight: 600;
+      box-shadow: 0 8px 24px rgba(99,102,241,0.28);
+      transition: width .2s ease, height .2s ease, border-radius .2s ease;
+    }
+    .pv-avatar.hero {
+      width: 100%; max-width: 180px; height: 110px; border-radius: 14px; font-size: 42px;
+    }
+    .pv-name { font-family: var(--font-display); font-weight: 600; font-size: 18px; }
+    .pv-bio { font-size: 12px; color: var(--pv-muted, #4B5563); text-align: center; line-height: 1.4; }
+    .pv-handle { font-size: 11px; color: var(--brand-primary); font-weight: 500; }
+    .pv-socials { display: flex; gap: 8px; margin-top: 2px; }
+    .pv-socials span {
+      width: 22px; height: 22px; border-radius: 6px;
+      display: flex; align-items: center; justify-content: center;
+      color: #fff;
+    }
+    .pv-socials span svg { width: 12px; height: 12px; }
+    .pv-blocks {
+      width: 100%; display: flex; flex-direction: column; gap: 8px; margin-top: 6px;
+    }
+    .pv-block {
+      display: flex; align-items: center; gap: 10px;
+      background: var(--pv-btn-bg, #fff);
+      color: var(--pv-btn-fg, #111827);
+      border: 1px solid var(--pv-btn-border, #E5E7EB);
+      border-radius: var(--pv-btn-radius, 12px);
+      padding: 10px 12px;
+      font-size: 12.5px; font-weight: 500;
+      box-shadow: var(--pv-btn-shadow, none);
+      transition: background .2s ease, color .2s ease, border-radius .2s ease, border-color .2s ease, box-shadow .2s ease;
+    }
+    .pv-block .pvb-ic {
+      width: 26px; height: 26px; border-radius: 7px;
+      display: flex; align-items: center; justify-content: center;
+      color: #fff; flex-shrink: 0;
+    }
+    .pv-block .pvb-ic svg { width: 14px; height: 14px; }
+    .pv-footer {
+      margin-top: auto; padding: 10px 0 6px;
+      font-size: 10px; color: var(--pv-muted, #9CA3AF);
+      text-align: center;
+    }
+
+    /* Wallpaper / theme / button data-attr driven variables */
+    .pv-inner[data-wallpaper="fill"]     { --pv-bg: var(--pv-bg-color, #EEF2FF); }
+    .pv-inner[data-wallpaper="gradient"] { --pv-bg: linear-gradient(160deg, var(--pv-bg-color,#EEF2FF) 0%, #FEF3C7 100%); }
+    .pv-inner[data-wallpaper="blur"]     {
+      --pv-bg:
+        radial-gradient(circle at 20% 20%, rgba(99,102,241,0.45), transparent 55%),
+        radial-gradient(circle at 80% 70%, rgba(245,158,11,0.4), transparent 55%),
+        #F8F9FC;
+    }
+    .pv-inner[data-wallpaper="pattern"]  {
+      --pv-bg: var(--pv-bg-color, #EEF2FF);
+    }
+    .pv-inner[data-wallpaper="pattern"]::before {
+      content: ""; position: absolute; inset: 0; pointer-events: none;
+      background-image:
+        linear-gradient(rgba(99,102,241,0.12) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(99,102,241,0.12) 1px, transparent 1px);
+      background-size: 20px 20px;
+    }
+    .pv-inner[data-theme="dark"] {
+      --pv-bg: #0B0F1E; --pv-fg: #F9FAFB; --pv-muted: #9CA3AF;
+      --pv-btn-bg: rgba(255,255,255,0.06); --pv-btn-fg: #F9FAFB;
+      --pv-btn-border: rgba(255,255,255,0.12);
+    }
+    .pv-inner[data-theme="editorial"] {
+      --pv-bg: #F8F5EE; --pv-fg: #1F1B16;
+      font-family: 'Fraunces', 'Crimson Pro', serif;
+      --pv-btn-bg: #fff; --pv-btn-border: #E6DFCF;
+    }
+    .pv-inner[data-theme="sunset"] {
+      --pv-bg: linear-gradient(180deg,#FCA5A5 0%,#F59E0B 55%, #7C3AED 100%);
+      --pv-fg: #fff; --pv-muted: rgba(255,255,255,0.78);
+      --pv-btn-bg: rgba(255,255,255,0.9); --pv-btn-fg: #111827;
+      --pv-btn-border: rgba(255,255,255,0.7);
+    }
+    .pv-inner[data-theme="ocean"] {
+      --pv-bg: linear-gradient(180deg,#A7F3D0 0%,#3B82F6 70%,#1E3A8A 100%);
+      --pv-fg: #fff; --pv-muted: rgba(255,255,255,0.78);
+      --pv-btn-bg: rgba(255,255,255,0.9); --pv-btn-fg: #111827;
+    }
+
+    /* Button style */
+    .pv-inner[data-btn="fill"]    { --pv-btn-bg: #6366F1; --pv-btn-fg: #fff; --pv-btn-border: transparent; --pv-btn-radius: 12px; }
+    .pv-inner[data-btn="outline"] { --pv-btn-bg: transparent; --pv-btn-fg: #6366F1; --pv-btn-border: #6366F1; --pv-btn-radius: 12px; }
+    .pv-inner[data-btn="soft"]    { --pv-btn-bg: rgba(99,102,241,0.14); --pv-btn-fg: #6366F1; --pv-btn-border: transparent; --pv-btn-radius: 12px; }
+    .pv-inner[data-btn="hard"]    { --pv-btn-radius: 2px; }
+    .pv-inner[data-btn="round"]   { --pv-btn-radius: 999px; }
+    .pv-inner[data-btn="shadow"]  { --pv-btn-shadow: 0 4px 0 rgba(99,102,241,0.9); }
+
+    /* --------------------------------------------------------------
+       Mobile bottom tabs (≤720px)
+       -------------------------------------------------------------- */
+    .mobile-tabs {
+      position: fixed; bottom: 0; left: 0; right: 0;
+      background: var(--bg-elevated); border-top: 1px solid var(--border);
+      display: flex; justify-content: space-around;
+      padding: 6px 0 max(6px, env(safe-area-inset-bottom));
+      z-index: 40;
+    }
+    @media (min-width: 720px) { .mobile-tabs { display: none; } }
+    .mt-btn {
+      background: transparent; border: 0; padding: 6px 10px;
+      display: flex; flex-direction: column; align-items: center; gap: 2px;
+      font-size: 10px; color: var(--fg-muted); font-weight: 500;
+    }
+    .mt-btn svg { width: 20px; height: 20px; }
+    .mt-btn.active { color: var(--brand-primary); }
+    .mt-btn.active svg { color: var(--brand-primary); }
+
+    /* Mobile preview FAB + full-screen drawer */
+    .mobile-preview-fab {
+      position: fixed; right: 14px; bottom: 66px;
+      z-index: 38;
+      background: var(--fg); color: #fff;
+      border: 0; border-radius: 999px;
+      padding: 10px 16px; font-size: 13px; font-weight: 500;
+      box-shadow: 0 10px 30px rgba(17,24,39,0.3);
+      display: none; align-items: center; gap: 6px;
+    }
+    @media (max-width: 1179px) { .mobile-preview-fab { display: inline-flex; } }
+    @media (min-width: 720px) and (max-width: 1179px) { .mobile-preview-fab { bottom: 22px; } }
+
+    .mobile-preview-overlay {
+      position: fixed; inset: 0;
+      background: rgba(11,15,30,0.72);
+      backdrop-filter: blur(6px);
+      z-index: 50;
+      display: none;
+      align-items: center; justify-content: center;
+      padding: 20px;
+    }
+    .mobile-preview-overlay.open { display: flex; }
+    .mobile-preview-overlay .mpo-close {
+      position: absolute; top: 14px; right: 14px;
+      background: rgba(255,255,255,0.95); color: #111827;
+      width: 36px; height: 36px; border-radius: 50%;
+      border: 0; font-size: 20px; line-height: 1;
+    }
+    .mobile-preview-overlay .mpo-hint {
+      color: #fff; font-size: 12px;
+      position: absolute; top: 24px; left: 24px; opacity: 0.8;
+    }
+
+    /* Panel visibility driven by data-tab on .layout */
+    .main-page, .main-design, .main-placeholder { display: none; }
+    .layout[data-tab="page"]     .main-page     { display: block; }
+    .layout[data-tab="design"]   .main-design   { display: block; }
+    .layout[data-tab="insights"] .main-placeholder[data-for="insights"] { display: block; }
+    .layout[data-tab="shop"]     .main-placeholder[data-for="shop"]     { display: block; }
+    .layout[data-tab="settings"] .main-placeholder[data-for="settings"] { display: block; }
+    /* data-tab="pages" removed — "pages" nav item replaced by disabled "+ Add page" sub-item */
+
+    /* Empty-state visibility */
+    .only-ready { display: block; }
+    .only-empty { display: none; }
+    body[data-state="empty"] .only-ready { display: none; }
+    body[data-state="empty"] .only-empty { display: block; }
+
+    .row-sp { display: flex; align-items: center; justify-content: space-between; gap: 10px; flex-wrap: wrap; }
+
+    /* ==============================================================
+       Animations sub-panel
+       ============================================================== */
+    .tile-grid-anim { grid-template-columns: repeat(auto-fill, minmax(130px, 1fr)); }
+    .anim-tile .anim-preview {
+      position: absolute; inset: 0;
+      display: flex; align-items: center; justify-content: center;
+      background: #F8F9FC;
+      overflow: hidden;
+    }
+    .pill-signature {
+      display: inline-block;
+      margin-left: 6px;
+      padding: 2px 8px;
+      background: linear-gradient(135deg, rgba(99,102,241,0.14), rgba(245,158,11,0.18));
+      color: #6366F1;
+      border-radius: 999px;
+      font-size: 9px;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      vertical-align: middle;
+    }
+
+    /* "None" preview — flat line */
+    .anim-none::after { content: ''; width: 40%; height: 2px; background: #D1D5DB; border-radius: 2px; }
+
+    /* "Ta-da" — orbit + flash (echoes Motion v10) */
+    .anim-tada .anim-dot {
+      width: 16px; height: 16px; border-radius: 50%;
+      background: radial-gradient(circle at 30% 30%, #F59E0B 0%, #DC8908 75%);
+      box-shadow: 0 0 18px rgba(245,158,11,0.55);
+      animation: anim-tada 2.2s cubic-bezier(.2,.8,.2,1) infinite;
+    }
+    @keyframes anim-tada {
+      0%   { transform: scale(0.3); opacity: 0; box-shadow: 0 0 0 rgba(245,158,11,0); }
+      28%  { transform: scale(1.25); opacity: 1; box-shadow: 0 0 32px rgba(245,158,11,0.9); }
+      45%  { transform: scale(1); opacity: 1; }
+      85%  { transform: scale(1); opacity: 1; }
+      100% { transform: scale(1); opacity: 0; }
+    }
+
+    /* Cascade — three bars appear with stagger */
+    .anim-cascade { flex-direction: column; gap: 4px; }
+    .anim-cascade span {
+      width: 46px; height: 4px; border-radius: 2px; background: #6366F1;
+      opacity: 0;
+      animation: anim-cascade 2s ease-in-out infinite;
+    }
+    .anim-cascade span:nth-child(1) { animation-delay: 0s; }
+    .anim-cascade span:nth-child(2) { animation-delay: 0.18s; background: #8B5CF6; }
+    .anim-cascade span:nth-child(3) { animation-delay: 0.36s; background: #F59E0B; }
+    @keyframes anim-cascade {
+      0%   { transform: translateY(6px); opacity: 0; }
+      30%  { transform: translateY(0); opacity: 1; }
+      80%  { transform: translateY(0); opacity: 1; }
+      100% { transform: translateY(-3px); opacity: 0; }
+    }
+
+    /* Fade up */
+    .anim-fadeup span {
+      width: 42px; height: 20px; border-radius: 4px;
+      background: linear-gradient(135deg, #6366F1, #8B5CF6);
+      animation: anim-fadeup 2s ease-in-out infinite;
+    }
+    @keyframes anim-fadeup {
+      0%   { transform: translateY(12px); opacity: 0; }
+      35%  { transform: translateY(0); opacity: 1; }
+      80%  { transform: translateY(0); opacity: 1; }
+      100% { transform: translateY(-2px); opacity: 0; }
+    }
+
+    /* Spotlight orbit — Motion v10 echo */
+    .anim-spotlight { position: relative; }
+    .anim-spotlight::before {
+      content: '';
+      position: absolute; inset: 16px;
+      border-radius: 50%;
+      border: 1.5px dashed rgba(99,102,241,0.25);
+    }
+    .anim-spotlight .anim-orb {
+      position: absolute;
+      width: 10px; height: 10px;
+      border-radius: 50%;
+      background: #F59E0B;
+      box-shadow: 0 0 14px #F59E0B;
+      top: 50%; left: 50%;
+      transform-origin: -20px 0;
+      animation: anim-orbit 2.4s linear infinite;
+    }
+    @keyframes anim-orbit {
+      from { transform: translate(-50%, -50%) rotate(0deg) translateX(22px); }
+      to   { transform: translate(-50%, -50%) rotate(360deg) translateX(22px); }
+    }
+
+    /* Typewriter caret */
+    .anim-typewriter { align-items: baseline; gap: 2px; font-family: var(--font-display, serif); font-size: 18px; color: var(--fg); }
+    .anim-typewriter::before {
+      content: 'Hello';
+      opacity: 0;
+      animation: anim-type 3s steps(5) infinite;
+      overflow: hidden;
+      white-space: nowrap;
+      display: inline-block;
+    }
+    .anim-typewriter .anim-caret {
+      color: var(--brand-primary);
+      font-weight: 400;
+      animation: anim-caret 1s step-start infinite;
+    }
+    @keyframes anim-type {
+      0%   { opacity: 0; width: 0; }
+      10%  { opacity: 1; width: 0; }
+      60%  { opacity: 1; width: 5ch; }
+      90%  { opacity: 1; width: 5ch; }
+      100% { opacity: 0; width: 5ch; }
+    }
+    @keyframes anim-caret {
+      50% { opacity: 0; }
+    }
+
+    /* Accessibility row */
+    .a11y-row {
+      display: flex;
+      gap: 10px;
+      align-items: flex-start;
+      padding: 12px 14px;
+      background: rgba(99,102,241,0.04);
+      border: 1px solid rgba(99,102,241,0.15);
+      border-radius: 10px;
+      cursor: pointer;
+    }
+    .a11y-row input[type="checkbox"] { margin-top: 3px; width: 16px; height: 16px; cursor: pointer; }
+
+    /* Reduced-motion halts the tile animations */
+    body.reduced-motion .anim-preview *,
+    body.reduced-motion .anim-tile .anim-preview::after,
+    body.reduced-motion .anim-tile .anim-preview::before { animation: none !important; }
+
+    /* Phone preview re-play class hooks */
+    .phone-screen.is-replaying .phone-blocks > * {
+      opacity: 0;
+      animation: block-entrance-stagger .7s cubic-bezier(.2,.8,.2,1) forwards;
+    }
+    .phone-screen.is-replaying .phone-blocks > *:nth-child(1) { animation-delay: 0.05s; }
+    .phone-screen.is-replaying .phone-blocks > *:nth-child(2) { animation-delay: 0.18s; }
+    .phone-screen.is-replaying .phone-blocks > *:nth-child(3) { animation-delay: 0.31s; }
+    .phone-screen.is-replaying .phone-blocks > *:nth-child(n+4) { animation-delay: 0.44s; }
+    @keyframes block-entrance-stagger {
+      from { opacity: 0; transform: translateY(10px) scale(0.98); }
+      to   { opacity: 1; transform: translateY(0) scale(1); }
+    }
+
+    /* ==============================================================
+       Dark mode (mockup-level — toggleable via theme button)
+       ============================================================== */
+    body.dark-mode {
+      --bg: #0B0F1E;
+      --bg-elevated: #141A2D;
+      --bg-sunken: #0A0F1C;
+      --fg: #F3F4F6;
+      --fg-muted: #9CA3AF;
+      --fg-subtle: #6B7280;
+      --border: #1F2937;
+      --border-strong: #374151;
+      background: #0B0F1E;
+      color: #F3F4F6;
+    }
+    body.dark-mode .appbar {
+      background: rgba(11, 15, 30, 0.85);
+      border-bottom-color: rgba(31, 41, 55, 0.6);
+    }
+    body.dark-mode .appbar .handle-pill { background: #141A2D; border-color: #1F2937; color: #9CA3AF; }
+    body.dark-mode .appbar .handle-pill b { color: #F3F4F6; }
+    body.dark-mode .appbar .iconbtn { color: #D1D5DB; }
+    body.dark-mode .appbar .iconbtn:hover { background: #1F2937; color: #F3F4F6; }
+    body.dark-mode .appbar .wm .ify { color: #F3F4F6; }
+    body.dark-mode .side {
+      background: #141A2D;
+      border-right-color: #1F2937;
+    }
+    body.dark-mode .side .nav-item { color: #9CA3AF; }
+    body.dark-mode .side .nav-item:hover { background: #1F2937; color: #F3F4F6; }
+    body.dark-mode .side .nav-item.active { background: rgba(99, 102, 241, 0.18); color: #A5B4FC; }
+    /* V2: accordion + stepper dark-mode */
+    body.dark-mode .nav-design-parent[aria-expanded="true"] { background: #1F2937; color: #F3F4F6; }
+    body.dark-mode .nav-design-parent[aria-expanded="true"].active { background: rgba(99, 102, 241, 0.18); color: #A5B4FC; }
+    body.dark-mode .nav-sub-list { border-left-color: #1F2937; }
+    body.dark-mode .nav-sub-item { color: #9CA3AF; }
+    body.dark-mode .nav-sub-item:hover { background: #1F2937; color: #F3F4F6; }
+    body.dark-mode .nav-sub-item.active { background: rgba(99, 102, 241, 0.18); color: #A5B4FC; }
+    body.dark-mode .design-stepper {
+      background: linear-gradient(180deg, rgba(99,102,241,0.10), rgba(99,102,241,0.05));
+      border-color: rgba(99,102,241,0.30);
+    }
+    body.dark-mode .stepper-cell { color: #9CA3AF; }
+    body.dark-mode .stepper-cell:hover:not(:disabled) { background: rgba(31,41,55,0.6); color: #F3F4F6; }
+    body.dark-mode .stepper-cell.is-current { background: #1F2937; color: #A5B4FC; }
+    body.dark-mode .stepper-divider { background: rgba(99,102,241,0.30); }
+    body.dark-mode .stepper-dropdown { background: #141A2D; border-color: #1F2937; box-shadow: 0 8px 24px rgba(0,0,0,0.4); }
+    body.dark-mode .stepper-dropdown-item { color: #F3F4F6; }
+    body.dark-mode .stepper-dropdown-item:hover { background: #1F2937; }
+    body.dark-mode .stepper-dropdown-item.is-current { background: rgba(99,102,241,0.18); color: #A5B4FC; }
+    body.dark-mode .side .side-user { border-bottom-color: #1F2937; }
+    body.dark-mode .side .utxt .uname { color: #F3F4F6; }
+    body.dark-mode .side .utxt .uhandle { color: #6B7280; }
+    body.dark-mode .main, body.dark-mode .preview { background: transparent; }
+    body.dark-mode .design-subnav { background: #141A2D; border-color: #1F2937; }
+    body.dark-mode .sub-item { color: #9CA3AF; }
+    body.dark-mode .sub-item:hover { background: #1F2937; color: #F3F4F6; }
+    body.dark-mode .sub-item.active { background: rgba(99, 102, 241, 0.18); color: #A5B4FC; }
+    body.dark-mode .design-content { background: #141A2D; border-color: #1F2937; }
+    body.dark-mode .field-group { border-color: #1F2937; }
+    body.dark-mode .fg-label { color: #F3F4F6; }
+    body.dark-mode .fg-help { color: #9CA3AF; }
+    body.dark-mode input[type="text"], body.dark-mode textarea, body.dark-mode select {
+      background: #0A0F1C; color: #F3F4F6; border-color: #1F2937;
+    }
+    body.dark-mode .seg { background: #141A2D; color: #9CA3AF; border-color: #1F2937; }
+    body.dark-mode .seg:hover { background: #1F2937; }
+    body.dark-mode .seg.active { background: rgba(99, 102, 241, 0.22); color: #A5B4FC; border-color: #6366F1; }
+    body.dark-mode .tile { background: #0A0F1C; border-color: #1F2937; }
+    body.dark-mode .tile.selected { border-color: #6366F1; box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.3); }
+    body.dark-mode .tile-label { color: #F3F4F6; }
+    body.dark-mode .anim-tile .anim-preview { background: #0A0F1C; }
+    body.dark-mode .anim-none::after { background: #374151; }
+    body.dark-mode .a11y-row { background: rgba(99, 102, 241, 0.08); border-color: rgba(99, 102, 241, 0.25); }
+    body.dark-mode .profile-card,
+    body.dark-mode .editor-panel,
+    body.dark-mode .design-panel,
+    body.dark-mode .blocks-list .block-row,
+    body.dark-mode .preview-panel,
+    body.dark-mode .device-toggle,
+    body.dark-mode .add-block-btn-secondary,
+    body.dark-mode .main-placeholder {
+      background: #141A2D !important;
+      border-color: #1F2937;
+      color: #F3F4F6;
+    }
+    body.dark-mode .blocks-list .block-row:hover { border-color: #374151; box-shadow: 0 2px 10px -2px rgba(0,0,0,0.4); }
+    body.dark-mode .block-label { color: #F3F4F6; }
+    body.dark-mode .block-sub { color: #9CA3AF; }
+    body.dark-mode .block-toggle { background: #374151; }
+    body.dark-mode .device-toggle button:not(.active) { color: #9CA3AF; }
+    body.dark-mode .device-toggle button.active { background: #1F2937; color: #F3F4F6; }
+    body.dark-mode .stat-chip { background: #1F2937; color: #9CA3AF; }
+    body.dark-mode .stat-chip strong { color: #F3F4F6; }
+    body.dark-mode .pricelock,
+    body.dark-mode .welcome-banner {
+      filter: brightness(0.9);
+    }
+    body.dark-mode .iconbtn { color: #D1D5DB; }
+    /* Animation tile previews stay legible in dark */
+    body.dark-mode .anim-typewriter { color: #F3F4F6; }
+
+    /* ==============================================================
+       ADD-MODAL — extensible integration picker (categories + search)
+       Prefix: .add-modal  (no collisions with existing .add-panel)
+       ============================================================== */
+
+    /* Backdrop */
+    .add-modal-backdrop {
+      display: none;
+      position: fixed; inset: 0; z-index: 200;
+      background: rgba(15, 23, 42, 0.55);
+      backdrop-filter: blur(8px);
+      -webkit-backdrop-filter: blur(8px);
+      animation: amFadeIn .18s ease;
+    }
+    .add-modal-backdrop.open { display: flex; align-items: center; justify-content: center; }
+    @keyframes amFadeIn { from { opacity: 0; } to { opacity: 1; } }
+
+    /* Modal shell */
+    .add-modal {
+      background: var(--bg-elevated);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      box-shadow: 0 24px 80px rgba(15,23,42,0.22), 0 4px 16px rgba(15,23,42,0.1);
+      width: min(880px, calc(100vw - 32px));
+      max-height: calc(100vh - 48px);
+      display: flex; flex-direction: column;
+      overflow: hidden;
+      animation: amSlideUp .22s cubic-bezier(0.22,1,0.36,1);
+    }
+    @keyframes amSlideUp { from { transform: translateY(12px); opacity: 0; } to { transform: translateY(0); opacity: 1; } }
+
+    /* Header */
+    .add-modal-header {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 20px 24px 0;
+      flex-shrink: 0;
+    }
+    .add-modal-header h2 {
+      font-family: var(--font-display); font-size: 24px; font-weight: 600;
+      margin: 0; color: var(--fg); letter-spacing: -0.02em;
+    }
+    .add-modal-close {
+      width: 32px; height: 32px; border-radius: 50%;
+      border: 1px solid var(--border-strong); background: var(--bg);
+      color: var(--fg-muted); display: flex; align-items: center; justify-content: center;
+      cursor: pointer; font-size: 16px; line-height: 1; flex-shrink: 0;
+      transition: all .15s ease;
+    }
+    .add-modal-close:hover { background: var(--bg-muted); color: var(--fg); }
+
+    /* Search row */
+    .add-modal-search-wrap {
+      padding: 16px 24px;
+      flex-shrink: 0;
+    }
+    .add-modal-search {
+      display: flex; align-items: center; gap: 10px;
+      background: var(--bg); border: 1.5px solid var(--border-strong);
+      border-radius: 12px; padding: 10px 14px;
+      transition: border-color .15s ease;
+    }
+    .add-modal-search:focus-within { border-color: var(--brand-primary); }
+    .add-modal-search svg { color: var(--fg-muted); flex-shrink: 0; }
+    .add-modal-search input {
+      flex: 1; border: none; outline: none; background: transparent;
+      font-family: var(--font-sans); font-size: 14px; color: var(--fg);
+    }
+    .add-modal-search input::placeholder { color: var(--fg-muted); }
+
+    /* Detected URL chip */
+    .add-modal-detected {
+      display: none;
+      margin: 0 24px 12px;
+      padding: 8px 14px; border-radius: 10px;
+      background: rgba(99,102,241,0.08); border: 1px solid rgba(99,102,241,0.22);
+      font-size: 13px; color: var(--brand-primary); font-weight: 500;
+      align-items: center; gap: 8px; cursor: pointer;
+      flex-shrink: 0;
+    }
+    .add-modal-detected.visible { display: flex; }
+    .add-modal-detected:hover { background: rgba(99,102,241,0.14); }
+
+    /* Body — two-column */
+    .add-modal-body {
+      display: grid; grid-template-columns: 180px 1fr;
+      flex: 1; overflow: hidden;
+      border-top: 1px solid var(--border);
+      min-height: 0;
+    }
+
+    /* Left rail */
+    .add-modal-rail {
+      border-right: 1px solid var(--border);
+      padding: 12px 8px;
+      overflow-y: auto;
+      display: flex; flex-direction: column; gap: 2px;
+      flex-shrink: 0;
+    }
+    .am-cat {
+      display: flex; align-items: center; gap: 10px;
+      padding: 9px 12px; border-radius: 10px;
+      font-size: 13.5px; font-weight: 500; color: var(--fg-muted);
+      cursor: pointer; background: transparent; border: none;
+      text-align: left; width: 100%; transition: all .12s ease;
+    }
+    .am-cat svg { width: 16px; height: 16px; flex-shrink: 0; }
+    .am-cat:hover { background: var(--bg-muted); color: var(--fg); }
+    .am-cat.active {
+      background: rgba(99,102,241,0.1); color: var(--brand-primary); font-weight: 600;
+    }
+    .am-cat-viewall { margin-top: auto; padding-top: 8px; color: var(--fg-muted); }
+    .am-cat-viewall:hover { color: var(--brand-primary); }
+
+    /* Right area */
+    .add-modal-right {
+      display: flex; flex-direction: column; overflow: hidden;
+    }
+
+    /* Category heading inside right area */
+    .add-modal-cat-title {
+      padding: 16px 20px 8px;
+      font-family: var(--font-display); font-size: 18px; font-weight: 600;
+      color: var(--fg); flex-shrink: 0;
+    }
+
+    /* Featured tiles row */
+    .add-modal-featured {
+      display: flex; gap: 10px; padding: 0 20px 14px;
+      flex-shrink: 0;
+    }
+    .am-feat-tile {
+      flex: 1; min-width: 100px; max-width: 160px;
+      background: var(--bg); border: 1.5px solid var(--border);
+      border-radius: 14px; padding: 14px 12px;
+      cursor: pointer; text-align: left;
+      transition: all .15s ease; display: flex; flex-direction: column; gap: 10px;
+    }
+    .am-feat-tile:hover {
+      border-color: var(--brand-primary);
+      box-shadow: 0 2px 8px rgba(99,102,241,0.12);
+      transform: translateY(-1px);
+    }
+    .am-feat-tile .am-ft-icon {
+      width: 40px; height: 40px; border-radius: 10px;
+      display: flex; align-items: center; justify-content: center;
+      font-size: 18px; overflow: hidden; flex-shrink: 0;
+    }
+    .am-feat-tile .am-ft-name {
+      font-size: 13px; font-weight: 600; color: var(--fg);
+    }
+
+    /* Integration list */
+    .add-modal-list {
+      flex: 1; overflow-y: auto; padding: 0 12px 12px;
+    }
+
+    /* Integration row */
+    .am-integration-row {
+      display: flex; align-items: center; gap: 14px;
+      padding: 11px 8px; border-radius: 12px;
+      cursor: pointer; transition: all .12s ease;
+      border: 1px solid transparent;
+    }
+    .am-integration-row:hover {
+      background: var(--bg); border-color: var(--border);
+      transform: translateY(-1px);
+      box-shadow: 0 2px 6px rgba(15,23,42,0.06);
+    }
+    .am-integration-row.highlighted {
+      background: rgba(99,102,241,0.06); border-color: rgba(99,102,241,0.25);
+    }
+    .am-int-icon {
+      width: 40px; height: 40px; border-radius: 10px;
+      display: flex; align-items: center; justify-content: center;
+      flex-shrink: 0; overflow: hidden; font-size: 18px;
+    }
+    .am-int-info { flex: 1; min-width: 0; }
+    .am-int-name {
+      font-size: 14px; font-weight: 600; color: var(--fg); margin-bottom: 2px;
+    }
+    .am-int-desc {
+      font-size: 12px; color: var(--fg-muted); line-height: 1.4;
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    }
+    .am-int-right {
+      display: flex; align-items: center; gap: 8px; flex-shrink: 0;
+    }
+    .am-gating-pill {
+      font-size: 11px; font-weight: 600; padding: 3px 8px; border-radius: 20px;
+      white-space: nowrap;
+    }
+    .am-gating-pill.creator {
+      background: linear-gradient(135deg, rgba(245,158,11,0.12), rgba(245,158,11,0.06));
+      color: var(--brand-warm-dark);
+      border: 1px solid rgba(245,158,11,0.25);
+    }
+    .am-gating-pill.pro {
+      background: linear-gradient(135deg, rgba(139,92,246,0.12), rgba(139,92,246,0.06));
+      color: #7C3AED;
+      border: 1px solid rgba(139,92,246,0.25);
+    }
+    .am-int-chevron { color: var(--fg-muted); font-size: 14px; }
+
+    /* Empty / no results */
+    .add-modal-empty {
+      display: none; flex-direction: column; align-items: center;
+      justify-content: center; padding: 40px 20px; text-align: center;
+      color: var(--fg-muted); gap: 8px;
+    }
+    .add-modal-empty.visible { display: flex; }
+    .add-modal-empty svg { opacity: 0.35; }
+    .add-modal-empty p { font-size: 14px; margin: 0; }
+
+    /* Pro-gated inline confirm */
+    .am-gating-confirm {
+      display: none; position: fixed; z-index: 210;
+      background: var(--bg-elevated); border: 1px solid var(--border-strong);
+      border-radius: 14px; padding: 16px 18px; max-width: 300px;
+      box-shadow: 0 8px 32px rgba(15,23,42,0.18);
+      font-size: 13px; color: var(--fg); line-height: 1.5;
+    }
+    .am-gating-confirm.visible { display: block; }
+    .am-gating-confirm strong { display: block; margin-bottom: 6px; }
+    .am-gc-btns { display: flex; gap: 8px; margin-top: 12px; }
+    .am-gc-btns button {
+      flex: 1; padding: 7px 10px; border-radius: 8px; font-size: 12px; font-weight: 600; cursor: pointer;
+    }
+    .am-gc-cancel { background: var(--bg-muted); border: 1px solid var(--border); color: var(--fg-muted); }
+    .am-gc-ok     { background: var(--brand-primary); border: none; color: #fff; }
+
+    /* Mobile — ≤640px: full-screen, rail becomes horizontal pill scroll */
+    @media (max-width: 640px) {
+      .add-modal {
+        width: 100vw; height: 100vh; max-height: 100vh;
+        border-radius: 0; margin: 0;
+      }
+      .add-modal-body {
+        grid-template-columns: 1fr; grid-template-rows: auto 1fr;
+      }
+      .add-modal-rail {
+        border-right: none; border-bottom: 1px solid var(--border);
+        flex-direction: row; overflow-x: auto; overflow-y: hidden;
+        padding: 8px 12px; gap: 6px;
+      }
+      .am-cat { padding: 6px 12px; white-space: nowrap; border-radius: 20px; }
+      .am-cat svg { display: none; }
+      .am-cat-viewall { margin-top: 0; padding-top: 0; }
+      .add-modal-featured { overflow-x: auto; }
+      .am-feat-tile { min-width: 110px; }
+    }
+
+    /* Dark mode tweaks for modal */
+    body.dark-mode .add-modal { background: #111827; border-color: #374151; }
+    body.dark-mode .add-modal-search { background: #1F2937; border-color: #374151; }
+    body.dark-mode .add-modal-search input { color: #F3F4F6; }
+    body.dark-mode .am-feat-tile { background: #1F2937; border-color: #374151; }
+    body.dark-mode .am-integration-row:hover { background: #1F2937; border-color: #374151; }
+    body.dark-mode .am-gating-confirm { background: #1F2937; border-color: #374151; }
+
+    /* ==============================================================
+       AI Theme matcher — Design > Theme sub-panel
+       ============================================================== */
+    .ai-theme-card {
+      background: linear-gradient(135deg, rgba(99,102,241,0.05) 0%, rgba(245,158,11,0.05) 100%);
+      border: 1px solid rgba(99,102,241,0.18);
+      border-radius: 14px;
+      padding: 18px;
+      position: relative;
+      overflow: hidden;
+    }
+    .ai-theme-card::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at 100% 0%, rgba(245,158,11,0.08), transparent 60%);
+      pointer-events: none;
+    }
+    .ai-theme-head {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 14px;
+      margin-bottom: 14px;
+      position: relative;
+    }
+    .ai-spark {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 26px; height: 26px;
+      border-radius: 8px;
+      background: linear-gradient(135deg, #6366F1, #F59E0B);
+      color: #fff;
+      flex-shrink: 0;
+    }
+    .ai-tokens-pill {
+      display: inline-flex;
+      align-items: center;
+      padding: 5px 11px;
+      background: #fff;
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      font-size: 11px;
+      font-weight: 500;
+      color: var(--fg-muted);
+      flex-shrink: 0;
+      white-space: nowrap;
+    }
+    .ai-tokens-pill strong { color: var(--brand-primary); font-weight: 700; font-size: 12px; }
+    .ai-theme-input-row {
+      display: flex;
+      gap: 8px;
+      align-items: stretch;
+      margin-bottom: 12px;
+      position: relative;
+      flex-wrap: wrap;
+    }
+    .ai-theme-prompt {
+      flex: 1;
+      min-width: 200px;
+      padding: 10px 14px;
+      background: #fff;
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      font-family: inherit;
+      font-size: 14px;
+      color: var(--fg);
+    }
+    .ai-theme-prompt:focus { outline: 2px solid rgba(99,102,241,0.3); outline-offset: -1px; border-color: var(--brand-primary); }
+    .ai-image-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 10px 14px;
+      background: #fff;
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--fg);
+      cursor: pointer;
+      transition: border-color .15s ease, background .15s ease;
+      flex-shrink: 0;
+    }
+    .ai-image-btn:hover { border-color: var(--brand-primary); background: #FAFBFC; }
+    .ai-image-btn .hide-sm { display: none; }
+    @media (min-width: 480px) { .ai-image-btn .hide-sm { display: inline; } }
+    .ai-generate-btn { flex-shrink: 0; padding: 10px 18px; }
+    .ai-generate-btn .ai-btn-label { white-space: nowrap; }
+    .ai-generate-btn:disabled { opacity: 0.6; cursor: not-allowed; }
+    .ai-suggest-chips {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      align-items: center;
+      margin-bottom: 12px;
+      position: relative;
+    }
+    .ai-suggest-label {
+      font-size: 11px;
+      color: var(--fg-subtle);
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      margin-right: 4px;
+    }
+    .ai-chip {
+      padding: 4px 10px;
+      background: rgba(99,102,241,0.08);
+      border: 1px solid rgba(99,102,241,0.18);
+      border-radius: 999px;
+      font-size: 12px;
+      color: var(--fg);
+      cursor: pointer;
+      transition: background .15s ease, border-color .15s ease;
+    }
+    .ai-chip:hover { background: rgba(99,102,241,0.15); border-color: rgba(99,102,241,0.4); }
+    .ai-tier-hint {
+      font-size: 11px;
+      color: var(--fg-muted);
+      padding: 8px 12px;
+      background: rgba(245,158,11,0.05);
+      border: 1px dashed rgba(245,158,11,0.25);
+      border-radius: 8px;
+      position: relative;
+      line-height: 1.5;
+      margin-top: 10px;
+    }
+    .ai-tier-hint strong { color: var(--fg); font-weight: 700; }
+    .ai-theme-result {
+      margin-top: 14px;
+      padding: 14px;
+      background: #fff;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      animation: ai-fade-in .35s ease;
+      position: relative;
+    }
+    @keyframes ai-fade-in {
+      from { opacity: 0; transform: translateY(6px); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
+    .ai-theme-result-head {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 12px;
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--fg);
+    }
+    .ai-results-grid { grid-template-columns: repeat(2, 1fr); gap: 8px; }
+    @media (min-width: 480px) { .ai-results-grid { grid-template-columns: repeat(4, 1fr); } }
+    .ai-result-tile { position: relative; }
+    .ai-result-tile .match-pct {
+      position: absolute;
+      top: 6px; right: 6px;
+      background: rgba(255,255,255,0.95);
+      color: var(--brand-primary);
+      font-size: 10px;
+      font-weight: 700;
+      padding: 2px 7px;
+      border-radius: 999px;
+      backdrop-filter: blur(4px);
+      z-index: 2;
+    }
+    .ai-generate-btn.generating { background: var(--fg) !important; color: #fff !important; }
+    .ai-generate-btn.generating::before {
+      content: '';
+      display: inline-block;
+      width: 12px; height: 12px;
+      border: 2px solid rgba(255,255,255,0.4);
+      border-top-color: #fff;
+      border-radius: 50%;
+      animation: ai-spin 0.7s linear infinite;
+      margin-right: 8px;
+      vertical-align: -2px;
+    }
+    @keyframes ai-spin { to { transform: rotate(360deg); } }
+    .link-inline { color: var(--brand-primary); font-weight: 600; text-decoration: none; }
+    .link-inline:hover { text-decoration: underline; }
+
+    /* Dark-mode tweaks for AI theme card */
+    body.dark-mode .ai-theme-card { background: linear-gradient(135deg, rgba(99,102,241,0.1) 0%, rgba(245,158,11,0.08) 100%); border-color: rgba(99,102,241,0.3); }
+    body.dark-mode .ai-tokens-pill { background: #141A2D; border-color: #1F2937; color: #9CA3AF; }
+    body.dark-mode .ai-theme-prompt { background: #0A0F1C; border-color: #1F2937; color: #F3F4F6; }
+    body.dark-mode .ai-image-btn { background: #141A2D; border-color: #1F2937; color: #F3F4F6; }
+    body.dark-mode .ai-image-btn:hover { background: #1F2937; }
+    body.dark-mode .ai-chip { background: rgba(99,102,241,0.18); border-color: rgba(99,102,241,0.35); color: #F3F4F6; }
+    body.dark-mode .ai-theme-result { background: #141A2D; border-color: #1F2937; }
+    body.dark-mode .ai-tier-hint { background: rgba(245,158,11,0.08); border-color: rgba(245,158,11,0.3); color: #D1D5DB; }
+
+    /* ==============================================================
+       Support badge (opt-in tadaify branding) — Footer panel
+       ============================================================== */
+    .support-badge-group { margin-top: 18px; }
+    .wm-mini {
+      display: inline-flex; align-items: baseline;
+      font-family: var(--font-display, serif);
+      font-weight: 700;
+      letter-spacing: -0.005em;
+    }
+    .wm-mini .ta  { color: var(--brand-primary, #6366F1); }
+    .wm-mini .da  { color: var(--warm-primary, #F59E0B); }
+    .wm-mini .ify { color: var(--fg, #111827); }
+    body.dark-mode .wm-mini .ify { color: #F3F4F6; }
+
+    .support-row {
+      display: flex;
+      gap: 14px;
+      align-items: flex-start;
+      padding: 16px;
+      background: linear-gradient(135deg, rgba(99,102,241,0.04) 0%, rgba(245,158,11,0.04) 100%);
+      border: 1px solid rgba(99,102,241,0.18);
+      border-radius: 14px;
+      cursor: pointer;
+      transition: border-color .15s ease;
+      margin-top: 12px;
+    }
+    .support-row:hover { border-color: rgba(99,102,241,0.35); }
+
+    .support-toggle {
+      position: relative;
+      flex-shrink: 0;
+      margin-top: 2px;
+      display: inline-flex;
+    }
+    .support-toggle input { position: absolute; opacity: 0; pointer-events: none; }
+    .support-toggle-track {
+      width: 38px; height: 22px;
+      background: var(--border-strong, #D1D5DB);
+      border-radius: 999px;
+      position: relative;
+      transition: background .15s ease;
+      display: inline-block;
+    }
+    .support-toggle-thumb {
+      position: absolute;
+      top: 2px; left: 2px;
+      width: 18px; height: 18px;
+      background: #fff;
+      border-radius: 50%;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+      transition: left .18s cubic-bezier(.2,.8,.2,1);
+    }
+    .support-toggle input:checked ~ .support-toggle-track {
+      background: linear-gradient(135deg, #6366F1, #F59E0B);
+    }
+    .support-toggle input:checked ~ .support-toggle-track .support-toggle-thumb { left: 18px; }
+
+    .support-row-body { flex: 1; min-width: 0; }
+    .support-row-title {
+      font-size: 14px;
+      font-weight: 600;
+      color: var(--fg);
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+    .support-row-title em { font-style: italic; font-weight: 500; color: var(--fg-muted); }
+    .opt-in-pill {
+      font-size: 10px;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: var(--brand-primary);
+      background: rgba(99,102,241,0.12);
+      padding: 3px 8px;
+      border-radius: 999px;
+    }
+    .support-row-sub {
+      font-size: 13px;
+      color: var(--fg-muted);
+      line-height: 1.5;
+      margin-top: 6px;
+    }
+    .support-row-sub code {
+      font-family: var(--font-mono, ui-monospace, monospace);
+      background: rgba(0,0,0,0.05);
+      padding: 1px 5px;
+      border-radius: 4px;
+      font-size: 12px;
+    }
+
+    .support-preview {
+      margin-top: 14px;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+    .support-preview-label {
+      font-size: 11px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--fg-subtle);
+      font-weight: 600;
+      flex-shrink: 0;
+    }
+    .support-preview-frame {
+      flex: 1;
+      padding: 14px 14px 12px;
+      background: #fff;
+      border: 1px dashed var(--border-strong);
+      border-radius: 10px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 10px;
+    }
+    .support-preview-block {
+      width: 80%;
+      padding: 9px 14px;
+      background: var(--bg-muted, #F3F4F6);
+      border-radius: 8px;
+      text-align: center;
+      font-size: 12px;
+      color: var(--fg-muted);
+    }
+    .support-preview-badge {
+      font-size: 11px;
+      color: var(--fg-subtle);
+      display: inline-flex;
+      align-items: baseline;
+      gap: 4px;
+      animation: support-fade-in .25s ease;
+    }
+    @keyframes support-fade-in {
+      from { opacity: 0; transform: translateY(2px); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
+
+    .support-fineprint {
+      font-size: 11px;
+      color: var(--fg-subtle);
+      margin: 10px 0 0;
+      text-align: center;
+    }
+
+    body.dark-mode .support-row { background: linear-gradient(135deg, rgba(99,102,241,0.1), rgba(245,158,11,0.06)); border-color: rgba(99,102,241,0.3); }
+    body.dark-mode .support-toggle-track { background: #374151; }
+    body.dark-mode .support-row-sub code { background: rgba(255,255,255,0.06); }
+    body.dark-mode .support-preview-frame { background: #141A2D; border-color: #374151; }
+    body.dark-mode .support-preview-block { background: #1F2937; color: #9CA3AF; }
+  </style>
+</head>
+<body data-state="ready">
+
+  <!-- ============ APP BAR ============ -->
+  <header class="appbar">
+    <a class="brand" href="./landing.html">
+      <span class="logo-mark" data-logo style="width:28px;height:28px"></span>
+      <span class="wm"><span class="ta">ta</span><span class="da">da!</span><span class="ify">ify</span></span>
+    </a>
+    <span class="env">Creator dashboard</span>
+    <span class="spacer"></span>
+    <a class="handle-pill" href="./creator-public.html" target="_blank" rel="noopener" data-tip="Open live page in new tab">
+      <span class="live-dot"></span>
+      <span class="hide-sm">tadaify.com/</span><b id="handle-text">alexandra</b>
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17l10-10M17 7H9M17 7v8"/></svg>
+    </a>
+    <button class="iconbtn" data-tip="Notifications">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9"/><path d="M10 21a2 2 0 0 0 4 0"/></svg>
+    </button>
+    <button class="iconbtn theme-toggle" id="theme-toggle" data-tip="Toggle light / dark" aria-label="Toggle theme">
+      <svg class="theme-icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+      <svg class="theme-icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+    </button>
+  </header>
+
+  <!-- ============ LAYOUT ============ -->
+  <div class="layout" data-tab="page">
+
+    <!-- -------- SIDEBAR -------- -->
+    <aside class="side" aria-label="Primary navigation">
+      <div class="side-user">
+        <div class="av">A</div>
+        <div class="utxt">
+          <div class="uname">Alexandra Silva</div>
+          <div class="uhandle">@alexandra · Free</div>
+        </div>
+        <svg class="chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="8 9 12 5 16 9"/><polyline points="8 15 12 19 16 15"/></svg>
+      </div>
+
+      <!-- GROUP 1: Pages (Homepage + Add page disabled) -->
+      <div class="nav-group">
+        <button class="nav-item active" data-nav="page" data-tip="Homepage" aria-label="Homepage">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+          <span class="label">Homepage</span>
+          <span class="nav-count" id="nav-page-count">3</span>
+        </button>
+        <button class="nav-item nav-add-page is-disabled" data-tip="Multi-page coming Q+1 — Free 1 / Creator 5 / Pro 20 / Business unlimited per DEC-MULTIPAGE-01" aria-disabled="true" onclick="event.preventDefault();event.stopPropagation();showAddPageToast(event)">
+          <span class="nav-icon">+</span>
+          <span class="nav-label">Add page</span>
+          <span class="nav-pill nav-pill-soon">soon</span>
+        </button>
+      </div>
+
+      <!-- DIVIDER -->
+      <div class="nav-divider"></div>
+
+      <!-- GROUP 2: Design (accordion) + Domain (building tools) -->
+      <div class="nav-group" style="padding-top:0">
+        <!-- V2: Design parent with inline-expanding sub-items (replaces secondary rail) -->
+        <button class="nav-item nav-design-parent" data-nav="design" data-tip="Design" aria-expanded="false" aria-controls="nav-design-sub">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="13.5" cy="6.5" r=".5" fill="currentColor"/><circle cx="17.5" cy="10.5" r=".5" fill="currentColor"/><circle cx="8.5" cy="7.5" r=".5" fill="currentColor"/><circle cx="6.5" cy="12.5" r=".5" fill="currentColor"/><path d="M12 2A10 10 0 0 0 2 12a10 10 0 0 0 10 10c1.4 0 2-.8 2-1.8 0-.5-.2-.9-.5-1.2-.3-.3-.5-.7-.5-1.2 0-1 .8-1.8 1.8-1.8H17a5 5 0 0 0 5-5c0-4.9-4.5-9-10-9z"/></svg>
+          <span class="label">Design</span>
+          <svg class="nav-caret" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+        </button>
+        <div class="nav-sub-list" id="nav-design-sub" data-expanded="false" role="group" aria-label="Design sub-sections">
+          <button class="nav-sub-item" data-nav-sub="theme">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M9 9v12"/></svg>
+            <span>Theme</span>
+          </button>
+          <button class="nav-sub-item" data-nav-sub="profile">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"/><path d="M4 21a8 8 0 0 1 16 0"/></svg>
+            <span>Profile</span>
+          </button>
+          <button class="nav-sub-item" data-nav-sub="background">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M3 15h18M9 3v18M15 3v18"/></svg>
+            <span>Background</span>
+          </button>
+          <button class="nav-sub-item" data-nav-sub="text">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 7 4 4 20 4 20 7"/><line x1="9" y1="20" x2="15" y2="20"/><line x1="12" y1="4" x2="12" y2="20"/></svg>
+            <span>Text</span>
+          </button>
+          <button class="nav-sub-item" data-nav-sub="buttons">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="6" width="20" height="5" rx="2.5"/><rect x="2" y="14" width="20" height="5" rx="2.5"/></svg>
+            <span>Buttons</span>
+          </button>
+          <button class="nav-sub-item" data-nav-sub="animations">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v4"/><path d="M12 18v4"/><path d="M4.93 4.93l2.83 2.83"/><path d="M16.24 16.24l2.83 2.83"/><path d="M2 12h4"/><path d="M18 12h4"/><path d="M4.93 19.07l2.83-2.83"/><path d="M16.24 7.76l2.83-2.83"/></svg>
+            <span>Animations</span>
+          </button>
+          <button class="nav-sub-item" data-nav-sub="colors">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="13.5" cy="6.5" r=".5" fill="currentColor"/><circle cx="17.5" cy="10.5" r=".5" fill="currentColor"/><circle cx="8.5" cy="7.5" r=".5" fill="currentColor"/><circle cx="6.5" cy="12.5" r=".5" fill="currentColor"/><path d="M12 2A10 10 0 0 0 2 12a10 10 0 0 0 10 10c1.4 0 2-.8 2-1.8 0-.5-.2-.9-.5-1.2-.3-.3-.5-.7-.5-1.2 0-1 .8-1.8 1.8-1.8H17a5 5 0 0 0 5-5c0-4.9-4.5-9-10-9z"/></svg>
+            <span>Colors</span>
+          </button>
+          <button class="nav-sub-item" data-nav-sub="footer">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="2" x2="12" y2="22"/><line x1="2" y1="12" x2="22" y2="12"/></svg>
+            <span>Footer</span>
+          </button>
+        </div>
+        <button class="nav-item" data-nav="domain" data-tip="Custom domain — universal $2/mo add-on per DEC-PRICELOCK-02. Coming soon." onclick="event.preventDefault(); window.location.href='./app-domain.html';">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+          <span class="label">Domain</span>
+          <span style="margin-left:auto;font-size:10px;font-weight:600;padding:1px 6px;border-radius:99px;background:var(--bg-muted);color:var(--fg-subtle);white-space:nowrap">soon</span>
+        </button>
+      </div>
+
+      <!-- DIVIDER -->
+      <div class="nav-divider"></div>
+
+      <!-- GROUP 3: Insights + Shop -->
+      <div class="nav-group" style="padding-top:0">
+        <button class="nav-item" data-nav="insights" data-tip="Insights">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><path d="M7 14l4-4 4 4 5-7"/></svg>
+          <span class="label">Insights</span>
+        </button>
+        <button class="nav-item" data-nav="shop" data-tip="Shop">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="21" r="1"/><circle cx="20" cy="21" r="1"/><path d="M1 1h4l2.7 13.4a2 2 0 0 0 2 1.6h9.7a2 2 0 0 0 2-1.6L23 6H6"/></svg>
+          <span class="label">Shop</span>
+          <span class="nav-count">0</span>
+        </button>
+      </div>
+
+      <!-- DIVIDER -->
+      <div class="nav-divider"></div>
+
+      <!-- GROUP 4: Settings (standalone, no section header) -->
+      <div class="nav-group" style="padding-top:0">
+        <button class="nav-item" data-nav="settings" data-tip="Settings">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1a1.7 1.7 0 0 0-1-1.5 1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1a1.7 1.7 0 0 0 1.5-1 1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.8.3h0a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8v0a1.7 1.7 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1z"/></svg>
+          <span class="label">Settings</span>
+        </button>
+        <button class="nav-item" data-tip="Help &amp; docs">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M9.1 9a3 3 0 1 1 5.8 1c0 2-3 3-3 3M12 17h.01"/></svg>
+          <span class="label">Help &amp; docs</span>
+        </button>
+      </div>
+    </aside>
+
+    <!-- -------- MAIN CONTENT -------- -->
+    <main class="content">
+
+      <!-- ======== PAGE TAB ======== -->
+      <section class="main-page" aria-labelledby="page-title">
+        <div class="page-head">
+          <div>
+            <h1 id="page-title">My page</h1>
+            <div class="sub">
+              <span id="blocks-summary">3 blocks</span>
+              <span class="dot"></span>
+              <span class="only-ready">Live · updated 2 min ago</span>
+              <span class="only-empty">Not live yet — add a block to go live</span>
+            </div>
+          </div>
+          <div class="actions">
+            <button class="btn btn-ghost btn-sm" onclick="copyLink(event)">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+              Copy link
+            </button>
+            <button class="btn btn-primary btn-sm" onclick="openAddBlockModal()">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+              Add block
+            </button>
+          </div>
+        </div>
+
+        <!-- Welcome banner (ready only) -->
+        <div class="welcome-banner only-ready">
+          <span class="wb-ic">🎉</span>
+          <div class="wb-body">
+            <b>Your page is live.</b> Share <a href="./creator-public.html" style="color:var(--brand-primary); font-weight:500">tadaify.com/alexandra</a> on your socials — you had 142 visits this week.
+          </div>
+          <button class="wb-close" aria-label="Dismiss" onclick="this.parentElement.remove()">✕</button>
+        </div>
+
+        <!-- Pinned message primitive — tadaify differentiator (DEC-PINNED-MSG-01) -->
+        <div id="pinned-msg-row" style="margin-top:16px;margin-bottom:4px;padding:10px 14px;background:rgba(99,102,241,0.06);border:1px solid rgba(99,102,241,0.15);border-radius:10px;display:flex;align-items:center;gap:10px">
+          <label style="display:flex;align-items:center;gap:8px;cursor:pointer;flex-shrink:0">
+            <span class="toggle" id="pinned-toggle" onclick="togglePinnedMsg(this)" style="flex-shrink:0"></span>
+            <span style="font-size:13px;font-weight:600;color:var(--fg)">Pinned message</span>
+          </label>
+          <div id="pinned-input-wrap" style="flex:1;display:flex;align-items:center;gap:6px">
+            <input type="text" id="pinned-msg-input" maxlength="80" placeholder="e.g. New course Friday — set a reminder? 📣"
+              style="flex:1;font-family:var(--font-sans);font-size:13px;padding:6px 10px;border:1px solid var(--border-strong);border-radius:7px;background:var(--bg-elevated);color:var(--fg);min-width:0"
+              oninput="document.getElementById('pinned-char').textContent=(80-this.value.length)" />
+            <span id="pinned-char" style="font-size:11px;color:var(--fg-subtle);flex-shrink:0">80</span>
+          </div>
+          <span style="font-size:11px;color:var(--fg-subtle);flex-shrink:0">Dismissible by visitor</span>
+        </div>
+
+        <!-- Profile card -->
+        <div class="profile-card" id="profile-card">
+          <div class="pc-av-wrap">
+            <div class="pc-av" onclick="alert('In the real app this opens an avatar upload dialog.')" data-tip="Change avatar">A</div>
+            <div class="pc-av-cam">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"/><circle cx="12" cy="13" r="4"/></svg>
+            </div>
+          </div>
+          <div class="pc-body">
+            <div class="pc-head">
+              <div class="pc-name" id="pc-name">Alexandra Silva</div>
+              <span class="chip verified" data-tip="Handle verified">✓ verified</span>
+            </div>
+            <div class="pc-bio" id="pc-bio">Creator + educator 🪄 — helping people turn ideas into tiny daily wins.</div>
+            <div class="pc-handle">tadaify.com/alexandra</div>
+            <div class="pc-socials">
+              <button class="pc-social social-ig" data-tip="Instagram @alexandra" onclick="alert('In the real app this jumps to the Instagram Follow block editor.')">
+                <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.2c3.2 0 3.6 0 4.8.1 1.2.1 1.9.2 2.3.4.6.2 1 .5 1.5 1s.8.9 1 1.5c.2.4.3 1.1.4 2.3.1 1.3.1 1.6.1 4.8s0 3.6-.1 4.8c-.1 1.2-.2 1.9-.4 2.3-.2.6-.5 1-1 1.5s-.9.8-1.5 1c-.4.2-1.1.3-2.3.4-1.3.1-1.6.1-4.8.1s-3.6 0-4.8-.1c-1.2-.1-1.9-.2-2.3-.4-.6-.2-1-.5-1.5-1s-.8-.9-1-1.5c-.2-.4-.3-1.1-.4-2.3C2.2 15.6 2.2 15.3 2.2 12s0-3.6.1-4.8c.1-1.2.2-1.9.4-2.3.2-.6.5-1 1-1.5s.9-.8 1.5-1c.4-.2 1.1-.3 2.3-.4 1.2-.1 1.6-.1 4.8-.1zm0 3.1a6.7 6.7 0 1 0 0 13.4 6.7 6.7 0 0 0 0-13.4zm0 11a4.4 4.4 0 1 1 0-8.8 4.4 4.4 0 0 1 0 8.8zm7-11.4a1.2 1.2 0 1 1-2.4 0 1.2 1.2 0 0 1 2.4 0z"/></svg>
+              </button>
+              <button class="pc-social social-tt" data-tip="TikTok @alexandra" onclick="alert('In the real app this jumps to the TikTok Follow block editor.')">
+                <svg viewBox="0 0 24 24" fill="currentColor"><path d="M19.3 6.7a5 5 0 0 1-3.6-3.1 5 5 0 0 1-.1-1V2h-3.4v13.6a2.4 2.4 0 1 1-2.4-2.4c.2 0 .5 0 .7.1V9.8a6 6 0 1 0 5.2 5.9V8.3a8.3 8.3 0 0 0 4.8 1.5V6.4c-.4 0-.8 0-1.2-.1z"/></svg>
+              </button>
+              <button class="pc-social social-yt" data-tip="YouTube @alexandra" onclick="alert('In the real app this jumps to the YouTube Follow block editor.')">
+                <svg viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 0 0-2.1-2.1C19.6 3.6 12 3.6 12 3.6s-7.6 0-9.4.5A3 3 0 0 0 .5 6.2 31.5 31.5 0 0 0 0 12a31.5 31.5 0 0 0 .5 5.8 3 3 0 0 0 2.1 2.1c1.8.5 9.4.5 9.4.5s7.6 0 9.4-.5a3 3 0 0 0 2.1-2.1A31.5 31.5 0 0 0 24 12a31.5 31.5 0 0 0-.5-5.8zM9.6 15.6V8.4l6.3 3.6-6.3 3.6z"/></svg>
+              </button>
+              <button class="pc-social social-x" data-tip="X @alexandra" onclick="alert('In the real app this jumps to the X Follow block editor.')">
+                <svg viewBox="0 0 24 24" fill="currentColor"><path d="M18.9 2H22l-7 8 8.3 12h-6.5l-5-7.3L5.8 22H2.7l7.5-8.6L2 2h6.6l4.6 6.6L18.9 2zm-1 18.1h1.8L7.3 3.8H5.4l12.5 16.3z"/></svg>
+              </button>
+              <button class="pc-social-add" data-tip="Add another social" onclick="openAddBlockModal()">+</button>
+            </div>
+          </div>
+          <button class="pc-edit" onclick="toggleProfileEdit()">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 1 1 3 3L7 19l-4 1 1-4 12.5-12.5z"/></svg>
+            <span>Edit</span>
+          </button>
+
+          <!-- Inline editor (flex-basis:100% to break to new row) -->
+          <div class="profile-editor">
+            <div class="pe-row">
+              <div class="field">
+                <label for="pe-name">Display name</label>
+                <input id="pe-name" type="text" value="Alexandra Silva" oninput="livePreviewName(this.value)"/>
+              </div>
+              <div class="field">
+                <label for="pe-pronouns">Pronouns (optional)</label>
+                <input id="pe-pronouns" type="text" placeholder="she / her" />
+              </div>
+            </div>
+            <div class="field">
+              <div class="row-sp">
+                <label for="pe-bio">Bio</label>
+                <span class="counter" id="pe-counter">64 / 80</span>
+              </div>
+              <textarea id="pe-bio" maxlength="80" oninput="updateBioCounter(this)">Creator + educator 🪄 — helping people turn ideas into tiny daily wins.</textarea>
+            </div>
+            <div class="pe-actions">
+              <button class="btn btn-ghost btn-sm" onclick="toggleProfileEdit()">Cancel</button>
+              <button class="btn btn-primary btn-sm" onclick="saveProfileEdit()">Save changes</button>
+            </div>
+          </div>
+        </div>
+
+        <!-- Quick chips -->
+        <div class="quick-chips only-ready">
+          <!-- Organise… dropdown (replaces "Add collection" + "View archive" chips) -->
+          <div style="position:relative;display:inline-block" id="organise-wrap">
+            <button class="qchip" onclick="toggleOrganise()" id="organise-btn">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
+              Organise…
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="12" height="12"><polyline points="6 9 12 15 18 9"/></svg>
+            </button>
+            <div id="organise-menu" style="display:none;position:absolute;top:calc(100% + 6px);left:0;z-index:80;background:var(--bg-elevated);border:1px solid var(--border);border-radius:10px;box-shadow:0 8px 24px rgba(0,0,0,.12);padding:4px;min-width:172px">
+              <button onclick="toggleOrganise();toggleCollectionInline()" style="display:flex;align-items:center;gap:10px;width:100%;padding:9px 12px;border:0;background:transparent;color:var(--fg);font-size:13.5px;font-weight:500;border-radius:7px;cursor:pointer;text-align:left;font-family:var(--font-sans)">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="15" height="15"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+                Group into collection
+              </button>
+              <button onclick="toggleOrganise();toggleArchive()" style="display:flex;align-items:center;gap:10px;width:100%;padding:9px 12px;border:0;background:transparent;color:var(--fg);font-size:13.5px;font-weight:500;border-radius:7px;cursor:pointer;text-align:left;font-family:var(--font-sans)">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="15" height="15"><polyline points="21 8 21 21 3 21 3 8"/><rect x="1" y="3" width="22" height="5"/><line x1="10" y1="12" x2="14" y2="12"/></svg>
+                Archive <span style="color:var(--fg-muted);font-weight:400">(2)</span>
+              </button>
+              <button onclick="toggleOrganise();alert('Drag to reorder — in real app this enables drag-sort mode')" style="display:flex;align-items:center;gap:10px;width:100%;padding:9px 12px;border:0;background:transparent;color:var(--fg);font-size:13.5px;font-weight:500;border-radius:7px;cursor:pointer;text-align:left;font-family:var(--font-sans)">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="15" height="15"><line x1="3" y1="9" x2="21" y2="9"/><line x1="3" y1="15" x2="21" y2="15"/><path d="M9 3L3 9M9 21l-6-6"/></svg>
+                Reorder
+              </button>
+              <button onclick="toggleOrganise();alert('Export — in real app downloads blocks as CSV/JSON')" style="display:flex;align-items:center;gap:10px;width:100%;padding:9px 12px;border:0;background:transparent;color:var(--fg);font-size:13.5px;font-weight:500;border-radius:7px;cursor:pointer;text-align:left;font-family:var(--font-sans)">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="15" height="15"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                Export blocks
+              </button>
+            </div>
+          </div>
+          <button class="qchip" onclick="alert('In the real app this opens the share-page sheet.')">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8"/><polyline points="16 6 12 2 8 6"/><line x1="12" y1="2" x2="12" y2="15"/></svg>
+            Share page
+          </button>
+        </div>
+
+        <!-- Inline new-collection input -->
+        <div class="collection-inline" id="collection-inline">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--brand-primary)"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+          <input type="text" placeholder="Collection name (e.g. 'Latest drops')" />
+          <button class="btn btn-ghost btn-sm" onclick="toggleCollectionInline()">Cancel</button>
+          <button class="btn btn-primary btn-sm" onclick="toggleCollectionInline(); alert('Would create the collection in real app.')">Create</button>
+        </div>
+
+        <!-- Archive list -->
+        <div class="archive-list" id="archive-list">
+          <h4>Archived blocks (2)</h4>
+          <div class="archive-row">
+            <span class="ar-ic">FB</span>
+            <div>
+              <div style="color:var(--fg); font-weight:500">Follow me on Facebook</div>
+              <div style="font-size:11.5px">Archived 3 weeks ago</div>
+            </div>
+            <span class="spacer"></span>
+            <button>Restore</button>
+          </div>
+          <div class="archive-row">
+            <span class="ar-ic">SP</span>
+            <div>
+              <div style="color:var(--fg); font-weight:500">My Spotify playlist</div>
+              <div style="font-size:11.5px">Archived 2 months ago</div>
+            </div>
+            <span class="spacer"></span>
+            <button>Restore</button>
+          </div>
+        </div>
+
+        <!-- Ready state: blocks -->
+        <div class="only-ready">
+          <div class="section-label">Blocks</div>
+          <section class="blocks" aria-label="Page blocks" id="blocks-list">
+            <div class="block" data-block="ig">
+              <span class="grip" title="Drag to reorder">⋮⋮</span>
+              <span class="ic social-ig">
+                <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.2c3.2 0 3.6 0 4.8.1 1.2.1 1.9.2 2.3.4.6.2 1 .5 1.5 1s.8.9 1 1.5c.2.4.3 1.1.4 2.3.1 1.3.1 1.6.1 4.8s0 3.6-.1 4.8c-.1 1.2-.2 1.9-.4 2.3-.2.6-.5 1-1 1.5s-.9.8-1.5 1c-.4.2-1.1.3-2.3.4-1.3.1-1.6.1-4.8.1s-3.6 0-4.8-.1c-1.2-.1-1.9-.2-2.3-.4-.6-.2-1-.5-1.5-1s-.8-.9-1-1.5c-.2-.4-.3-1.1-.4-2.3C2.2 15.6 2.2 15.3 2.2 12s0-3.6.1-4.8c.1-1.2.2-1.9.4-2.3.2-.6.5-1 1-1.5s.9-.8 1.5-1c.4-.2 1.1-.3 2.3-.4 1.2-.1 1.6-.1 4.8-.1zm0 3.1a6.7 6.7 0 1 0 0 13.4 6.7 6.7 0 0 0 0-13.4zm0 11a4.4 4.4 0 1 1 0-8.8 4.4 4.4 0 0 1 0 8.8zm7-11.4a1.2 1.2 0 1 1-2.4 0 1.2 1.2 0 0 1 2.4 0z"/></svg>
+              </span>
+              <div class="meta">
+                <div class="t">Follow me on Instagram</div>
+                <div class="u">instagram.com/alexandra</div>
+              </div>
+              <div class="stat"><b>41</b>clicks · 7d</div>
+              <div class="tools">
+                <span class="toggle on" onclick="toggleBlock(this, 'ig')" data-tip="Live — click to hide"></span>
+                <button class="iconbtn" data-tip="Edit block">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 1 1 3 3L7 19l-4 1 1-4 12.5-12.5z"/></svg>
+                </button>
+                <button class="iconbtn" data-tip="More">
+                  <svg viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="5" r="1.5"/><circle cx="12" cy="12" r="1.5"/><circle cx="12" cy="19" r="1.5"/></svg>
+                </button>
+              </div>
+            </div>
+
+            <div class="block" data-block="tt">
+              <span class="grip">⋮⋮</span>
+              <span class="ic social-tt">
+                <svg viewBox="0 0 24 24" fill="currentColor"><path d="M19.3 6.7a5 5 0 0 1-3.6-3.1 5 5 0 0 1-.1-1V2h-3.4v13.6a2.4 2.4 0 1 1-2.4-2.4c.2 0 .5 0 .7.1V9.8a6 6 0 1 0 5.2 5.9V8.3a8.3 8.3 0 0 0 4.8 1.5V6.4c-.4 0-.8 0-1.2-.1z"/></svg>
+              </span>
+              <div class="meta">
+                <div class="t">Follow me on TikTok</div>
+                <div class="u">tiktok.com/@alexandra</div>
+              </div>
+              <div class="stat"><b>32</b>clicks · 7d</div>
+              <div class="tools">
+                <span class="toggle on" onclick="toggleBlock(this, 'tt')" data-tip="Live — click to hide"></span>
+                <button class="iconbtn" data-tip="Edit block">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 1 1 3 3L7 19l-4 1 1-4 12.5-12.5z"/></svg>
+                </button>
+                <button class="iconbtn" data-tip="More">
+                  <svg viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="5" r="1.5"/><circle cx="12" cy="12" r="1.5"/><circle cx="12" cy="19" r="1.5"/></svg>
+                </button>
+              </div>
+            </div>
+
+            <div class="block" data-block="yt">
+              <span class="grip">⋮⋮</span>
+              <span class="ic social-yt">
+                <svg viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 0 0-2.1-2.1C19.6 3.6 12 3.6 12 3.6s-7.6 0-9.4.5A3 3 0 0 0 .5 6.2 31.5 31.5 0 0 0 0 12a31.5 31.5 0 0 0 .5 5.8 3 3 0 0 0 2.1 2.1c1.8.5 9.4.5 9.4.5s7.6 0 9.4-.5a3 3 0 0 0 2.1-2.1A31.5 31.5 0 0 0 24 12a31.5 31.5 0 0 0-.5-5.8zM9.6 15.6V8.4l6.3 3.6-6.3 3.6z"/></svg>
+              </span>
+              <div class="meta">
+                <div class="t">Follow me on YouTube</div>
+                <div class="u">youtube.com/@alexandra</div>
+              </div>
+              <div class="stat"><b>14</b>clicks · 7d</div>
+              <div class="tools">
+                <span class="toggle on" onclick="toggleBlock(this, 'yt')" data-tip="Live — click to hide"></span>
+                <button class="iconbtn" data-tip="Edit block">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 1 1 3 3L7 19l-4 1 1-4 12.5-12.5z"/></svg>
+                </button>
+                <button class="iconbtn" data-tip="More">
+                  <svg viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="5" r="1.5"/><circle cx="12" cy="12" r="1.5"/><circle cx="12" cy="19" r="1.5"/></svg>
+                </button>
+              </div>
+            </div>
+
+            <button class="add-block" onclick="openAddBlockModal()">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+              Add a block
+            </button>
+          </section>
+        </div>
+
+        <!-- Empty state -->
+        <div class="only-empty">
+          <div class="section-label">Get started</div>
+          <div class="empty-cards">
+            <button class="empty-card" onclick="openAddBlockModal()">
+              <span class="ec-ic">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.5.5l3-3a5 5 0 0 0-7-7l-1.7 1.7"/><path d="M14 11a5 5 0 0 0-7.5-.5l-3 3a5 5 0 0 0 7 7l1.7-1.7"/></svg>
+              </span>
+              <div class="ec-title">Add a link</div>
+              <div class="ec-body">Your newsletter, portfolio, merch — anything with a URL.</div>
+            </button>
+            <button class="empty-card" onclick="openAddBlockModal()">
+              <span class="ec-ic">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M2 12h20M12 2a15 15 0 0 1 4 10 15 15 0 0 1-4 10M12 2a15 15 0 0 0-4 10 15 15 0 0 0 4 10"/></svg>
+              </span>
+              <div class="ec-title">Connect a social</div>
+              <div class="ec-body">Drop your @handle — we auto-style an Instagram, TikTok or YouTube card.</div>
+            </button>
+            <button class="empty-card" onclick="location.href='./onboarding-template.html'">
+              <span class="ec-ic">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>
+              </span>
+              <div class="ec-title">Pick a template</div>
+              <div class="ec-body">Creator, musician, coach, shop — pre-filled layouts you can tweak.</div>
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <!-- ======== DESIGN TAB ======== -->
+      <section class="main-design" aria-labelledby="design-title">
+        <div class="page-head">
+          <div>
+            <h1 id="design-title">Design</h1>
+            <div class="sub">Changes apply instantly in the preview. Your page saves automatically as you go.</div>
+          </div>
+          <div class="actions">
+            <button class="btn btn-ghost btn-sm" onclick="alert('In real app this reverts to the last published design.')">Discard</button>
+            <button class="btn btn-primary btn-sm" onclick="alert('Auto-saved. Already live on tadaify.com/alexandra.')">Save</button>
+          </div>
+        </div>
+
+        <div class="design-wrap">
+          <nav class="design-subnav" aria-label="Design sub-navigation">
+            <button class="sub-item" data-subnav="theme">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M9 9v12"/></svg>
+              Theme
+            </button>
+            <button class="sub-item" data-subnav="profile">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"/><path d="M4 21a8 8 0 0 1 16 0"/></svg>
+              Profile
+            </button>
+            <button class="sub-item active" data-subnav="background">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M3 15h18M9 3v18M15 3v18"/></svg>
+              Background
+            </button>
+            <button class="sub-item" data-subnav="text">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 7 4 4 20 4 20 7"/><line x1="9" y1="20" x2="15" y2="20"/><line x1="12" y1="4" x2="12" y2="20"/></svg>
+              Text
+            </button>
+            <button class="sub-item" data-subnav="buttons">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="6" width="20" height="5" rx="2.5"/><rect x="2" y="14" width="20" height="5" rx="2.5"/></svg>
+              Buttons
+            </button>
+            <button class="sub-item" data-subnav="animations">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v4"/><path d="M12 18v4"/><path d="M4.93 4.93l2.83 2.83"/><path d="M16.24 16.24l2.83 2.83"/><path d="M2 12h4"/><path d="M18 12h4"/><path d="M4.93 19.07l2.83-2.83"/><path d="M16.24 7.76l2.83-2.83"/></svg>
+              Animations
+            </button>
+            <button class="sub-item" data-subnav="colors">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="13.5" cy="6.5" r=".5" fill="currentColor"/><circle cx="17.5" cy="10.5" r=".5" fill="currentColor"/><circle cx="8.5" cy="7.5" r=".5" fill="currentColor"/><circle cx="6.5" cy="12.5" r=".5" fill="currentColor"/><path d="M12 2A10 10 0 0 0 2 12a10 10 0 0 0 10 10c1.4 0 2-.8 2-1.8 0-.5-.2-.9-.5-1.2-.3-.3-.5-.7-.5-1.2 0-1 .8-1.8 1.8-1.8H17a5 5 0 0 0 5-5c0-4.9-4.5-9-10-9z"/></svg>
+              Colors
+            </button>
+            <button class="sub-item" data-subnav="footer">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="2" x2="12" y2="22"/><line x1="2" y1="12" x2="22" y2="12"/></svg>
+              Footer
+            </button>
+          </nav>
+
+          <div class="design-content" style="min-width:0">
+
+            <!-- V2: Breadcrumb stepper — prev / current / next, replaces the secondary rail walkthrough -->
+            <nav class="design-stepper" aria-label="Design sub-section stepper" id="design-stepper">
+              <button class="stepper-cell stepper-arrow" data-stepper="prev" aria-label="Previous sub-section">
+                <svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
+                <span class="stepper-arrow-label" data-stepper-prev-label>—</span>
+              </button>
+              <span class="stepper-divider" aria-hidden="true"></span>
+              <button class="stepper-cell is-current" data-stepper="current" aria-haspopup="listbox" aria-expanded="false" aria-controls="stepper-dropdown">
+                <span class="step-spark" aria-hidden="true"></span>
+                <span data-stepper-current-label>Background</span>
+              </button>
+              <span class="stepper-divider" aria-hidden="true"></span>
+              <button class="stepper-cell stepper-arrow" data-stepper="next" aria-label="Next sub-section">
+                <span class="stepper-arrow-label" data-stepper-next-label>Text</span>
+                <svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+              </button>
+              <div class="stepper-dropdown" id="stepper-dropdown" data-open="false" role="listbox" aria-label="All Design sub-sections"></div>
+            </nav>
+
+            <!-- THEME -->
+            <div class="design-panel" data-panel="theme">
+
+              <!-- ✨ AI theme matcher — predefined catalogue + semantic match (not generative) -->
+              <div class="field-group ai-theme-card">
+                <div class="ai-theme-head">
+                  <div>
+                    <label class="fg-label" style="display:flex; align-items:center; gap:8px; margin:0;">
+                      <span class="ai-spark" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2l2.4 5.4L20 10l-5.6 2.6L12 18l-2.4-5.4L4 10l5.6-2.6L12 2z"/><path d="M19 17l.6 1.4L21 19l-1.4.6L19 21l-.6-1.4L17 19l1.4-.6L19 17z"/></svg>
+                      </span>
+                      Generate with AI
+                    </label>
+                    <div class="fg-help" style="margin-top:6px">
+                      Describe what you like — or upload a photo that captures the vibe. We'll match you to the closest theme from our catalogue of 1000+ presets.
+                    </div>
+                  </div>
+                  <span class="ai-tokens-pill" id="ai-tokens-pill" data-tip="AI uses reset on the 1st of each month">
+                    <strong id="ai-tokens-count">4</strong>&nbsp;/&nbsp;5 AI uses left
+                  </span>
+                </div>
+
+                <div class="ai-theme-input-row">
+                  <input
+                    type="text"
+                    id="ai-theme-prompt"
+                    placeholder="e.g. warm sunset over Lisbon rooftops, editorial feel"
+                    class="ai-theme-prompt"
+                    maxlength="120"
+                  />
+                  <label for="ai-theme-image" class="ai-image-btn" data-tip="Upload an inspiration image — we extract the 2 dominant colors and match a theme">
+                    <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="9" cy="9" r="2"/><path d="M21 15l-5-5-9 9"/></svg>
+                    <span class="hide-sm">Image</span>
+                  </label>
+                  <input type="file" id="ai-theme-image" accept="image/*" style="display:none" onchange="onAiImageSelected(this)"/>
+                  <button type="button" class="btn btn-warm ai-generate-btn" id="ai-generate-btn" onclick="generateAiTheme()">
+                    <span class="ai-btn-label">✨ Generate</span>
+                  </button>
+                </div>
+
+                <!-- Suggested chips — click to use as a hint -->
+                <div class="ai-suggest-chips">
+                  <span class="ai-suggest-label">Try:</span>
+                  <button type="button" class="ai-chip" onclick="useAiHint(this)">cozy bookstore</button>
+                  <button type="button" class="ai-chip" onclick="useAiHint(this)">90s zine</button>
+                  <button type="button" class="ai-chip" onclick="useAiHint(this)">brutalist concrete</button>
+                  <button type="button" class="ai-chip" onclick="useAiHint(this)">soft pastel skincare</button>
+                  <button type="button" class="ai-chip" onclick="useAiHint(this)">vinyl record store</button>
+                </div>
+
+                <!-- Result area — populated when AI matches return -->
+                <div class="ai-theme-result" id="ai-theme-result" hidden>
+                  <div class="ai-theme-result-head">
+                    <span>Closest matches from our catalogue</span>
+                    <button type="button" class="link-btn" onclick="closeAiResult()" style="background:transparent; border:0; color:var(--fg-muted); cursor:pointer; font-size:12px;">Close ×</button>
+                  </div>
+                  <div class="tile-grid ai-results-grid" id="ai-results-grid">
+                    <!-- populated by JS -->
+                  </div>
+                  <div class="fg-help" style="margin-top:10px; font-size:12px;">
+                    These are existing themes from our catalogue. We never generate brand-new colors — just find the best fit, so your page stays consistent and your AI quota stretches further.
+                  </div>
+                </div>
+
+                <!-- Tier hint (subtle, AP-028) — DEC-AI-QUOTA-LADDER-01=B: 5/20/100/∞ -->
+                <div class="ai-tier-hint">
+                  💡 Free: <strong>5 AI uses/mo</strong>. Creator <strong>20</strong> · Pro <strong>100</strong> · Business <strong>unlimited</strong>. Price locked for life.
+                </div>
+              </div>
+
+              <div class="field-group">
+                <label class="fg-label">Or pick a preset</label>
+                <div class="fg-help">A preset sets all seven layers at once — you can still tweak any of them after.</div>
+                <div class="tile-grid">
+                  <div class="tile" data-theme-preset="minimal"><div class="theme-minimal" style="position:absolute;inset:0"></div><div class="tile-label">Minimal</div></div>
+                  <div class="tile selected" data-theme-preset="bold"><div class="theme-bold" style="position:absolute;inset:0"></div><div class="tile-label">Bold</div></div>
+                  <div class="tile" data-theme-preset="editorial"><div class="theme-editorial" style="position:absolute;inset:0"></div><div class="tile-label">Editorial</div></div>
+                  <div class="tile" data-theme-preset="playful"><div class="theme-playful" style="position:absolute;inset:0"></div><div class="tile-label">Playful</div></div>
+                  <div class="tile" data-theme-preset="dark"><div class="theme-dark" style="position:absolute;inset:0"></div><div class="tile-label">Dark</div></div>
+                  <div class="tile" data-theme-preset="sunset"><div class="theme-sunset" style="position:absolute;inset:0"></div><div class="tile-label">Sunset</div></div>
+                  <div class="tile" data-theme-preset="ocean"><div class="theme-ocean" style="position:absolute;inset:0"></div><div class="tile-label">Ocean</div></div>
+                  <div class="tile" data-theme-preset="nord"><div class="theme-nord" style="position:absolute;inset:0"></div><div class="tile-label">Nord</div></div>
+                </div>
+                <div class="fg-help" style="margin-top:10px; font-size:12px;">
+                  Browsing all <strong>1000+ themes</strong>? <a href="#" class="link-inline">Open theme library →</a>
+                </div>
+              </div>
+            </div>
+
+            <!-- PROFILE (renamed from Header) -->
+            <div class="design-panel" data-panel="profile">
+              <div class="field-group">
+                <label class="fg-label">Profile card layout</label>
+                <div class="fg-help">Choose how your avatar and name appear at the top of your page.</div>
+                <div class="tile-grid" style="grid-template-columns:repeat(3,1fr); gap:10px; margin-top:10px">
+                  <div class="tile selected" data-profile-layout="classic" onclick="document.querySelectorAll('[data-profile-layout]').forEach(t=>t.classList.remove('selected'));this.classList.add('selected');">
+                    <div style="position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:5px;padding:8px">
+                      <div style="width:28px;height:28px;border-radius:50%;background:var(--hero-gradient);flex-shrink:0"></div>
+                      <div style="width:44px;height:5px;border-radius:3px;background:var(--fg-muted);opacity:.5"></div>
+                      <div style="width:36px;height:4px;border-radius:3px;background:var(--fg-subtle);opacity:.4"></div>
+                    </div>
+                    <div class="tile-label">Classic Card</div>
+                  </div>
+                  <div class="tile" data-profile-layout="hero" onclick="document.querySelectorAll('[data-profile-layout]').forEach(t=>t.classList.remove('selected'));this.classList.add('selected');">
+                    <div style="position:absolute;inset:0;display:flex;flex-direction:column;align-items:flex-start;justify-content:flex-end;gap:4px;padding:8px;background:linear-gradient(160deg,rgba(99,102,241,.15),rgba(139,92,246,.1))">
+                      <div style="width:40px;height:40px;border-radius:8px;background:var(--hero-gradient);flex-shrink:0"></div>
+                      <div style="width:48px;height:5px;border-radius:3px;background:var(--fg-muted);opacity:.6"></div>
+                    </div>
+                    <div class="tile-label">Hero Cover</div>
+                  </div>
+                  <div class="tile" data-profile-layout="sidebar" onclick="document.querySelectorAll('[data-profile-layout]').forEach(t=>t.classList.remove('selected'));this.classList.add('selected');">
+                    <div style="position:absolute;inset:0;display:flex;flex-direction:row;align-items:center;gap:6px;padding:8px">
+                      <div style="width:24px;height:24px;border-radius:50%;background:var(--hero-gradient);flex-shrink:0"></div>
+                      <div style="display:flex;flex-direction:column;gap:4px;flex:1">
+                        <div style="width:100%;height:4px;border-radius:3px;background:var(--fg-muted);opacity:.5"></div>
+                        <div style="width:70%;height:3px;border-radius:3px;background:var(--fg-subtle);opacity:.4"></div>
+                      </div>
+                    </div>
+                    <div class="tile-label">Sidebar Compact</div>
+                  </div>
+                </div>
+              </div>
+
+              <div class="field-group" style="margin-top:16px">
+                <label class="fg-label">Title styling</label>
+                <div class="fg-help">Font, size, and color — in one row.</div>
+                <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-top:8px">
+                  <div class="segmented" style="flex-shrink:0">
+                    <button class="seg active">
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14"><polyline points="4 7 4 4 20 4 20 7"/><line x1="12" y1="4" x2="12" y2="20"/><line x1="9" y1="20" x2="15" y2="20"/></svg>
+                      Text
+                    </button>
+                    <button class="seg">
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="9" cy="10" r="2"/><path d="M21 15l-5-5L5 21"/></svg>
+                      Logo
+                    </button>
+                  </div>
+                  <div class="segmented" style="flex-shrink:0">
+                    <button class="seg">S</button>
+                    <button class="seg active">M</button>
+                    <button class="seg">L</button>
+                  </div>
+                  <div class="color-input" style="width:120px;flex-shrink:0">
+                    <input type="text" value="#111827" style="font-size:12px"/>
+                    <span class="swatch" style="background:#111827"></span>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <!-- BACKGROUND (renamed from Wallpaper; default active per ?subtab=background) -->
+            <div class="design-panel active" data-panel="background">
+              <div class="field-group">
+                <label class="fg-label">Background style</label>
+                <div class="fg-help">Pick the vibe behind your blocks. Image and Video live on Creator tier ($5/mo) — your page still works on Free without them.</div>
+                <div class="tile-grid">
+                  <div class="tile selected" data-wallpaper-kind="fill" onclick="selectWallpaper(this, 'fill')">
+                    <div class="wp-fill" style="position:absolute;inset:0"></div>
+                    <div class="tile-label">Fill</div>
+                  </div>
+                  <div class="tile" data-wallpaper-kind="gradient" onclick="selectWallpaper(this, 'gradient')">
+                    <div class="wp-gradient" style="position:absolute;inset:0"></div>
+                    <div class="tile-label">Gradient</div>
+                  </div>
+                  <div class="tile" data-wallpaper-kind="blur" onclick="selectWallpaper(this, 'blur')">
+                    <div class="wp-blur" style="position:absolute;inset:0"></div>
+                    <div class="tile-label">Blur</div>
+                  </div>
+                  <div class="tile" data-wallpaper-kind="pattern" onclick="selectWallpaper(this, 'pattern')">
+                    <div class="wp-pattern" style="position:absolute;inset:0"></div>
+                    <div class="tile-label">Pattern</div>
+                  </div>
+                  <div class="tile" data-wallpaper-kind="image" data-tip="Creator tier — $5/mo" onclick="selectWallpaper(this, 'image')">
+                    <div class="wp-image" style="position:absolute;inset:0"></div>
+                    <span class="pro-badge">💡 Creator</span>
+                    <div class="tile-label">Image</div>
+                  </div>
+                  <div class="tile" data-wallpaper-kind="video" data-tip="Creator tier — $5/mo" onclick="selectWallpaper(this, 'video')">
+                    <div class="wp-video" style="position:absolute;inset:0"></div>
+                    <span class="pro-badge">💡 Creator</span>
+                    <div class="tile-label">Video</div>
+                  </div>
+                </div>
+              </div>
+
+              <div class="field-group">
+                <label class="fg-label" for="bg-color">Background color</label>
+                <div class="color-input">
+                  <input id="bg-color" type="text" value="#6366F1" oninput="setBgColor(this.value)"/>
+                  <span class="swatch" id="bg-swatch" style="background:#6366F1"></span>
+                </div>
+              </div>
+            </div>
+
+            <!-- TEXT -->
+            <div class="design-panel" data-panel="text">
+              <div class="field-group">
+                <label class="fg-label">Page font</label>
+                <div class="font-list">
+                  <button class="font-tile" onclick="selectFont(this, 'system')"><span class="ft-preview" style="font-family:Inter,sans-serif">Aa — Ready when you are.</span><span class="ft-name">System sans</span></button>
+                  <button class="font-tile selected" onclick="selectFont(this, 'crimson')"><span class="ft-preview" style="font-family:'Crimson Pro',serif">Aa — Ready when you are.</span><span class="ft-name">Crimson Pro</span></button>
+                  <button class="font-tile" onclick="selectFont(this, 'fraunces')"><span class="ft-preview" style="font-family:'Fraunces',serif">Aa — Ready when you are.</span><span class="ft-name">Fraunces</span></button>
+                  <button class="font-tile" onclick="selectFont(this, 'playfair')"><span class="ft-preview" style="font-family:'Playfair Display',serif">Aa — Ready when you are.</span><span class="ft-name">Playfair</span></button>
+                  <button class="font-tile" onclick="selectFont(this, 'display')"><span class="ft-preview" style="font-family:Georgia,serif; font-weight:600">Aa — Ready when you are.</span><span class="ft-name">Display serif</span></button>
+                  <button class="font-tile" onclick="selectFont(this, 'mono')"><span class="ft-preview" style="font-family:'JetBrains Mono',monospace; font-size:17px">Aa — Ready when you are.</span><span class="ft-name">Mono</span></button>
+                </div>
+              </div>
+
+              <div class="field-group">
+                <label class="fg-label">Page text color</label>
+                <div class="color-input">
+                  <input type="text" value="#111827"/>
+                  <span class="swatch" style="background:#111827"></span>
+                </div>
+              </div>
+            </div>
+
+            <!-- BUTTONS -->
+            <div class="design-panel" data-panel="buttons">
+              <div class="field-group">
+                <label class="fg-label">Button style</label>
+                <div class="btn-style-grid">
+                  <button class="btn-style-tile selected" onclick="selectBtnStyle(this, 'fill')">
+                    <div class="bst-preview fill">Follow</div>
+                    <div class="bst-label">Fill</div>
+                  </button>
+                  <button class="btn-style-tile" onclick="selectBtnStyle(this, 'outline')">
+                    <div class="bst-preview outline">Follow</div>
+                    <div class="bst-label">Outline</div>
+                  </button>
+                  <button class="btn-style-tile" onclick="selectBtnStyle(this, 'soft')">
+                    <div class="bst-preview soft">Follow</div>
+                    <div class="bst-label">Soft</div>
+                  </button>
+                  <button class="btn-style-tile" onclick="selectBtnStyle(this, 'hard')">
+                    <div class="bst-preview hard">Follow</div>
+                    <div class="bst-label">Hard edge</div>
+                  </button>
+                  <button class="btn-style-tile" onclick="selectBtnStyle(this, 'round')">
+                    <div class="bst-preview round">Follow</div>
+                    <div class="bst-label">Round</div>
+                  </button>
+                  <button class="btn-style-tile" onclick="selectBtnStyle(this, 'shadow')">
+                    <div class="bst-preview shadow">Follow</div>
+                    <div class="bst-label">Shadow</div>
+                  </button>
+                </div>
+              </div>
+
+              <div class="field-group">
+                <label class="fg-label">Button color</label>
+                <div class="color-input">
+                  <input type="text" value="#FFFFFF"/>
+                  <span class="swatch" style="background:#FFFFFF; border:1px solid var(--border-strong)"></span>
+                </div>
+              </div>
+              <div class="field-group">
+                <label class="fg-label">Button text color</label>
+                <div class="color-input">
+                  <input type="text" value="#111827"/>
+                  <span class="swatch" style="background:#111827"></span>
+                </div>
+              </div>
+            </div>
+
+            <!-- ANIMATIONS — tadaify signature: two sections + accessibility footer -->
+            <div class="design-panel" data-panel="animations">
+              <div class="fg-help" style="font-size:13px; color:var(--fg-muted); margin-bottom:14px">
+                Motion is core to the <span style="font-family:var(--font-display); font-style:italic">tada!ify</span> brand — visitors should feel the reveal.
+                <button type="button" class="link-btn" onclick="replayAnimation()" style="margin-left:6px; background:transparent; border:0; color:var(--brand-primary); font-weight:600; cursor:pointer; padding:0;">↻ Replay preview</button>
+              </div>
+
+              <!-- SECTION 1: Entrance — runs once on page load -->
+              <section class="anim-section" style="margin-bottom:24px">
+                <div style="font-size:12px;font-weight:700;text-transform:uppercase;letter-spacing:0.07em;color:var(--fg-subtle);margin-bottom:12px;display:flex;align-items:center;gap:8px">
+                  <span>Entrance</span>
+                  <span style="font-size:11px;font-weight:500;text-transform:none;letter-spacing:0;color:var(--fg-muted);opacity:.7">— runs once on page load</span>
+                </div>
+
+                <div class="field-group">
+                  <label class="fg-label">Page entrance</label>
+                  <div class="fg-help">The first thing visitors see when the page loads.</div>
+                  <div class="tile-grid tile-grid-anim">
+                    <div class="tile anim-tile" data-anim-entrance="none" onclick="selectAnim(this, 'entrance', 'none')">
+                      <div class="anim-preview anim-none"></div>
+                      <div class="tile-label">None</div>
+                    </div>
+                    <div class="tile anim-tile selected" data-anim-entrance="tada" onclick="selectAnim(this, 'entrance', 'tada')">
+                      <div class="anim-preview anim-tada"><span class="anim-dot"></span></div>
+                      <div class="tile-label">Ta-da reveal <span class="pill-signature">signature</span></div>
+                    </div>
+                    <div class="tile anim-tile" data-anim-entrance="cascade" onclick="selectAnim(this, 'entrance', 'cascade')">
+                      <div class="anim-preview anim-cascade"><span></span><span></span><span></span></div>
+                      <div class="tile-label">Cascade</div>
+                    </div>
+                    <div class="tile anim-tile" data-anim-entrance="fade-up" onclick="selectAnim(this, 'entrance', 'fade-up')">
+                      <div class="anim-preview anim-fadeup"><span></span></div>
+                      <div class="tile-label">Fade up</div>
+                    </div>
+                    <div class="tile anim-tile" data-anim-entrance="spotlight" onclick="selectAnim(this, 'entrance', 'spotlight')">
+                      <div class="anim-preview anim-spotlight"><span class="anim-orb"></span></div>
+                      <div class="tile-label">Spotlight orbit</div>
+                    </div>
+                    <div class="tile anim-tile" data-anim-entrance="typewriter" onclick="selectAnim(this, 'entrance', 'typewriter')">
+                      <div class="anim-preview anim-typewriter"><span class="anim-caret">|</span></div>
+                      <div class="tile-label">Typewriter</div>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="field-group">
+                  <label class="fg-label">Block entrance</label>
+                  <div class="fg-help">How each block appears individually on first view.</div>
+                  <div class="seg-row" role="group">
+                    <button class="seg" data-anim-block="none" onclick="selectSeg(this, 'block', 'none')">None</button>
+                    <button class="seg active" data-anim-block="stagger" onclick="selectSeg(this, 'block', 'stagger')">Stagger cascade</button>
+                    <button class="seg" data-anim-block="pop" onclick="selectSeg(this, 'block', 'pop')">Pop-in</button>
+                    <button class="seg" data-anim-block="slide-up" onclick="selectSeg(this, 'block', 'slide-up')">Slide up</button>
+                  </div>
+                </div>
+
+                <div class="field-group">
+                  <label class="fg-label">Hover effect</label>
+                  <div class="fg-help">What happens when a visitor hovers (desktop) or taps (mobile) a block.</div>
+                  <div class="seg-row" role="group">
+                    <button class="seg" data-anim-hover="none" onclick="selectSeg(this, 'hover', 'none')">None</button>
+                    <button class="seg active" data-anim-hover="lift" onclick="selectSeg(this, 'hover', 'lift')">Lift</button>
+                    <button class="seg" data-anim-hover="glow" onclick="selectSeg(this, 'hover', 'glow')">Glow</button>
+                    <button class="seg" data-anim-hover="tilt" onclick="selectSeg(this, 'hover', 'tilt')">Tilt 3D</button>
+                  </div>
+                </div>
+              </section>
+
+              <!-- SECTION 2: Ambient — always-on motion overlay -->
+              <section class="anim-section" style="margin-bottom:24px">
+                <div style="font-size:12px;font-weight:700;text-transform:uppercase;letter-spacing:0.07em;color:var(--fg-subtle);margin-bottom:12px;display:flex;align-items:center;gap:8px">
+                  <span>Ambient</span>
+                  <span style="font-size:11px;font-weight:500;text-transform:none;letter-spacing:0;color:var(--fg-muted);opacity:.7">— always-on motion overlay</span>
+                </div>
+
+                <div class="field-group">
+                  <label class="fg-label">Effect</label>
+                  <div class="fg-help">A continuous particle or overlay effect on your page background. Respects reduced-motion OS setting.</div>
+                  <div class="tile-grid tile-grid-anim" style="grid-template-columns:repeat(5,1fr)">
+                    <div class="tile anim-tile selected" data-ambient="none" onclick="selectAmbient(this,'none')">
+                      <div class="anim-preview anim-none"></div>
+                      <div class="tile-label">None</div>
+                    </div>
+                    <div class="tile anim-tile" data-ambient="snow" onclick="selectAmbient(this,'snow')">
+                      <div class="anim-preview" style="display:flex;align-items:center;justify-content:center;font-size:18px">❄</div>
+                      <div class="tile-label">Snow</div>
+                    </div>
+                    <div class="tile anim-tile" data-ambient="confetti" onclick="selectAmbient(this,'confetti')">
+                      <div class="anim-preview" style="display:flex;align-items:center;justify-content:center;font-size:18px">🎊</div>
+                      <div class="tile-label">Confetti</div>
+                    </div>
+                    <div class="tile anim-tile" data-ambient="sparkles" onclick="selectAmbient(this,'sparkles')">
+                      <div class="anim-preview" style="display:flex;align-items:center;justify-content:center;font-size:18px">✨</div>
+                      <div class="tile-label">Sparkles</div>
+                    </div>
+                    <div class="tile anim-tile" data-ambient="bokeh" onclick="selectAmbient(this,'bokeh')">
+                      <div class="anim-preview" style="display:flex;align-items:center;justify-content:center;font-size:18px">🔵</div>
+                      <div class="tile-label">Bokeh</div>
+                    </div>
+                    <div class="tile anim-tile" data-ambient="aurora" onclick="selectAmbient(this,'aurora')">
+                      <div class="anim-preview" style="background:linear-gradient(135deg,rgba(99,102,241,.3),rgba(139,92,246,.3),rgba(16,185,129,.2));"></div>
+                      <div class="tile-label">Aurora</div>
+                    </div>
+                    <div class="tile anim-tile" data-ambient="hearts" onclick="selectAmbient(this,'hearts')">
+                      <div class="anim-preview" style="display:flex;align-items:center;justify-content:center;font-size:18px">💗</div>
+                      <div class="tile-label">Hearts</div>
+                    </div>
+                    <div class="tile anim-tile" data-ambient="stars" onclick="selectAmbient(this,'stars')">
+                      <div class="anim-preview" style="display:flex;align-items:center;justify-content:center;font-size:18px">⭐</div>
+                      <div class="tile-label">Stars</div>
+                    </div>
+                    <div class="tile anim-tile" data-ambient="bubbles" onclick="selectAmbient(this,'bubbles')">
+                      <div class="anim-preview" style="display:flex;align-items:center;justify-content:center;font-size:18px">🫧</div>
+                      <div class="tile-label">Bubbles</div>
+                    </div>
+                    <div class="tile anim-tile" data-ambient="petals" onclick="selectAmbient(this,'petals')">
+                      <div class="anim-preview" style="display:flex;align-items:center;justify-content:center;font-size:18px">🌸</div>
+                      <div class="tile-label">Petals</div>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="field-group" id="ambient-controls" style="display:none">
+                  <label class="fg-label">Density</label>
+                  <input type="range" min="1" max="10" value="5" style="width:100%;accent-color:var(--brand-primary)"/>
+
+                  <label class="fg-label" style="margin-top:12px">Speed</label>
+                  <input type="range" min="1" max="10" value="4" style="width:100%;accent-color:var(--brand-primary)"/>
+
+                  <label class="fg-label" style="margin-top:12px">Color</label>
+                  <div style="display:flex;gap:8px;align-items:center;margin-top:4px">
+                    <span class="seg active" style="padding:5px 10px;cursor:pointer;font-size:12px;border-radius:8px;border:1px solid var(--border-strong);background:var(--bg-elevated)">Match theme</span>
+                    <div class="color-input" style="width:120px">
+                      <input type="text" value="#6366F1" style="font-size:12px"/>
+                      <span class="swatch" style="background:#6366F1"></span>
+                    </div>
+                  </div>
+                </div>
+              </section>
+
+              <!-- SECTION 3: Accessibility footer -->
+              <section class="anim-section" style="border-top:1px solid var(--border);padding-top:16px">
+                <div style="font-size:12px;font-weight:700;text-transform:uppercase;letter-spacing:0.07em;color:var(--fg-subtle);margin-bottom:12px">Accessibility</div>
+                <label class="a11y-row">
+                  <input type="checkbox" id="reduced-motion-toggle" checked onchange="toggleReducedMotion(this)"/>
+                  <div>
+                    <div style="font-weight:600; color:var(--fg); font-size:14px">Respect reduced-motion</div>
+                    <div class="fg-help" style="margin-top:2px">
+                      Visitors with <code>prefers-reduced-motion: reduce</code> in their OS settings see a still version. Applies to both Entrance and Ambient. Keep this on unless you have a strong reason.
+                    </div>
+                  </div>
+                </label>
+              </section>
+            </div>
+
+            <!-- COLORS -->
+            <div class="design-panel" data-panel="colors">
+              <div class="fg-help" style="font-size:13px; color:var(--fg-muted); margin-bottom:4px">Three color tokens — primary actions, text, and background. Change once, everything follows.</div>
+
+              <div class="field-group">
+                <label class="fg-label">Primary (buttons · accents)</label>
+                <div class="color-input">
+                  <input type="text" value="#6366F1"/>
+                  <span class="swatch" style="background:#6366F1"></span>
+                </div>
+              </div>
+
+              <div class="field-group">
+                <label class="fg-label">Text</label>
+                <div class="color-input">
+                  <input type="text" value="#111827"/>
+                  <span class="swatch" style="background:#111827"></span>
+                </div>
+              </div>
+
+              <div class="field-group">
+                <label class="fg-label">Background</label>
+                <div class="color-input">
+                  <input type="text" value="#FFFFFF"/>
+                  <span class="swatch" style="background:#FFFFFF; border:1px solid var(--border-strong)"></span>
+                </div>
+              </div>
+            </div>
+
+            <!-- FOOTER — no "Powered by tadaify" toggle (AP-001) -->
+            <div class="design-panel" data-panel="footer">
+              <div class="field-group">
+                <label class="fg-label">Footer content</label>
+                <div class="fg-help">Your footer is yours. tadaify doesn't stick a "Powered by" line on your page — your creator brand stays yours, even on Free.</div>
+
+                <div style="display:flex; flex-direction:column; gap:10px; margin-top:6px">
+                  <label class="footer-option">
+                    <span class="fo-radio"></span>
+                    <div class="fo-body">
+                      <div class="fo-title">Empty footer</div>
+                      <div class="fo-sub">Nothing below your last block — the cleanest look.</div>
+                    </div>
+                  </label>
+
+                  <label class="footer-option selected">
+                    <span class="fo-radio"></span>
+                    <div class="fo-body">
+                      <div class="fo-title">Custom text</div>
+                      <div class="fo-sub">A line in your own voice — copyright, tagline, contact hint, anything.</div>
+                      <textarea>© 2026 Alexandra Silva · hello@alexandra.co</textarea>
+                    </div>
+                  </label>
+
+                  <label class="footer-option">
+                    <span class="fo-radio"></span>
+                    <div class="fo-body">
+                      <div class="fo-title">Social handles</div>
+                      <div class="fo-sub">Repeat your @ handles in the footer so people can find you across platforms.</div>
+                    </div>
+                  </label>
+                </div>
+
+                <div class="footer-tadaify-note">
+                  <strong>Your footer, your call.</strong>
+                  tadaify never inserts a "Powered by" line on your page. Your footer is entirely yours on every tier — Free included.
+                </div>
+              </div>
+
+              <!-- Optional support badge — strictly opt-IN, default OFF -->
+              <div class="field-group support-badge-group">
+                <label class="fg-label">Help tadaify grow (optional)</label>
+                <div class="fg-help">
+                  We're a young, indie team. We <strong>never</strong> force our brand on your page —
+                  but if you'd like to help others discover us, you can add a small,
+                  understated <span class="wm-mini"><span class="ta">ta</span><span class="da">da!</span><span class="ify">ify</span></span> mark below your footer.
+                </div>
+
+                <label class="support-row">
+                  <span class="support-toggle">
+                    <input type="checkbox" id="support-badge-toggle" onchange="toggleSupportBadge(this)"/>
+                    <span class="support-toggle-track"><span class="support-toggle-thumb"></span></span>
+                  </span>
+                  <div class="support-row-body">
+                    <div class="support-row-title">
+                      Show <em>made with</em> <span class="wm-mini"><span class="ta">ta</span><span class="da">da!</span><span class="ify">ify</span></span> badge
+                      <span class="opt-in-pill">Opt-in · Off by default</span>
+                    </div>
+                    <div class="support-row-sub">
+                      Adds a tiny line under your last block: <em>made with <span class="wm-mini"><span class="ta">ta</span><span class="da">da!</span><span class="ify">ify</span></span></em> linking to <code>tadaify.com</code>. Your visitors who like your page can discover us — and you help an indie team grow. No discount, no incentive needed; just a thank-you option.
+                    </div>
+                  </div>
+                </label>
+
+                <div class="support-preview" aria-live="polite">
+                  <span class="support-preview-label">Preview</span>
+                  <div class="support-preview-frame">
+                    <div class="support-preview-block">your last block</div>
+                    <div class="support-preview-badge" id="support-preview-badge" hidden>
+                      made with <span class="wm-mini"><span class="ta">ta</span><span class="da">da!</span><span class="ify">ify</span></span>
+                    </div>
+                  </div>
+                </div>
+
+                <p class="support-fineprint">
+                  Free to remove anytime · Never affects your plan · We don't track who turns this on
+                </p>
+              </div>
+            </div>
+
+          </div><!-- /.design-content -->
+        </div><!-- /.design-wrap -->
+      </section>
+
+      <!-- Pages placeholder (DEC-MULTIPAGE-01 — post-MVP Q+1) -->
+      <section class="main-placeholder" data-for="pages">
+        <div class="page-head">
+          <div>
+            <h1>Pages</h1>
+            <div class="sub">Multiple pages per account — privacy, about, portfolio, workshop landings.</div>
+          </div>
+        </div>
+        <div class="placeholder-panel">
+          <div class="ph-ic">🗂</div>
+          <h3>Multi-page is coming Q+1</h3>
+          <p>
+            Today every account has one page — yours is at
+            <strong>tadaify.com/&lt;handle&gt;</strong>.
+            We'll let you add more (privacy, about, portfolio, workshop landings)
+            without an upgrade for Free creators (1 included), and the tier limits
+            scale up to 20 on Pro and unlimited on Business.
+          </p>
+          <p style="margin-top:10px;font-size:12px;color:var(--fg-muted)">
+            DEC-MULTIPAGE-01 · Free 1 / Creator 5 / Pro 20 / Business unlimited
+          </p>
+        </div>
+      </section>
+
+      <!-- Placeholder tabs -->
+      <section class="main-placeholder" data-for="insights">
+        <div class="page-head">
+          <div>
+            <h1>Insights</h1>
+            <div class="sub">Views, clicks, drop-off — everything your blocks did this week.</div>
+          </div>
+        </div>
+        <div class="placeholder-panel">
+          <div class="ph-ic">📊</div>
+          <h3>Coming in next mockup iteration</h3>
+          <p>Traffic graph, per-block click-through, device + country breakdown, weekly email digest.</p>
+        </div>
+      </section>
+
+      <section class="main-placeholder" data-for="shop">
+        <div class="page-head">
+          <div>
+            <h1>Shop</h1>
+            <div class="sub">Sell a product, a PDF, a 1:1 call — Stripe-native, no add-on apps.</div>
+          </div>
+        </div>
+        <div class="placeholder-panel">
+          <div class="ph-ic">🛍</div>
+          <h3>Coming in next mockup iteration</h3>
+          <p>Product list, Stripe connection status, fulfilment settings, order log.</p>
+        </div>
+      </section>
+
+      <section class="main-placeholder" data-for="settings">
+        <div class="page-head">
+          <div>
+            <h1>Settings</h1>
+            <div class="sub">Account, handle, billing, integrations, GDPR tools.</div>
+          </div>
+        </div>
+        <div class="placeholder-panel">
+          <div class="ph-ic">⚙</div>
+          <h3>Coming in next mockup iteration</h3>
+          <p>Handle, email, password, Stripe Connect, integrations, data export, delete account.</p>
+        </div>
+      </section>
+
+    </main>
+
+    <!-- -------- RIGHT PREVIEW -------- -->
+    <aside class="preview" aria-label="Live preview">
+      <div class="preview-head">
+        <h3>Live preview</h3>
+        <button class="refresh" data-tip="Reload preview">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><path d="M20.5 15a9 9 0 1 1-2.1-9.4L23 10"/></svg>
+          Refresh
+        </button>
+      </div>
+
+      <div class="device-toggle">
+        <div class="segmented narrow" role="radiogroup" aria-label="Preview device">
+          <button class="seg active" data-device="mobile" onclick="setDevice('mobile')">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="5" y="2" width="14" height="20" rx="2"/><line x1="12" y1="18" x2="12" y2="18.01"/></svg>
+            Mobile
+          </button>
+          <button class="seg" data-device="tablet" onclick="setDevice('tablet')">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="12" y1="18" x2="12" y2="18.01"/></svg>
+            Tablet
+          </button>
+          <button class="seg" data-device="desktop" onclick="setDevice('desktop')">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="4" width="20" height="13" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
+            Desktop
+          </button>
+        </div>
+      </div>
+
+      <div class="preview-stage">
+        <div class="preview-frame is-mobile" id="preview-frame">
+          <div class="pv-notch"></div>
+          <div class="pv-chrome" style="display:none">
+            <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+            <span class="url">tadaify.com/alexandra</span>
+          </div>
+          <div class="pv-inner" id="pv-inner" data-wallpaper="fill" data-theme="" data-btn="fill" style="--pv-bg-color:#EEF2FF">
+            <div class="pv-body" id="pv-body">
+              <div class="pv-avatar" id="pv-av">A</div>
+              <div class="pv-name" id="pv-name">Alexandra Silva</div>
+              <div class="pv-bio" id="pv-bio">Creator + educator 🪄</div>
+              <div class="pv-handle">tadaify.com/alexandra</div>
+              <div class="pv-socials">
+                <span class="social-ig"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.2c3.2 0 3.6 0 4.8.1 1.2.1 1.9.2 2.3.4.6.2 1 .5 1.5 1s.8.9 1 1.5c.2.4.3 1.1.4 2.3.1 1.3.1 1.6.1 4.8s0 3.6-.1 4.8c-.1 1.2-.2 1.9-.4 2.3-.2.6-.5 1-1 1.5s-.9.8-1.5 1c-.4.2-1.1.3-2.3.4-1.3.1-1.6.1-4.8.1s-3.6 0-4.8-.1c-1.2-.1-1.9-.2-2.3-.4-.6-.2-1-.5-1.5-1s-.8-.9-1-1.5c-.2-.4-.3-1.1-.4-2.3C2.2 15.6 2.2 15.3 2.2 12s0-3.6.1-4.8c.1-1.2.2-1.9.4-2.3.2-.6.5-1 1-1.5s.9-.8 1.5-1c.4-.2 1.1-.3 2.3-.4 1.2-.1 1.6-.1 4.8-.1zm0 3.1a6.7 6.7 0 1 0 0 13.4 6.7 6.7 0 0 0 0-13.4zm0 11a4.4 4.4 0 1 1 0-8.8 4.4 4.4 0 0 1 0 8.8z"/></svg></span>
+                <span class="social-tt"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M19.3 6.7a5 5 0 0 1-3.6-3.1V2h-3.4v13.6a2.4 2.4 0 1 1-2.4-2.4V9.8a6 6 0 1 0 5.2 5.9V8.3a8.3 8.3 0 0 0 4.8 1.5V6.4c-.4 0-.8 0-1.2-.1z"/></svg></span>
+                <span class="social-yt"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 0 0-2.1-2.1C19.6 3.6 12 3.6 12 3.6s-7.6 0-9.4.5A3 3 0 0 0 .5 6.2 31.5 31.5 0 0 0 0 12a31.5 31.5 0 0 0 .5 5.8 3 3 0 0 0 2.1 2.1c1.8.5 9.4.5 9.4.5s7.6 0 9.4-.5a3 3 0 0 0 2.1-2.1A31.5 31.5 0 0 0 24 12a31.5 31.5 0 0 0-.5-5.8zM9.6 15.6V8.4l6.3 3.6-6.3 3.6z"/></svg></span>
+              </div>
+              <div class="pv-blocks" id="pv-blocks">
+                <div class="pv-block" data-block="ig"><span class="pvb-ic social-ig"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 5.3a6.7 6.7 0 1 0 0 13.4 6.7 6.7 0 0 0 0-13.4zm0 11a4.4 4.4 0 1 1 0-8.8 4.4 4.4 0 0 1 0 8.8z"/></svg></span>Instagram</div>
+                <div class="pv-block" data-block="tt"><span class="pvb-ic social-tt"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M19.3 6.7a5 5 0 0 1-3.6-3.1V2h-3.4v13.6a2.4 2.4 0 1 1-2.4-2.4V9.8a6 6 0 1 0 5.2 5.9V8.3a8.3 8.3 0 0 0 4.8 1.5V6.4c-.4 0-.8 0-1.2-.1z"/></svg></span>TikTok</div>
+                <div class="pv-block" data-block="yt"><span class="pvb-ic social-yt"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 0 0-2.1-2.1C19.6 3.6 12 3.6 12 3.6s-7.6 0-9.4.5A3 3 0 0 0 .5 6.2 31.5 31.5 0 0 0 0 12a31.5 31.5 0 0 0 .5 5.8 3 3 0 0 0 2.1 2.1c1.8.5 9.4.5 9.4.5s7.6 0 9.4-.5a3 3 0 0 0 2.1-2.1A31.5 31.5 0 0 0 24 12a31.5 31.5 0 0 0-.5-5.8zM9.6 15.6V8.4l6.3 3.6-6.3 3.6z"/></svg></span>YouTube</div>
+              </div>
+              <div class="pv-footer">© 2026 Alexandra Silva</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div style="display:flex; justify-content:center; gap:8px; margin-top:6px">
+        <button class="btn btn-ghost btn-sm" onclick="window.open('./creator-public.html', '_blank')">
+          Open in new tab
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17l10-10M17 7H9M17 7v8"/></svg>
+        </button>
+      </div>
+    </aside>
+
+  </div><!-- /.layout -->
+
+  <!-- ============ Add-block modal ============ -->
+  <div class="add-modal-backdrop" id="add-modal-backdrop" role="dialog" aria-modal="true" aria-label="Add a block" onclick="handleBackdropClick(event)">
+    <div class="add-modal" id="add-modal">
+
+      <!-- Header -->
+      <div class="add-modal-header">
+        <h2>Add a block</h2>
+        <button class="add-modal-close" id="add-modal-close" aria-label="Close">✕</button>
+      </div>
+
+      <!-- Search -->
+      <div class="add-modal-search-wrap">
+        <div class="add-modal-search">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+          <input type="text" id="add-modal-search-input" placeholder="Paste a URL or search…" autocomplete="off" spellcheck="false">
+        </div>
+      </div>
+
+      <!-- Detected URL chip -->
+      <div class="add-modal-detected" id="add-modal-detected">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        <span id="add-modal-detected-text">Detected: Instagram · Click to add</span>
+      </div>
+
+      <!-- Two-column body -->
+      <div class="add-modal-body">
+
+        <!-- Left rail — categories -->
+        <nav class="add-modal-rail" id="add-modal-rail">
+          <!-- rendered by JS -->
+        </nav>
+
+        <!-- Right area -->
+        <div class="add-modal-right">
+          <div class="add-modal-cat-title" id="add-modal-cat-title">Suggested</div>
+
+          <!-- Featured tiles -->
+          <div class="add-modal-featured" id="add-modal-featured">
+            <!-- rendered by JS -->
+          </div>
+
+          <!-- Integration list -->
+          <div class="add-modal-list" id="add-modal-list">
+            <!-- rendered by JS -->
+          </div>
+
+          <!-- Empty state -->
+          <div class="add-modal-empty" id="add-modal-empty">
+            <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+            <p>No integrations match your search.</p>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+  <!-- Pro/Creator gating inline confirm (AP-028) -->
+  <div class="am-gating-confirm" id="am-gating-confirm">
+    <strong id="am-gc-title">💡 Creator tier feature</strong>
+    <span id="am-gc-body">This is a Creator tier feature ($5/mo). Add it as a placeholder block for now?</span>
+    <div class="am-gc-btns">
+      <button class="am-gc-cancel" onclick="closeGatingConfirm()">Cancel</button>
+      <button class="am-gc-ok" id="am-gc-ok">Add placeholder</button>
+    </div>
+  </div>
+
+  <!-- ============ Mobile bottom tabs ============ -->
+  <nav class="mobile-tabs" aria-label="Mobile navigation">
+    <button class="mt-btn active" data-nav="page">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg>
+      Home
+    </button>
+    <button class="mt-btn" data-nav="design">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><circle cx="13.5" cy="6.5" r=".5" fill="currentColor"/><circle cx="17.5" cy="10.5" r=".5" fill="currentColor"/><circle cx="8.5" cy="7.5" r=".5" fill="currentColor"/></svg>
+      Design
+    </button>
+    <button class="mt-btn" data-nav="insights">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><path d="M7 14l4-4 4 4 5-7"/></svg>
+      Stats
+    </button>
+    <button class="mt-btn" data-nav="shop">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="21" r="1"/><circle cx="20" cy="21" r="1"/><path d="M1 1h4l2.7 13.4a2 2 0 0 0 2 1.6h9.7a2 2 0 0 0 2-1.6L23 6H6"/></svg>
+      Shop
+    </button>
+    <button class="mt-btn" data-nav="settings">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1a1.7 1.7 0 0 0-1-1.5 1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1a1.7 1.7 0 0 0 1.5-1 1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8"/></svg>
+      Settings
+    </button>
+  </nav>
+
+  <!-- ============ Mobile preview FAB + drawer ============ -->
+  <button class="mobile-preview-fab" onclick="document.getElementById('mobile-preview-overlay').classList.add('open')">
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="5" y="2" width="14" height="20" rx="2"/></svg>
+    Preview
+  </button>
+  <div class="mobile-preview-overlay" id="mobile-preview-overlay" onclick="if(event.target===this) this.classList.remove('open')">
+    <button class="mpo-close" aria-label="Close preview" onclick="document.getElementById('mobile-preview-overlay').classList.remove('open')">✕</button>
+    <div class="mpo-hint">Live preview — tap outside to close</div>
+    <div class="preview-frame is-mobile">
+      <div class="pv-notch"></div>
+      <div class="pv-inner" data-wallpaper="fill" data-btn="fill" style="--pv-bg-color:#EEF2FF">
+        <div class="pv-body">
+          <div class="pv-avatar">A</div>
+          <div class="pv-name">Alexandra Silva</div>
+          <div class="pv-bio">Creator + educator 🪄</div>
+          <div class="pv-handle">tadaify.com/alexandra</div>
+          <div class="pv-blocks">
+            <div class="pv-block"><span class="pvb-ic social-ig" style="font-size:9px">IG</span>Instagram</div>
+            <div class="pv-block"><span class="pvb-ic social-tt" style="font-size:9px">TT</span>TikTok</div>
+            <div class="pv-block"><span class="pvb-ic social-yt" style="font-size:9px">YT</span>YouTube</div>
+          </div>
+          <div class="pv-footer">© 2026 Alexandra Silva</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script src="./shared/partials.js"></script>
+  <script src="./shared/tokens.js"></script>
+  <script>
+    // =================================================================
+    // URL state
+    // =================================================================
+    const params = new URLSearchParams(window.location.search);
+    const handle = params.get('handle') || 'alexandra';
+    // ?tab=pages legacy redirect → page (Homepage)
+    const rawTab = params.get('tab') || 'page';
+    const initialTab = rawTab === 'pages' ? 'page' : rawTab;
+    const initialSubtab = params.get('subtab') || 'background';
+    const initialDevice = params.get('device') || 'mobile';
+    const initialState = params.get('state') || 'ready';
+
+    document.body.dataset.state = initialState;
+    document.getElementById('handle-text').textContent = handle;
+
+    // =================================================================
+    // Top-level nav
+    // =================================================================
+    const layoutEl = document.querySelector('.layout');
+    function setTab(tab) {
+      layoutEl.dataset.tab = tab;
+      document.querySelectorAll('.nav-item[data-nav]').forEach(b => {
+        b.classList.toggle('active', b.dataset.nav === tab);
+      });
+      document.querySelectorAll('.mt-btn[data-nav]').forEach(b => {
+        b.classList.toggle('active', b.dataset.nav === tab);
+      });
+      syncUrl();
+    }
+    document.querySelectorAll('[data-nav]').forEach(btn => {
+      if (btn.getAttribute('aria-disabled') === 'true') return; // skip disabled items
+      btn.addEventListener('click', () => setTab(btn.dataset.nav));
+    });
+
+    // Add-page disabled button — show tooltip flash
+    function showAddPageToast(e) {
+      const existing = document.getElementById('add-page-toast');
+      if (existing) return;
+      const toast = document.createElement('div');
+      toast.id = 'add-page-toast';
+      toast.textContent = 'Multi-page coming Q+1';
+      Object.assign(toast.style, {
+        position: 'fixed', left: (e.clientX + 12) + 'px', top: (e.clientY - 8) + 'px',
+        background: 'var(--fg)', color: 'var(--bg)', fontSize: '12px', fontWeight: '600',
+        padding: '5px 10px', borderRadius: '6px', zIndex: '9999',
+        pointerEvents: 'none', whiteSpace: 'nowrap', boxShadow: '0 2px 8px rgba(0,0,0,.18)'
+      });
+      document.body.appendChild(toast);
+      setTimeout(() => toast.remove(), 1500);
+    }
+
+    // =================================================================
+    // V2: Design sub-nav (sidebar accordion + breadcrumb stepper)
+    //
+    // Single source of truth for "current sub-section" remains the same
+    // mechanism as v1 (active class on .design-panel). What changes:
+    //   - .sub-item (legacy secondary rail) is hidden via CSS but still
+    //     gets state synced for diff parity.
+    //   - .nav-sub-item (sidebar accordion children) drives navigation.
+    //   - .design-stepper (top of .design-content) shows prev/curr/next
+    //     window + dropdown for full picker.
+    // =================================================================
+    const SUBTAB_ORDER = ['theme', 'profile', 'background', 'text', 'buttons', 'animations', 'colors', 'footer'];
+    const SUBTAB_LABELS = {
+      theme: 'Theme', profile: 'Profile', background: 'Background', text: 'Text',
+      buttons: 'Buttons', animations: 'Animations', colors: 'Colors', footer: 'Footer'
+    };
+
+    function setSubnav(sub) {
+      // Legacy secondary-rail state (hidden but kept in sync)
+      document.querySelectorAll('.sub-item').forEach(b => {
+        b.classList.toggle('active', b.dataset.subnav === sub);
+      });
+      // Active panel
+      document.querySelectorAll('.design-panel').forEach(p => {
+        p.classList.toggle('active', p.dataset.panel === sub);
+      });
+      // V2: sidebar accordion sub-items
+      document.querySelectorAll('.nav-sub-item').forEach(b => {
+        b.classList.toggle('active', b.dataset.navSub === sub);
+      });
+      // V2: ensure accordion is expanded so active sub-item is visible
+      setDesignAccordion(true);
+      // V2: refresh stepper window
+      renderStepper(sub);
+      syncUrl();
+    }
+    document.querySelectorAll('.sub-item').forEach(btn => {
+      btn.addEventListener('click', () => setSubnav(btn.dataset.subnav));
+    });
+    document.querySelectorAll('.nav-sub-item').forEach(btn => {
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        setTab('design');
+        setSubnav(btn.dataset.navSub);
+      });
+    });
+
+    // -----------------------------------------------------------------
+    // V2: Sidebar accordion expand/collapse for Design parent
+    // -----------------------------------------------------------------
+    function setDesignAccordion(expanded) {
+      const parent = document.querySelector('.nav-design-parent');
+      const list = document.getElementById('nav-design-sub');
+      if (!parent || !list) return;
+      parent.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+      list.dataset.expanded = expanded ? 'true' : 'false';
+    }
+    (function wireDesignParentClick() {
+      const parent = document.querySelector('.nav-design-parent');
+      if (!parent) return;
+      // Override default data-nav handler — toggle accordion + jump into Design tab
+      parent.addEventListener('click', (e) => {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        const currentlyExpanded = parent.getAttribute('aria-expanded') === 'true';
+        const onDesignTab = layoutEl.dataset.tab === 'design';
+        if (!onDesignTab) {
+          // First click: enter Design tab + expand
+          setTab('design');
+          setDesignAccordion(true);
+          // Default to current subtab from URL (already applied via initialSubtab)
+        } else {
+          // Already on Design tab — toggle accordion
+          setDesignAccordion(!currentlyExpanded);
+        }
+      }, true /* capture, so we beat the generic data-nav handler */);
+    })();
+
+    // -----------------------------------------------------------------
+    // V2: Breadcrumb stepper — prev / current / next + full dropdown
+    // -----------------------------------------------------------------
+    function renderStepper(sub) {
+      const i = SUBTAB_ORDER.indexOf(sub);
+      if (i < 0) return;
+      const prev = i > 0 ? SUBTAB_ORDER[i - 1] : null;
+      const next = i < SUBTAB_ORDER.length - 1 ? SUBTAB_ORDER[i + 1] : null;
+      const stepper = document.getElementById('design-stepper');
+      if (!stepper) return;
+
+      const prevBtn = stepper.querySelector('[data-stepper="prev"]');
+      const nextBtn = stepper.querySelector('[data-stepper="next"]');
+      const currLbl = stepper.querySelector('[data-stepper-current-label]');
+      const prevLbl = stepper.querySelector('[data-stepper-prev-label]');
+      const nextLbl = stepper.querySelector('[data-stepper-next-label]');
+
+      currLbl.textContent = SUBTAB_LABELS[sub];
+      prevLbl.textContent = prev ? SUBTAB_LABELS[prev] : '—';
+      nextLbl.textContent = next ? SUBTAB_LABELS[next] : '—';
+      prevBtn.disabled = !prev;
+      nextBtn.disabled = !next;
+      prevBtn.dataset.target = prev || '';
+      nextBtn.dataset.target = next || '';
+
+      // Render dropdown items (rebuild on every change to stay in sync)
+      const dd = document.getElementById('stepper-dropdown');
+      if (dd) {
+        dd.innerHTML = SUBTAB_ORDER.map(key => `
+          <button class="stepper-dropdown-item${key === sub ? ' is-current' : ''}" data-stepper-pick="${key}" role="option" aria-selected="${key === sub}">
+            <span class="radio-dot" aria-hidden="true"></span>
+            <span>${SUBTAB_LABELS[key]}</span>
+          </button>
+        `).join('');
+        dd.querySelectorAll('[data-stepper-pick]').forEach(item => {
+          item.addEventListener('click', () => {
+            setSubnav(item.dataset.stepperPick);
+            closeStepperDropdown();
+          });
+        });
+      }
+    }
+
+    function openStepperDropdown() {
+      const dd = document.getElementById('stepper-dropdown');
+      const cur = document.querySelector('.stepper-cell.is-current');
+      if (!dd || !cur) return;
+      dd.dataset.open = 'true';
+      cur.setAttribute('aria-expanded', 'true');
+      // close on outside click
+      setTimeout(() => {
+        document.addEventListener('click', function handler(e) {
+          if (!dd.contains(e.target) && !cur.contains(e.target)) {
+            closeStepperDropdown();
+            document.removeEventListener('click', handler);
+          }
+        });
+      }, 0);
+    }
+    function closeStepperDropdown() {
+      const dd = document.getElementById('stepper-dropdown');
+      const cur = document.querySelector('.stepper-cell.is-current');
+      if (!dd) return;
+      dd.dataset.open = 'false';
+      if (cur) cur.setAttribute('aria-expanded', 'false');
+    }
+
+    (function wireStepper() {
+      const stepper = document.getElementById('design-stepper');
+      if (!stepper) return;
+      stepper.querySelector('[data-stepper="prev"]').addEventListener('click', (e) => {
+        const target = e.currentTarget.dataset.target;
+        if (target) setSubnav(target);
+      });
+      stepper.querySelector('[data-stepper="next"]').addEventListener('click', (e) => {
+        const target = e.currentTarget.dataset.target;
+        if (target) setSubnav(target);
+      });
+      stepper.querySelector('[data-stepper="current"]').addEventListener('click', (e) => {
+        e.stopPropagation();
+        const dd = document.getElementById('stepper-dropdown');
+        if (dd && dd.dataset.open === 'true') {
+          closeStepperDropdown();
+        } else {
+          openStepperDropdown();
+        }
+      });
+      // Keyboard: ← / → navigates when stepper area focused
+      stepper.addEventListener('keydown', (e) => {
+        if (e.key === 'ArrowLeft') {
+          const t = stepper.querySelector('[data-stepper="prev"]').dataset.target;
+          if (t) { e.preventDefault(); setSubnav(t); }
+        } else if (e.key === 'ArrowRight') {
+          const t = stepper.querySelector('[data-stepper="next"]').dataset.target;
+          if (t) { e.preventDefault(); setSubnav(t); }
+        } else if (e.key === 'Escape') {
+          closeStepperDropdown();
+        }
+      });
+    })();
+
+    // =================================================================
+    // Device toggle
+    // =================================================================
+    function setDevice(d) {
+      const frame = document.getElementById('preview-frame');
+      frame.classList.remove('is-mobile', 'is-tablet', 'is-desktop');
+      frame.classList.add('is-' + d);
+      document.querySelectorAll('[data-device]').forEach(b => {
+        b.classList.toggle('active', b.dataset.device === d);
+      });
+      const notch = frame.querySelector('.pv-notch');
+      const chrome = frame.querySelector('.pv-chrome');
+      if (notch) notch.style.display = (d === 'mobile') ? 'block' : 'none';
+      if (chrome) chrome.style.display = (d === 'desktop') ? 'flex' : 'none';
+      syncUrl();
+    }
+
+    // =================================================================
+    // URL sync
+    // =================================================================
+    function syncUrl() {
+      const p = new URLSearchParams();
+      p.set('handle', handle);
+      const tab = layoutEl.dataset.tab;
+      if (tab !== 'page') p.set('tab', tab);
+      if (tab === 'design') {
+        const active = document.querySelector('.sub-item.active');
+        if (active && active.dataset.subnav !== 'background') p.set('subtab', active.dataset.subnav);
+      }
+      const activeDev = document.querySelector('[data-device].active');
+      if (activeDev && activeDev.dataset.device !== 'mobile') p.set('device', activeDev.dataset.device);
+      if (document.body.dataset.state === 'empty') p.set('state', 'empty');
+      const qs = p.toString();
+      history.replaceState(null, '', window.location.pathname + (qs ? '?' + qs : ''));
+    }
+
+    // =================================================================
+    // Profile card inline edit
+    // =================================================================
+    function toggleProfileEdit() {
+      document.getElementById('profile-card').classList.toggle('is-editing');
+    }
+    function saveProfileEdit() {
+      const name = document.getElementById('pe-name').value;
+      const bio  = document.getElementById('pe-bio').value;
+      document.getElementById('pc-name').textContent = name;
+      document.getElementById('pc-bio').textContent = bio;
+      document.getElementById('pv-name').textContent = name;
+      document.getElementById('pv-bio').textContent = bio;
+      toggleProfileEdit();
+    }
+    function updateBioCounter(el) {
+      document.getElementById('pe-counter').textContent = el.value.length + ' / 80';
+    }
+    function livePreviewName(val) {
+      document.getElementById('pv-name').textContent = val;
+    }
+
+    // =================================================================
+    // Block toggles
+    // =================================================================
+    function toggleBlock(el, key) {
+      el.classList.toggle('on');
+      const row = el.closest('.block');
+      row.classList.toggle('is-off', !el.classList.contains('on'));
+      const pvBlock = document.querySelector('#pv-blocks [data-block="' + key + '"]');
+      if (pvBlock) pvBlock.style.display = el.classList.contains('on') ? '' : 'none';
+    }
+// =================================================================
+    // Add block panel — delegates to openAddBlockModal() (defined below)
+    // =================================================================
+    function openAddPanel(preCategory) { openAddBlockModal(preCategory); }
+    function closeAddPanel() { closeAddBlockModal(); }
+    function addBlock(kind) { openAddBlockModal(); }
+    // =================================================================
+    // Quick chips
+    // =================================================================
+    function toggleArchive() {
+      document.getElementById('archive-list').classList.toggle('open');
+    }
+    function toggleCollectionInline() {
+      const el = document.getElementById('collection-inline');
+      el.classList.toggle('open');
+      if (el.classList.contains('open')) el.querySelector('input').focus();
+    }
+
+    // Organise… dropdown
+    function toggleOrganise() {
+      const menu = document.getElementById('organise-menu');
+      if (!menu) return;
+      const isOpen = menu.style.display !== 'none';
+      menu.style.display = isOpen ? 'none' : 'block';
+      if (!isOpen) {
+        // close on outside click
+        setTimeout(() => {
+          document.addEventListener('click', function handler(e) {
+            if (!document.getElementById('organise-wrap').contains(e.target)) {
+              menu.style.display = 'none';
+              document.removeEventListener('click', handler);
+            }
+          });
+        }, 0);
+      }
+    }
+
+    // Pinned message toggle
+    function togglePinnedMsg(toggleEl) {
+      toggleEl.classList.toggle('on');
+      const inputWrap = document.getElementById('pinned-input-wrap');
+      if (inputWrap) inputWrap.style.opacity = toggleEl.classList.contains('on') ? '1' : '0.4';
+    }
+
+    // Ambient effect selection
+    function selectAmbient(tile, kind) {
+      document.querySelectorAll('[data-ambient]').forEach(t => t.classList.remove('selected'));
+      tile.classList.add('selected');
+      const controls = document.getElementById('ambient-controls');
+      if (controls) controls.style.display = kind !== 'none' ? 'block' : 'none';
+    }
+
+    // =================================================================
+    // Copy link
+    // =================================================================
+    function copyLink(ev) {
+      const url = 'https://tadaify.com/' + handle;
+      if (navigator.clipboard) navigator.clipboard.writeText(url);
+      const btn = ev.currentTarget;
+      const prev = btn.innerHTML;
+      btn.innerHTML = '✓ Copied';
+      setTimeout(() => btn.innerHTML = prev, 1400);
+    }
+
+    // =================================================================
+    // Design → preview wiring
+    // =================================================================
+    const pvInner = document.getElementById('pv-inner');
+
+    function selectWallpaper(tile, kind) {
+      document.querySelectorAll('[data-wallpaper-kind]').forEach(t => t.classList.remove('selected'));
+      tile.classList.add('selected');
+      pvInner.dataset.wallpaper = kind;
+      // AP-028: pro-gated features = inline visual badge only, no blocking modal
+    }
+    function setBgColor(hex) {
+      pvInner.style.setProperty('--pv-bg-color', hex);
+      const sw = document.getElementById('bg-swatch');
+      if (sw) sw.style.background = hex;
+    }
+    function setHeaderLayout(btn, layout) {
+      document.querySelectorAll('[data-header-layout]').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      document.getElementById('pv-av').classList.toggle('hero', layout === 'hero');
+    }
+    function selectFont(tile, font) {
+      document.querySelectorAll('.font-tile').forEach(t => t.classList.remove('selected'));
+      tile.classList.add('selected');
+      const map = {
+        system: 'Inter, sans-serif',
+        crimson: '"Crimson Pro", serif',
+        fraunces: '"Fraunces", serif',
+        playfair: '"Playfair Display", serif',
+        display: 'Georgia, serif',
+        mono: '"JetBrains Mono", monospace'
+      };
+      pvInner.style.fontFamily = map[font] || '';
+    }
+    function selectBtnStyle(tile, style) {
+      document.querySelectorAll('.btn-style-tile').forEach(t => t.classList.remove('selected'));
+      tile.classList.add('selected');
+      pvInner.dataset.btn = style;
+    }
+
+    // Theme presets
+    document.querySelectorAll('[data-theme-preset]').forEach(tile => {
+      tile.addEventListener('click', () => {
+        document.querySelectorAll('[data-theme-preset]').forEach(t => t.classList.remove('selected'));
+        tile.classList.add('selected');
+        const map = {
+          minimal:   { theme: '',          wallpaper: 'fill',     bg: '#FFFFFF' },
+          bold:      { theme: '',          wallpaper: 'fill',     bg: '#6366F1' },
+          editorial: { theme: 'editorial', wallpaper: 'fill',     bg: '#F8F5EE' },
+          playful:   { theme: '',          wallpaper: 'gradient', bg: '#F59E0B' },
+          dark:      { theme: 'dark',      wallpaper: 'fill',     bg: '#0B0F1E' },
+          sunset:    { theme: 'sunset',    wallpaper: 'fill',     bg: '#F59E0B' },
+          ocean:     { theme: 'ocean',     wallpaper: 'fill',     bg: '#3B82F6' },
+          nord:      { theme: '',          wallpaper: 'fill',     bg: '#ECEFF4' }
+        };
+        const cfg = map[tile.dataset.themePreset] || map.minimal;
+        pvInner.dataset.theme = cfg.theme;
+        pvInner.dataset.wallpaper = cfg.wallpaper;
+        pvInner.style.setProperty('--pv-bg-color', cfg.bg);
+      });
+    });
+
+    // Footer radio options
+    document.querySelectorAll('.footer-option').forEach(opt => {
+      opt.addEventListener('click', () => {
+        document.querySelectorAll('.footer-option').forEach(o => o.classList.remove('selected'));
+        opt.classList.add('selected');
+      });
+    });
+
+    // =================================================================
+    // Animations sub-panel
+    // =================================================================
+    function selectAnim(tile, kind, value) {
+      // kind is currently 'entrance' only for tile-based picker
+      tile.parentElement.querySelectorAll('.anim-tile').forEach(t => t.classList.remove('selected'));
+      tile.classList.add('selected');
+      document.body.dataset['anim' + kind.charAt(0).toUpperCase() + kind.slice(1)] = value;
+      replayAnimation();
+    }
+
+    function selectSeg(btn, kind, value) {
+      btn.parentElement.querySelectorAll('.seg').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      document.body.dataset['anim' + kind.charAt(0).toUpperCase() + kind.slice(1)] = value;
+      if (kind === 'block') replayAnimation();
+    }
+
+    function replayAnimation() {
+      const screens = document.querySelectorAll('.phone-screen');
+      screens.forEach(s => {
+        s.classList.remove('is-replaying');
+        // Force reflow so the re-added class retriggers the animation
+        void s.offsetWidth;
+        s.classList.add('is-replaying');
+        setTimeout(() => s.classList.remove('is-replaying'), 1400);
+      });
+    }
+
+    function toggleReducedMotion(cb) {
+      document.body.classList.toggle('reduced-motion', !cb.checked);
+    }
+
+    window.selectAnim = selectAnim;
+    window.selectSeg = selectSeg;
+    window.replayAnimation = replayAnimation;
+    window.toggleReducedMotion = toggleReducedMotion;
+
+    // =================================================================
+    // AI Theme matcher (mockup — predefined catalogue match)
+    // =================================================================
+    // Catalogue of theme classes that already exist in CSS (theme-bold,
+    // theme-minimal, etc.). In production this would be a 1000+ entry
+    // catalogue with semantic tags + dominant-color signatures.
+    const AI_THEME_CATALOGUE = [
+      { id: 'sunset',    label: 'Sunset',     tags: ['warm', 'sunset', 'rooftop', 'lisbon', 'orange', 'pink', 'editorial', 'photographer'] },
+      { id: 'editorial', label: 'Editorial',  tags: ['bookstore', 'cozy', 'serif', 'magazine', 'reading', 'cafe'] },
+      { id: 'ocean',     label: 'Ocean',      tags: ['blue', 'water', 'beach', 'calm', 'spa', 'skincare'] },
+      { id: 'minimal',   label: 'Minimal',    tags: ['clean', 'white', 'concrete', 'brutalist', 'gallery', 'architecture'] },
+      { id: 'playful',   label: 'Playful',    tags: ['pastel', '90s', 'zine', 'fun', 'colorful', 'youth'] },
+      { id: 'bold',      label: 'Bold',       tags: ['vibrant', 'vinyl', 'record', 'music', 'dance', 'club'] },
+      { id: 'dark',      label: 'Dark',       tags: ['night', 'gallery', 'photographer', 'moody', 'cinema', 'bw'] },
+      { id: 'nord',      label: 'Nord',       tags: ['scandinavian', 'cold', 'snow', 'ski', 'minimal', 'airy'] }
+    ];
+
+    function tokenize(text) {
+      return (text || '').toLowerCase().match(/\w+/g) || [];
+    }
+
+    function aiSemanticMatch(prompt) {
+      const tokens = tokenize(prompt);
+      if (tokens.length === 0) return AI_THEME_CATALOGUE.slice(0, 4).map(t => ({...t, match: 60 + Math.random()*15}));
+      const scored = AI_THEME_CATALOGUE.map(theme => {
+        let score = 0;
+        for (const t of tokens) {
+          for (const tag of theme.tags) {
+            if (tag === t) score += 10;
+            else if (tag.includes(t) || t.includes(tag)) score += 5;
+          }
+        }
+        return { ...theme, match: Math.min(99, 50 + score + Math.floor(Math.random() * 10)) };
+      });
+      scored.sort((a, b) => b.match - a.match);
+      return scored.slice(0, 4);
+    }
+
+    function generateAiTheme() {
+      const btn = document.getElementById('ai-generate-btn');
+      const promptEl = document.getElementById('ai-theme-prompt');
+      const tokensEl = document.getElementById('ai-tokens-count');
+      const resultEl = document.getElementById('ai-theme-result');
+      const gridEl = document.getElementById('ai-results-grid');
+
+      const remaining = parseInt(tokensEl.textContent, 10);
+      if (remaining <= 0) {
+        alert('Out of AI uses this month. Upgrade to Creator for 40/mo or Pro for 200/mo. Resets on the 1st.');
+        return;
+      }
+
+      btn.classList.add('generating');
+      btn.disabled = true;
+      const labelSpan = btn.querySelector('.ai-btn-label');
+      const original = labelSpan.textContent;
+      labelSpan.textContent = 'Matching…';
+
+      // Simulate API latency
+      setTimeout(() => {
+        const matches = aiSemanticMatch(promptEl.value);
+        gridEl.innerHTML = matches.map(m => `
+          <div class="tile ai-result-tile" data-theme-preset="${m.id}" onclick="applyAiTheme(this, '${m.id}')">
+            <span class="match-pct">${m.match}%</span>
+            <div class="theme-${m.id}" style="position:absolute;inset:0"></div>
+            <div class="tile-label">${m.label}</div>
+          </div>
+        `).join('');
+        resultEl.hidden = false;
+
+        // Decrement token
+        tokensEl.textContent = String(remaining - 1);
+
+        btn.classList.remove('generating');
+        btn.disabled = false;
+        labelSpan.textContent = original;
+      }, 900);
+    }
+
+    function applyAiTheme(tile, themeId) {
+      // Apply the chosen theme to the actual preset row above
+      const presetRow = document.querySelector('[data-panel="theme"] .field-group:last-child .tile-grid');
+      if (presetRow) {
+        presetRow.querySelectorAll('.tile').forEach(t => t.classList.remove('selected'));
+        const target = presetRow.querySelector(`[data-theme-preset="${themeId}"]`);
+        if (target) {
+          target.classList.add('selected');
+          target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
+      }
+      // Mark this AI tile as the chosen one
+      tile.parentElement.querySelectorAll('.ai-result-tile').forEach(t => t.classList.remove('selected'));
+      tile.classList.add('selected');
+    }
+
+    function closeAiResult() {
+      document.getElementById('ai-theme-result').hidden = true;
+    }
+
+    function useAiHint(chip) {
+      document.getElementById('ai-theme-prompt').value = chip.textContent;
+      document.getElementById('ai-theme-prompt').focus();
+    }
+
+    function onAiImageSelected(input) {
+      const file = input.files && input.files[0];
+      if (!file) return;
+      // Mockup: pretend we extracted dominant colors and feed them as a synthetic prompt
+      const promptEl = document.getElementById('ai-theme-prompt');
+      const synthetic = `image: ${file.name.replace(/\.[^.]+$/, '').replace(/[-_]/g, ' ')} — dominant colors detected`;
+      promptEl.value = synthetic;
+      // Auto-generate when image is uploaded
+      generateAiTheme();
+    }
+
+    window.generateAiTheme = generateAiTheme;
+    window.applyAiTheme = applyAiTheme;
+    window.closeAiResult = closeAiResult;
+    window.useAiHint = useAiHint;
+    window.onAiImageSelected = onAiImageSelected;
+
+    // =================================================================
+    // Theme toggle (light / dark)
+    // =================================================================
+    const themeToggle = document.getElementById('theme-toggle');
+    const savedTheme = (function() {
+      try { return localStorage.getItem('tadaify-theme'); } catch (e) { return null; }
+    })();
+    if (savedTheme === 'dark') document.body.classList.add('dark-mode');
+    if (themeToggle) {
+      themeToggle.addEventListener('click', () => {
+        const isDark = document.body.classList.toggle('dark-mode');
+        try { localStorage.setItem('tadaify-theme', isDark ? 'dark' : 'light'); } catch (e) {}
+      });
+    }
+
+    // =================================================================
+    // Add Block modal — extensible integration picker
+    // =================================================================
+    const AM_CATEGORIES = [
+      { id: 'suggested', label: 'Smart picks', icon: '✨' },
+      { id: 'link',      label: 'Link',        icon: '🔗' },
+      { id: 'social',    label: 'Social',      icon: '👥' },
+      { id: 'media',     label: 'Media',       icon: '▶' },
+      { id: 'commerce',  label: 'Commerce',    icon: '💳' },
+      { id: 'contact',   label: 'Inbox',       icon: '✉' },
+      { id: 'events',    label: 'Calendar',    icon: '📅' },
+      { id: 'text',      label: 'Words',       icon: '📝' },
+      { id: 'layout',    label: 'Layout',      icon: '▦' }
+    ];
+    const AM_INTEGRATIONS = [
+      // featured = shown as tile above the list (per category)
+      { id:'add-link',     cat:'link',     name:'Add link',          desc:'Any URL — YouTube, blog, custom',           icon:'🔗', gating:'free',    featured:true },
+      { id:'collection',   cat:'link',     name:'Collection',        desc:'Group links under a heading',                icon:'📂', gating:'free',    featured:true },
+      { id:'instagram',    cat:'social',   name:'Instagram',         desc:'Follow-me block linking to your profile',    color:'linear-gradient(45deg,#F58529,#DD2A7B,#8134AF,#515BD4)', gating:'free', featured:true },
+      { id:'tiktok',       cat:'social',   name:'TikTok',            desc:'Follow-me block linking to your profile',    color:'#000', gating:'free', featured:true },
+      { id:'youtube',      cat:'social',   name:'YouTube',           desc:'Follow-me block linking to your channel',    color:'#FF0000', gating:'free', featured:true },
+      { id:'x',            cat:'social',   name:'X (Twitter)',       desc:'Follow-me block linking to your profile',    color:'#000', gating:'free' },
+      { id:'twitch',       cat:'social',   name:'Twitch',            desc:'Channel link with live indicator',           color:'#9146FF', gating:'free' },
+      { id:'spotify',      cat:'social',   name:'Spotify',           desc:'Profile link',                                color:'#1DB954', gating:'free' },
+      { id:'linkedin',     cat:'social',   name:'LinkedIn',          desc:'Profile link',                                color:'#0A66C2', gating:'free' },
+      { id:'pinterest',    cat:'social',   name:'Pinterest',         desc:'Profile link',                                color:'#E60023', gating:'free' },
+      { id:'threads',      cat:'social',   name:'Threads',           desc:'Profile link',                                color:'#000', gating:'free' },
+      { id:'soundcloud',   cat:'social',   name:'SoundCloud',        desc:'Profile link',                                color:'#FF5500', gating:'free' },
+      { id:'discord',      cat:'social',   name:'Discord',           desc:'Server invite',                               color:'#5865F2', gating:'free' },
+      { id:'yt-embed',     cat:'media',    name:'YouTube embed',     desc:'Inline video player',                         icon:'▶', gating:'free',  featured:true },
+      { id:'spot-track',   cat:'media',    name:'Spotify track',     desc:'Inline music player',                         icon:'♫', gating:'free',  featured:true },
+      { id:'vimeo',        cat:'media',    name:'Vimeo',             desc:'Embedded video',                              icon:'▶', gating:'free' },
+      { id:'apple-music',  cat:'media',    name:'Apple Music',       desc:'Track or playlist embed',                     icon:'♫', gating:'free' },
+      { id:'audio-file',   cat:'media',    name:'Audio file',        desc:'Upload an MP3 / WAV',                         icon:'🎙', gating:'creator' },
+      { id:'image-gallery',cat:'media',    name:'Image gallery',     desc:'Carousel of images',                          icon:'🖼', gating:'free' },
+      { id:'video-file',   cat:'media',    name:'Video file',        desc:'Upload an MP4',                               icon:'🎬', gating:'creator' },
+      { id:'product',      cat:'commerce', name:'Product',           desc:'Sell a digital download',                     icon:'💳', gating:'free',   featured:true },
+      { id:'service',      cat:'commerce', name:'Service',           desc:'Hourly / fixed-price service',                icon:'🛠', gating:'creator', featured:true },
+      { id:'tip-jar',      cat:'commerce', name:'Tip jar',           desc:'Accept tips — no platform fee',               icon:'🫙', gating:'free',  featured:true },
+      { id:'donations',    cat:'commerce', name:'Donations',         desc:'Cause-led contribution',                       icon:'❤', gating:'free' },
+      { id:'booking',      cat:'commerce', name:'Booking',           desc:'Calendar-based appointments',                 icon:'📅', gating:'pro' },
+      { id:'affiliate',    cat:'commerce', name:'Affiliate link',    desc:'Tracked link with commission split',          icon:'🤝', gating:'free' },
+      { id:'email',        cat:'contact',  name:'Email capture',     desc:'Grow your newsletter list',                   icon:'✉', gating:'free',  featured:true },
+      { id:'form',         cat:'contact',  name:'Contact form',      desc:'Custom-field form posting to your inbox',     icon:'📋', gating:'creator' },
+      { id:'cal-booking',  cat:'contact',  name:'Calendar booking',  desc:'Cal.com / Calendly / TidyCal embed',           icon:'📆', gating:'pro' },
+      { id:'whatsapp',     cat:'contact',  name:'WhatsApp',          desc:'Click-to-chat link',                          icon:'💬', gating:'free' },
+      { id:'event-card',   cat:'events',   name:'Event card',        desc:'Single upcoming event with date / RSVP',      icon:'🎟', gating:'free',  featured:true },
+      { id:'tour-list',    cat:'events',   name:'Tour list',         desc:'Multi-date tour or workshop schedule',         icon:'📍', gating:'pro' },
+      { id:'bandsintown',  cat:'events',   name:'Bandsintown',        desc:'Auto-pull tour dates from your Bandsintown',  icon:'🎤', gating:'pro' },
+      { id:'section',      cat:'text',     name:'Section header',    desc:'Heading divider with icon',                   icon:'§', gating:'free',  featured:true },
+      { id:'quote',        cat:'text',     name:'Quote',             desc:'Pull-quote with attribution',                 icon:'❝', gating:'free',  featured:true },
+      { id:'bio',          cat:'text',     name:'Bio paragraph',     desc:'Long-form intro under header',                icon:'¶', gating:'free' },
+      { id:'newsletter-cta',cat:'text',    name:'Newsletter CTA',    desc:'Stylised email-list prompt',                  icon:'✉', gating:'free' },
+      { id:'disclaimer',   cat:'text',     name:'Disclaimer',        desc:'Small-print compliance line',                 icon:'⚠', gating:'free' },
+      { id:'spacer',       cat:'layout',   name:'Spacer',            desc:'Vertical breathing room',                     icon:'⇕', gating:'free',  featured:true },
+      { id:'divider',      cat:'layout',   name:'Divider',           desc:'Subtle horizontal line',                      icon:'—', gating:'free',  featured:true },
+      { id:'image',        cat:'layout',   name:'Image',             desc:'Full-width image block',                      icon:'🖼', gating:'free' },
+      { id:'carousel',     cat:'layout',   name:'Image carousel',    desc:'Swipeable image set',                         icon:'🎠', gating:'free' },
+      { id:'logo-cloud',   cat:'layout',   name:'Logo cloud',        desc:'Press / clients / brands strip',              icon:'☁', gating:'free' },
+      { id:'featured',     cat:'layout',   name:'Featured card',     desc:'Highlighted prominent block',                 icon:'⭐', gating:'free' }
+    ];
+
+    // URL → integration auto-detect
+    const URL_DETECT = [
+      { hosts:['instagram.com','instagr.am'],     id:'instagram' },
+      { hosts:['tiktok.com'],                     id:'tiktok'    },
+      { hosts:['youtube.com','youtu.be'],         id:'youtube'   },
+      { hosts:['twitter.com','x.com'],            id:'x'         },
+      { hosts:['twitch.tv'],                      id:'twitch'    },
+      { hosts:['spotify.com','open.spotify.com'], id:'spotify'   },
+      { hosts:['linkedin.com'],                   id:'linkedin'  },
+      { hosts:['pinterest.com'],                  id:'pinterest' },
+      { hosts:['threads.net'],                    id:'threads'   },
+      { hosts:['soundcloud.com'],                 id:'soundcloud'},
+      { hosts:['discord.gg','discord.com'],       id:'discord'   },
+      { hosts:['vimeo.com'],                      id:'vimeo'     }
+    ];
+
+    let amActiveCategory = 'suggested';
+
+    function amRenderRail() {
+      const rail = document.getElementById('add-modal-rail');
+      if (!rail) return;
+      rail.innerHTML = AM_CATEGORIES.map(c =>
+        `<button class="am-cat ${c.id === amActiveCategory ? 'active' : ''}" data-cat="${c.id}" onclick="amSetCategory('${c.id}')">
+           <span style="font-size:14px;">${c.icon}</span><span>${c.label}</span>
+         </button>`
+      ).join('');
+    }
+
+    function amItemsForCategory(cat) {
+      if (cat === 'suggested') {
+        return AM_INTEGRATIONS.filter(i => i.featured).slice(0, 12);
+      }
+      return AM_INTEGRATIONS.filter(i => i.cat === cat);
+    }
+
+    function amGatingPill(gating) {
+      if (gating === 'creator') return '<span class="am-gating-pill creator">💡 Creator</span>';
+      if (gating === 'pro')     return '<span class="am-gating-pill pro">💡 Pro</span>';
+      return '';
+    }
+
+    function amTileMarkup(item) {
+      const colorBg = item.color || 'linear-gradient(135deg,#6366F1,#8B5CF6)';
+      const iconContent = item.color ? '' : (item.icon || '🔗');
+      const iconColor = item.color ? '#fff' : '#fff';
+      return `
+        <div class="am-feat-tile" data-id="${item.id}" onclick="amPickItem('${item.id}')">
+          <span class="am-ft-icon" style="background:${colorBg}; color:${iconColor};">${iconContent}</span>
+          <div class="am-ft-name">${item.name}</div>
+          ${amGatingPill(item.gating)}
+        </div>`;
+    }
+
+    function amRowMarkup(item) {
+      const colorBg = item.color || 'linear-gradient(135deg,#6366F1,#8B5CF6)';
+      const iconContent = item.color ? '' : (item.icon || '🔗');
+      return `
+        <div class="am-integration-row" data-id="${item.id}" onclick="amPickItem('${item.id}')">
+          <span class="am-int-icon" style="background:${colorBg}; color:#fff;">${iconContent}</span>
+          <div class="am-int-info">
+            <div class="am-int-name">${item.name}</div>
+            <div class="am-int-desc">${item.desc}</div>
+          </div>
+          <div class="am-int-right">
+            ${amGatingPill(item.gating)}
+            <span class="am-int-chevron">›</span>
+          </div>
+        </div>`;
+    }
+
+    function amRender() {
+      const cat = amActiveCategory;
+      const title = AM_CATEGORIES.find(c => c.id === cat)?.label || 'Add';
+      document.getElementById('add-modal-cat-title').textContent = title;
+      const items = amItemsForCategory(cat);
+      const featured = items.filter(i => i.featured).slice(0, 4);
+      const rest = items.filter(i => !featured.includes(i));
+      document.getElementById('add-modal-featured').innerHTML = featured.map(amTileMarkup).join('');
+      document.getElementById('add-modal-list').innerHTML = rest.map(amRowMarkup).join('');
+      document.getElementById('add-modal-empty').style.display = items.length === 0 ? 'flex' : 'none';
+    }
+
+    function amSetCategory(cat) {
+      amActiveCategory = cat;
+      document.getElementById('add-modal-search-input').value = '';
+      document.getElementById('add-modal-detected').classList.remove('visible');
+      amRenderRail();
+      amRender();
+    }
+
+    function amSearch(query) {
+      const q = (query || '').trim().toLowerCase();
+      const detectedEl = document.getElementById('add-modal-detected');
+      const detectedTextEl = document.getElementById('add-modal-detected-text');
+      // URL detection
+      const urlMatch = q.match(/(?:https?:\/\/)?(?:www\.)?([^\/\s]+)/);
+      if (urlMatch && q.includes('.')) {
+        const host = urlMatch[1];
+        for (const d of URL_DETECT) {
+          if (d.hosts.some(h => host.includes(h))) {
+            const it = AM_INTEGRATIONS.find(x => x.id === d.id);
+            if (it) {
+              detectedTextEl.textContent = `Detected: ${it.name} · Click to add`;
+              detectedEl.dataset.itemId = it.id;
+              detectedEl.classList.add('visible');
+              return;
+            }
+          }
+        }
+        // Fallback to generic Link
+        const link = AM_INTEGRATIONS.find(x => x.id === 'add-link');
+        detectedTextEl.textContent = `Detected: Generic link · Click to add`;
+        detectedEl.dataset.itemId = link.id;
+        detectedEl.classList.add('visible');
+        return;
+      }
+      detectedEl.classList.remove('visible');
+      // Text search
+      if (q === '') { amRender(); return; }
+      const filtered = AM_INTEGRATIONS.filter(i =>
+        i.name.toLowerCase().includes(q) ||
+        i.desc.toLowerCase().includes(q)
+      );
+      document.getElementById('add-modal-cat-title').textContent = `Results for "${query}"`;
+      document.getElementById('add-modal-featured').innerHTML = '';
+      document.getElementById('add-modal-list').innerHTML = filtered.map(amRowMarkup).join('');
+      document.getElementById('add-modal-empty').style.display = filtered.length === 0 ? 'flex' : 'none';
+    }
+
+    function amPickItem(itemId) {
+      const item = AM_INTEGRATIONS.find(i => i.id === itemId);
+      if (!item) return;
+      if (item.gating !== 'free') {
+        const tier = item.gating === 'creator' ? 'Creator ($5/mo)' : 'Pro ($15/mo)';
+        document.getElementById('am-gc-title').textContent = `💡 ${tier} feature`;
+        document.getElementById('am-gc-body').textContent = `"${item.name}" is a ${tier} feature. Add as a placeholder for now? You can swap to a real one after upgrading.`;
+        const gc = document.getElementById('am-gating-confirm');
+        gc.classList.add('visible');
+        document.getElementById('am-gc-ok').onclick = () => {
+          gc.classList.remove('visible');
+          alert(`Added "${item.name}" as a placeholder block.`);
+          closeAddBlockModal();
+        };
+        return;
+      }
+      alert(`Added "${item.name}" to your page.`);
+      closeAddBlockModal();
+    }
+
+    function openAddBlockModal(preCategory) {
+      const bd = document.getElementById('add-modal-backdrop');
+      bd.classList.add('open');
+      document.body.style.overflow = 'hidden';
+      amSetCategory(preCategory || 'suggested');
+      setTimeout(() => document.getElementById('add-modal-search-input').focus(), 50);
+    }
+
+    function closeAddBlockModal() {
+      document.getElementById('add-modal-backdrop').classList.remove('open');
+      document.body.style.overflow = '';
+      document.getElementById('add-modal-search-input').value = '';
+      document.getElementById('add-modal-detected').classList.remove('visible');
+    }
+
+    function closeGatingConfirm() {
+      document.getElementById('am-gating-confirm').classList.remove('visible');
+    }
+
+    function handleBackdropClick(e) {
+      if (e.target === e.currentTarget) closeAddBlockModal();
+    }
+
+    // Wire up modal close button + ESC + search input + detected chip
+    document.getElementById('add-modal-close')?.addEventListener('click', closeAddBlockModal);
+    document.addEventListener('keydown', e => {
+      if (e.key === 'Escape' && document.getElementById('add-modal-backdrop').classList.contains('open')) {
+        closeAddBlockModal();
+      }
+    });
+    document.getElementById('add-modal-search-input')?.addEventListener('input', e => amSearch(e.target.value));
+    document.getElementById('add-modal-detected')?.addEventListener('click', () => {
+      const id = document.getElementById('add-modal-detected').dataset.itemId;
+      if (id) amPickItem(id);
+    });
+
+    // Initial render so modal is ready when opened
+    amRenderRail();
+    amRender();
+
+    window.openAddBlockModal = openAddBlockModal;
+    window.closeAddBlockModal = closeAddBlockModal;
+    window.amSetCategory = amSetCategory;
+    window.amPickItem = amPickItem;
+    window.handleBackdropClick = handleBackdropClick;
+    window.closeGatingConfirm = closeGatingConfirm;
+
+    // =================================================================
+    // Optional support badge (Footer panel) — strictly opt-in
+    // =================================================================
+    function toggleSupportBadge(cb) {
+      document.getElementById('support-preview-badge').hidden = !cb.checked;
+      // Future: also toggle .support-badge-on body class to render in live preview phone
+      document.body.classList.toggle('support-badge-on', cb.checked);
+    }
+    window.toggleSupportBadge = toggleSupportBadge;
+
+    // =================================================================
+    // Boot
+    // =================================================================
+    setTab(initialTab);
+    setSubnav(initialSubtab);
+    setDevice(initialDevice);
+
+    // V2: auto-expand Design accordion if user landed directly on a
+    // Design sub-tab (default behavior; ?nav=collapsed would override
+    // but is not exposed in MVP). The setSubnav call above already
+    // expands it; this is just defensive for ?tab=design without subtab.
+    const initialNav = params.get('nav');
+    if (initialTab === 'design' || initialNav === 'expanded') {
+      setDesignAccordion(true);
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Independent A/B comparison mockup at `mockups/tadaify-mvp/app-dashboard-v2.html`. Navigation experiment — collapses Design's secondary left rail into expandable sub-items inside the main sidebar, and adds a breadcrumb-style stepper at the top of each Design sub-section for sequential walkthrough.

**Goal:** A/B comparison against the canonical `app-dashboard.html`. Both files coexist. User picks the winning IA, applies the winning variant back to `app-dashboard.html` in a follow-up. **Merge of this PR is NOT recommended until the A/B comparison is concluded.**

## What changes (the experiment)

### 1. Single sidebar with accordion

Design parent expands inline to reveal the 8 sub-items (Theme / Profile / Background / Text / Buttons / Animations / Colors / Footer). The secondary 180px left rail (`.design-subnav`) is hidden via CSS — markup preserved for diff parity but visually + interactively suppressed.

Click "Design" parent → expands accordion (caret rotates). Active sub-item highlighted with indigo bg + bold weight. Other sidebar items remain flat (no sub-items in this mockup).

### 2. Breadcrumb stepper

Indigo-tinted bar at top of `.design-content`. Visible only when `?tab=design`. Three cells: prev / current (bold + spark dot) / next. First sub-tab (Theme) shows `—` for prev; last (Footer) shows `—` for next. Click prev/next → sequential walk-through. Click current → dropdown radio-picker of all 8 sub-tabs. ← / → arrow keys navigate when stepper is keyboard-focused. Mobile (<720px) collapses to single label + chevrons.

### URL state

Same as current dashboard:
- `?tab=page|design|insights|shop|settings|domain` (default `page`)
- `?subtab=theme|profile|background|text|buttons|animations|colors|footer` (default `background`)
- `?device=mobile|tablet|desktop` (default `mobile`)
- `?state=ready|empty` (default `ready`)
- New: `?nav=expanded` — auto-expands Design accordion on load (default behavior when on a Design sub-tab)

## What did NOT change

Everything else is byte-identical to `app-dashboard.html` on main:
- Profile card with social handles row + edit-pencil-expands-inline-form
- Pinned message primitive (toggleable fading line above profile card)
- "Organise…" dropdown
- Blocks list + drag-handle + toggle + ⋯ menu
- Add Block modal (full Linktree-style with categories + search + URL detect + integrations + gating)
- AI Theme matcher (predefined catalogue + token meter + suggested chips)
- Animations 2-section split (Entrance + Ambient + Accessibility)
- Footer panel with opt-in support badge (default OFF, gradient toggle)
- Light/dark mode toggle in topbar
- 3-way device preview toggle (Mobile / Tablet / Desktop)
- Welcome banner (dismissible)
- All copy, all interaction patterns, all CSS tokens
- Mobile bottom-tab bar (5 items)

## Diff stats

- 1 file changed (`mockups/tadaify-mvp/app-dashboard-v2.html`)
- 4458 insertions / 0 deletions (file is new — copy of `app-dashboard.html` + accordion/stepper diff)
- Source `app-dashboard.html` baseline: 4047 lines → V2: 4458 lines (+411 net for accordion CSS/HTML/JS + stepper CSS/HTML/JS + dark-mode rules)

## Brand + DEC compliance

All locked DECs respected (same set as base `app-dashboard.html`):
DEC-019, DEC-WORDMARK-01, DEC-PRICELOCK-01/02, DEC-MULTIPAGE-01, DEC-LAYOUT-01, DEC-CREATOR-API-01, DEC-AI-QUOTA-LADDER-01, DEC-AI-FEATURES-ROADMAP-01, DEC-ANIMATIONS-SPLIT-01, DEC-WALLPAPER-ANIM-01, DEC-PINNED-MSG-01, DEC-CUSTOM-DOMAIN-NAV-01, DEC-OPT-BADGE, DEC-CUSTOM-DOMAIN-PROVIDER-01, DEC-CUSTOM-DOMAIN-VALIDATION-01.

Anti-patterns enforced: AP-001 / AP-013 / AP-017 / AP-031.

Wordmark, palette (Indigo Serif), fonts (Crimson Pro display + Inter sans), Motion v10 timings — all unchanged from baseline.

## Test plan

Manual A/B comparison click-through (open both files side-by-side):

1. **Sidebar accordion expand/collapse**
   - Open `?tab=design&subtab=theme` → accordion auto-expands, Theme highlighted in sidebar
   - Click Design parent again → collapses (caret de-rotates)
   - Click Design parent on Page tab → enters Design tab + expands accordion
2. **Stepper walk-through**
   - Click Theme sub-item in sidebar → main shows Theme panel; stepper reads `— / Theme / Profile`
   - Click stepper next-arrow ("Profile") → navigates to Profile panel; stepper updates to `Theme / Profile / Background`
   - Walk through to Footer → stepper reads `Colors / Footer / —`
   - Click "current" cell on Animations → dropdown opens with 8 radio items, Animations highlighted
   - Pick Buttons from dropdown → navigates + stepper updates + sidebar accordion highlight follows
   - Tab into stepper, press ← / → → keyboard nav works
3. **URL deep-link**
   - Open `?tab=design&subtab=animations` → accordion expanded, Animations active in sidebar AND in stepper
   - Open `?tab=design` (no subtab) → defaults to Background, accordion expanded
4. **Click-through preservation**
   - Click Domain in sidebar → navigates to `./app-domain.html`
   - Click Insights / Shop / Settings → switches tabs as before
5. **Mobile (<720px)**
   - Resize to 360px → stepper shows only `← Animations →` (icons + current label)
   - Sidebar drawer pattern unchanged from baseline
6. **Light/dark toggle**
   - Toggle dark mode → stepper bg darkens, accordion sub-list border-left adapts, dropdown surface darkens

## Mockup

`mockups/tadaify-mvp/app-dashboard-v2.html` (this PR). Side-by-side viewing instructions:
1. Open `app-dashboard.html?tab=design&subtab=animations` in tab A
2. Open `app-dashboard-v2.html?tab=design&subtab=animations` in tab B
3. Compare: nav real estate, click-depth to switch sub-section, discoverability, visual weight

## Rollback

Single-file feature; rollback = `git revert <SHA>` (deletes `app-dashboard-v2.html`). Zero risk to canonical `app-dashboard.html` — that file is untouched.

## Recommended verdict

**Single-nav with stepper wins.** Reasoning:
- Reclaims ~140px of horizontal real estate that the secondary rail was eating, which matters on tablet (768–1024px) where the rail collided with phone preview.
- Sequential stepper turns Design configuration into a guided flow ("set theme → profile → background → …"), which matches first-time creator mental model better than free-jump rail.
- Accordion in sidebar is a familiar pattern (Notion, Linear, Vercel dashboards) — discoverable without explanation.
- Dual-rail still wins for power users who jump non-linearly. Possible follow-up: keep V2 as default + add a "show all" toggle that re-opens the legacy rail, but that's gold-plating until users actually ask.

If the user disagrees and prefers `current-dual-nav`, the change is cheap — delete `app-dashboard-v2.html`, no other repo state touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
