### PR TITLE
feat(mockup): settings panel + sidebar Settings link wired

### DIFF
--- a/mockups/tadaify-mvp/README.md
+++ b/mockups/tadaify-mvp/README.md
@@ -21,6 +21,7 @@
 | `onboarding-complete.html` | Success — confetti + clipboard copy + Motion v10 burst | [#3 F-FULLFLOW-001](https://github.com/graspsoftwarepw/tadaify-app/issues/3) | 2026-04-25 |
 | `app-dashboard.html` | **Authenticated creator dashboard** — single sidebar + accordion + breadcrumb stepper for Design (v2 IA, accepted 2026-04-25) | [#26 F-APP-DASHBOARD-001](https://github.com/graspsoftwarepw/tadaify-app/issues/26) | 2026-04-25 |
 | `app-domain.html` | Custom domain management — 3-step add wizard (Enter / DNS / Live) + Free-tier subscription overlay + status states | [#30 F-CUSTOM-DOMAIN-001](https://github.com/graspsoftwarepw/tadaify-app/issues/30) | 2026-04-25 |
+| `app-settings.html` | **Authenticated creator settings** — Account / Billing / Security / GDPR & data / API keys (Pro) / Team (Business) / Danger zone (1-click cancel per AP-010, page-stays-live per AP-029, delete account per F-COMPLIANCE-001) | [#33 Account](https://github.com/graspsoftwarepw/tadaify-app/issues/33) · [#34 Billing](https://github.com/graspsoftwarepw/tadaify-app/issues/34) · [#35 Security](https://github.com/graspsoftwarepw/tadaify-app/issues/35) · [#36 GDPR](https://github.com/graspsoftwarepw/tadaify-app/issues/36) · [#37 API keys](https://github.com/graspsoftwarepw/tadaify-app/issues/37) · [#38 Team](https://github.com/graspsoftwarepw/tadaify-app/issues/38) · [#39 Danger zone](https://github.com/graspsoftwarepw/tadaify-app/issues/39) | 2026-04-25 |
 | `pricing.html` | Public pricing matrix — 4 tiers, compare table, Creator API spotlight, FAQ | [F-PRICING-LANDING-001 — TBD] | 2026-04-25 |
 | `creator-public.html` | Public creator page — what visitors see at tadaify.com/handle | implicit (rendered via F-FULLFLOW-001 publish path) | 2026-04-24 |
 | `product-public.html` | Public per-product page — tadaify.com/handle/p/slug | TBD (depends on F-PAGE-SHOP-001 #18) | 2026-04-24 |
@@ -88,6 +89,18 @@
 
 ## Changelog
 
+### 2026-04-25 — Settings mockup added (F-180..199 scope)
+- `app-settings.html` NEW — full settings panel: Account, Billing, Security, GDPR & data, API keys (Pro-gated), Team (Business-gated), Danger zone
+- AP-010 one-click cancel modal wired (no survey cascade)
+- AP-029 "page stays live" messaging in cancel + delete account flows
+- F-COMPLIANCE-001 GDPR data export + delete account + cookie preferences
+- DEC-CREATOR-API-01 API keys section with MCP server install snippet + Custom GPT template
+- DEC-PRICELOCK-01 "Locked for life" amber pill on Billing plan card
+- DEC-PRICELOCK-02 custom domain add-on line items in Billing
+- Demo toolbar (bottom-right, aria-hidden) for tier switching (Free/Creator/Pro/Business) to preview gated states
+- Settings link wired in `app-dashboard.html` and `app-domain.html` sidebars (were placeholders)
+- Cross-mockup link audit completed — 17 files scanned, 0 broken refs, 3 orphan candidates documented
+
 ### 2026-04-25 — Single-sidebar IA adopted (this PR)
 - `app-dashboard.html` replaced with v2 content (single-sidebar + breadcrumb stepper accordion). Old dual-rail v1 superseded.
 - `app-domain.html` added — full custom-domain management mockup
@@ -136,5 +149,5 @@
 
 - Read this README before starting any F-XXX-NNN implementation. The DEC trail and brand-lock are non-negotiable.
 - If your implementation deviates from the mockup, add a comment to the corresponding issue (per `change-tracker` skill) BEFORE merging the PR.
-- Cross-mockup navigation references: `./app-dashboard.html`, `./app-domain.html`, `./creator-public.html`, etc. — keep relative paths working when implementing routes.
+- Cross-mockup navigation references: `./app-dashboard.html`, `./app-domain.html`, `./app-settings.html`, `./creator-public.html`, etc. — keep relative paths working when implementing routes.
 - All mockups use `./shared/` assets — implementation should mirror this design-token approach (tokens.css → CSS variables in production).

--- a/mockups/tadaify-mvp/README.md
+++ b/mockups/tadaify-mvp/README.md
@@ -132,7 +132,7 @@
 
 ### 2026-04-24 — DEC-MULTIPAGE-01 application
 - Pages tier ladder added to pricing.html, onboarding-tier.html
-- Dashboard sidebar gained Pages placeholder (post-merge: replaced with Homepage + disabled Add page)
+- Dashboard sidebar: Pages accordion (parent) with Home as first page + disabled Add page sub-item. Mirror this structure in every dashboard-side mockup; first page is always labeled **Home**, never "Homepage" (rejected 2026-04-25).
 - Issues #1, #3 forward-compat updates
 
 ### 2026-04-24 — Initial dashboard mockup wave

--- a/mockups/tadaify-mvp/app-dashboard.html
+++ b/mockups/tadaify-mvp/app-dashboard.html
@@ -2414,10 +2414,10 @@
 
       <!-- GROUP 4: Settings (standalone, no section header) -->
       <div class="nav-group" style="padding-top:0">
-        <button class="nav-item" data-nav="settings" data-tip="Settings">
+        <a href="./app-settings.html" class="nav-item" data-nav="settings" data-tip="Settings">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1a1.7 1.7 0 0 0-1-1.5 1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1a1.7 1.7 0 0 0 1.5-1 1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.8.3h0a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8v0a1.7 1.7 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1z"/></svg>
           <span class="label">Settings</span>
-        </button>
+        </a>
         <button class="nav-item" data-tip="Help &amp; docs">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M9.1 9a3 3 0 1 1 5.8 1c0 2-3 3-3 3M12 17h.01"/></svg>
           <span class="label">Help &amp; docs</span>

--- a/mockups/tadaify-mvp/app-dashboard.html
+++ b/mockups/tadaify-mvp/app-dashboard.html
@@ -289,21 +289,24 @@
        V2 — Sidebar accordion: Design parent + collapsible sub-items
        (replaces the secondary left rail in app-dashboard.html)
        -------------------------------------------------------------- */
-    .nav-design-parent {
+    .nav-design-parent, .nav-pages-parent {
       position: relative;
     }
-    .nav-design-parent .nav-caret {
+    .nav-design-parent .nav-caret, .nav-pages-parent .nav-caret {
       margin-left: auto; flex-shrink: 0;
       width: 14px; height: 14px;
       color: var(--fg-subtle);
       transition: transform .18s ease;
     }
-    .nav-design-parent[aria-expanded="true"] .nav-caret { transform: rotate(90deg); }
-    .nav-design-parent[aria-expanded="true"] {
+    .nav-design-parent[aria-expanded="true"] .nav-caret,
+    .nav-pages-parent[aria-expanded="true"] .nav-caret { transform: rotate(90deg); }
+    .nav-design-parent[aria-expanded="true"],
+    .nav-pages-parent[aria-expanded="true"] {
       background: var(--bg-muted);
       color: var(--fg);
     }
-    .nav-design-parent[aria-expanded="true"].active {
+    .nav-design-parent[aria-expanded="true"].active,
+    .nav-pages-parent[aria-expanded="true"].active {
       background: rgba(99,102,241,0.10);
       color: var(--brand-primary);
     }
@@ -344,7 +347,8 @@
       .nav-item > span.label, .nav-item .nav-count { display: none; }
       .nav-item svg { width: 20px; height: 20px; }
       /* On tablet the accordion expands to a tooltip-like flyout instead of inline list */
-      .nav-design-parent .nav-caret { display: none; }
+      .nav-design-parent .nav-caret, .nav-pages-parent .nav-caret { display: none; }
+      .nav-pages-parent .nav-count { display: none; }
       .nav-sub-list { display: none !important; }
     }
 
@@ -2327,18 +2331,26 @@
         <svg class="chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="8 9 12 5 16 9"/><polyline points="8 15 12 19 16 15"/></svg>
       </div>
 
-      <!-- GROUP 1: Pages (Homepage + Add page disabled) -->
+      <!-- GROUP 1: Pages (accordion parent + Home + Add page disabled) -->
       <div class="nav-group">
-        <button class="nav-item active" data-nav="page" data-tip="Homepage" aria-label="Homepage">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
-          <span class="label">Homepage</span>
-          <span class="nav-count" id="nav-page-count">3</span>
+        <button class="nav-item nav-pages-parent active" data-nav="pages" data-tip="Pages"
+                aria-expanded="true" aria-controls="nav-pages-sub" aria-label="Pages">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+          <span class="label">Pages</span>
+          <span class="nav-count" id="nav-pages-count">1</span>
+          <svg class="nav-caret" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
         </button>
-        <button class="nav-item nav-add-page is-disabled" data-tip="Multi-page coming Q+1 — Free 1 / Creator 5 / Pro 20 / Business unlimited per DEC-MULTIPAGE-01" aria-disabled="true" onclick="event.preventDefault();event.stopPropagation();showAddPageToast(event)">
-          <span class="nav-icon">+</span>
-          <span class="nav-label">Add page</span>
-          <span class="nav-pill nav-pill-soon">soon</span>
-        </button>
+        <div class="nav-sub-list" id="nav-pages-sub" data-expanded="true" role="group" aria-label="Pages list">
+          <button class="nav-sub-item active" data-nav-sub="home" data-nav="page" data-tip="Home — your main page">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <span>Home</span>
+          </button>
+          <button class="nav-sub-item nav-sub-add is-disabled" data-tip="Multi-page coming Q+1 — Free 1 / Creator 5 / Pro 20 / Business unlimited per DEC-MULTIPAGE-01" aria-disabled="true" onclick="event.preventDefault();event.stopPropagation();showAddPageToast(event)">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+            <span>Add page</span>
+            <span class="nav-pill nav-pill-soon" style="margin-left:auto">soon</span>
+          </button>
+        </div>
       </div>
 
       <!-- DIVIDER -->
@@ -3570,7 +3582,7 @@
     // =================================================================
     const params = new URLSearchParams(window.location.search);
     const handle = params.get('handle') || 'alexandra';
-    // ?tab=pages legacy redirect → page (Homepage)
+    // ?tab=pages legacy redirect → page (Home)
     const rawTab = params.get('tab') || 'page';
     const initialTab = rawTab === 'pages' ? 'page' : rawTab;
     const initialSubtab = params.get('subtab') || 'background';
@@ -3657,9 +3669,19 @@
     });
     document.querySelectorAll('.nav-sub-item').forEach(btn => {
       btn.addEventListener('click', (e) => {
+        if (btn.classList.contains('is-disabled')) return; // disabled Add page
         e.stopPropagation();
-        setTab('design');
-        setSubnav(btn.dataset.navSub);
+        // Pages group (e.g. Home) → page tab; Design group → design tab + sub-section
+        const inPagesGroup = !!btn.closest('#nav-pages-sub');
+        if (inPagesGroup) {
+          setTab('page');
+          // mark the clicked Home (or future page sub) active among siblings
+          document.querySelectorAll('#nav-pages-sub .nav-sub-item').forEach(s => s.classList.remove('active'));
+          btn.classList.add('active');
+        } else {
+          setTab('design');
+          setSubnav(btn.dataset.navSub);
+        }
       });
     });
 
@@ -3673,6 +3695,32 @@
       parent.setAttribute('aria-expanded', expanded ? 'true' : 'false');
       list.dataset.expanded = expanded ? 'true' : 'false';
     }
+    function setPagesAccordion(expanded) {
+      const parent = document.querySelector('.nav-pages-parent');
+      const list = document.getElementById('nav-pages-sub');
+      if (!parent || !list) return;
+      parent.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+      list.dataset.expanded = expanded ? 'true' : 'false';
+    }
+    (function wirePagesParentClick() {
+      const parent = document.querySelector('.nav-pages-parent');
+      if (!parent) return;
+      parent.addEventListener('click', (e) => {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        const onPageTab = layoutEl.dataset.tab === 'page';
+        if (!onPageTab) {
+          // First click: enter page tab + ensure expanded
+          setTab('page');
+          setPagesAccordion(true);
+        } else {
+          // Already on page tab — toggle accordion
+          const currentlyExpanded = parent.getAttribute('aria-expanded') === 'true';
+          setPagesAccordion(!currentlyExpanded);
+        }
+      }, true);
+    })();
+
     (function wireDesignParentClick() {
       const parent = document.querySelector('.nav-design-parent');
       if (!parent) return;

--- a/mockups/tadaify-mvp/app-domain.html
+++ b/mockups/tadaify-mvp/app-domain.html
@@ -194,6 +194,33 @@
     }
     .nav-add-page:hover { background: transparent !important; }
 
+    /* Pages accordion (always-expanded read-only on Domain page) */
+    .nav-pages-parent { position: relative; }
+    .nav-pages-parent .nav-caret {
+      margin-left: 6px; flex-shrink: 0;
+      width: 14px; height: 14px;
+      color: var(--fg-subtle);
+      transform: rotate(90deg);
+    }
+    .nav-sub-list {
+      display: flex; flex-direction: column; gap: 1px;
+      margin: 2px 0 4px 17px;
+      padding-left: 8px;
+      border-left: 1px solid var(--border);
+    }
+    .nav-sub-item {
+      display: flex; align-items: center; gap: 9px;
+      width: 100%; padding: 6px 10px; border-radius: 7px;
+      font-size: 12.5px; font-weight: 500;
+      background: transparent; border: 0; color: var(--fg-muted);
+      text-align: left; text-decoration: none;
+      transition: background .12s ease, color .12s ease; cursor: pointer;
+    }
+    .nav-sub-item svg { width: 14px; height: 14px; flex-shrink: 0; color: var(--fg-subtle); }
+    .nav-sub-item:hover { background: var(--bg-muted); color: var(--fg); }
+    .nav-sub-item.is-disabled { cursor: not-allowed; opacity: 0.55; font-style: italic; }
+    .nav-sub-item.is-disabled:hover { background: transparent; color: var(--fg-muted); }
+
     /* Tablet rail — icons only */
     @media (min-width: 720px) and (max-width: 1179px) {
       aside.side { padding: 14px 8px; }
@@ -201,6 +228,9 @@
       .nav-item { justify-content: center; padding: 10px 6px; }
       .nav-item > span.label, .nav-item .nav-count { display: none; }
       .nav-item svg { width: 20px; height: 20px; }
+      .nav-pages-parent .nav-caret { display: none; }
+      .nav-pages-parent .nav-count { display: none; }
+      .nav-sub-list { display: none; }
     }
 
     /* ── Main content ── */
@@ -821,18 +851,25 @@
       <svg class="chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="8 9 12 5 16 9"/><polyline points="8 15 12 19 16 15"/></svg>
     </div>
 
-    <!-- GROUP 1: Homepage + Add page disabled -->
+    <!-- GROUP 1: Pages (parent always expanded — no JS toggle on Domain page) -->
     <div class="nav-group">
-      <button class="nav-item" data-nav="page" data-tip="Homepage" aria-label="Homepage">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
-        <span class="label">Homepage</span>
-        <span class="nav-count">3</span>
-      </button>
-      <button class="nav-item nav-add-page" aria-disabled="true">
-        <span class="nav-icon">+</span>
-        <span class="nav-label">Add page</span>
-        <span class="nav-pill">soon</span>
-      </button>
+      <a href="./app-dashboard.html?tab=page" class="nav-item nav-pages-parent" data-tip="Pages">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+        <span class="label">Pages</span>
+        <span class="nav-count">1</span>
+        <svg class="nav-caret" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+      </a>
+      <div class="nav-sub-list">
+        <a href="./app-dashboard.html?tab=page" class="nav-sub-item" data-tip="Home">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+          <span>Home</span>
+        </a>
+        <button class="nav-sub-item is-disabled" aria-disabled="true" data-tip="Multi-page coming Q+1 — DEC-MULTIPAGE-01">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+          <span>Add page</span>
+          <span class="nav-pill" style="margin-left:auto;font-size:10px;font-weight:600;padding:1px 6px;border-radius:99px;background:var(--bg-muted);color:var(--fg-subtle);white-space:nowrap">soon</span>
+        </button>
+      </div>
     </div>
 
     <div class="nav-divider"></div>

--- a/mockups/tadaify-mvp/app-domain.html
+++ b/mockups/tadaify-mvp/app-domain.html
@@ -868,10 +868,10 @@
 
     <!-- GROUP 4: Settings + Help -->
     <div class="nav-group" style="padding-top:0">
-      <button class="nav-item" data-nav="settings" data-tip="Settings">
+      <a href="./app-settings.html" class="nav-item" data-nav="settings" data-tip="Settings">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1a1.7 1.7 0 0 0-1-1.5 1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1a1.7 1.7 0 0 0 1.5-1 1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.8.3v0a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8v0a1.7 1.7 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1z"/></svg>
         <span class="label">Settings</span>
-      </button>
+      </a>
       <button class="nav-item" data-tip="Help &amp; docs">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M9.1 9a3 3 0 1 1 5.8 1c0 2-3 3-3 3M12 17h.01"/></svg>
         <span class="label">Help &amp; docs</span>

--- a/mockups/tadaify-mvp/app-settings.html
+++ b/mockups/tadaify-mvp/app-settings.html
@@ -1,0 +1,1780 @@
+<!DOCTYPE html>
+<!--
+  type: mockup
+  project: tadaify
+  title: Settings — /app/settings (F-180..199 Admin & Trust)
+  created_at: 2026-04-25
+  author: orchestrator
+  status: draft-for-review
+
+  Brand: Indigo Serif palette, Crimson Pro display + Inter sans, wordmark ta/da!/ify,
+  Motion v10 logo, light/dark mode toggle.
+
+  Tabs: Account | Billing | Security | GDPR & data | API keys (Pro) | Team (Business) | Danger zone
+
+  DEC trail:
+    AP-010 one-click cancel
+    AP-029 page stays live during dunning (cross-ref)
+    DEC-PRICELOCK-01 (price-lock-for-life shown on Billing card)
+    DEC-PRICELOCK-02 (custom domain add-on line items in Billing)
+    DEC-CREATOR-API-01 (API keys section, Pro-gated)
+    DEC-AI-QUOTA-LADDER-01 (no direct surface but cross-ref in account)
+    DEC-TADAIFY-BILLING-01 (Stripe billing flow)
+    F-COMPLIANCE-001 (GDPR data export + delete)
+    F-LEGAL-003 (ToS acceptance audit cross-link)
+    F-PRO-CREATOR-API-001 (API keys management)
+
+  Anti-patterns: AP-001 / AP-013 / AP-017 / AP-031 — all enforced.
+-->
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Settings — tadaify</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@400;500;600;700&family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="./shared/tokens.css">
+  <style>
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body {
+      background: var(--bg);
+      color: var(--fg);
+      font-family: var(--font-sans);
+      min-height: 100vh;
+    }
+    button { font-family: inherit; cursor: pointer; }
+    a { color: inherit; text-decoration: none; }
+
+    /* -----------------------------------------------------------------------
+       Wordmark — ta / da! / ify
+       --------------------------------------------------------------------- */
+    .wm { font-family: var(--font-display); font-weight: 600; letter-spacing: -0.02em; }
+    .wm .ta  { color: var(--wm-ta); }
+    .wm .da  { color: var(--wm-da); }
+    .wm .ify { color: var(--wm-ify); }
+
+    /* -----------------------------------------------------------------------
+       Shared atoms
+       --------------------------------------------------------------------- */
+    .chip {
+      display: inline-flex; align-items: center; gap: 6px;
+      padding: 3px 9px; border-radius: 999px;
+      font-size: 11px; font-weight: 600; line-height: 1;
+      background: var(--bg-muted); color: var(--fg-muted);
+      white-space: nowrap;
+    }
+    .chip.pro {
+      background: linear-gradient(135deg, rgba(245,158,11,0.15), rgba(245,158,11,0.08));
+      color: var(--brand-warm-dark);
+      border: 1px solid rgba(245,158,11,0.3);
+    }
+    .chip.business {
+      background: linear-gradient(135deg, rgba(99,102,241,0.15), rgba(139,92,246,0.08));
+      color: var(--brand-primary);
+      border: 1px solid rgba(99,102,241,0.3);
+    }
+    .chip.locked-life {
+      background: rgba(245,158,11,0.12); color: var(--brand-warm-dark);
+      border: 1px solid rgba(245,158,11,0.25);
+    }
+    .chip.danger { background: var(--danger-bg); color: #991B1B; }
+    .chip.success { background: var(--success-bg); color: #065F46; }
+
+    .btn {
+      font-family: var(--font-sans); font-weight: 500; font-size: 14px;
+      border-radius: 10px; padding: 9px 16px;
+      border: 1px solid transparent; cursor: pointer;
+      display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+      transition: all .15s ease;
+      line-height: 1.2;
+    }
+    .btn-primary { background: var(--brand-primary); color: #fff; }
+    .btn-primary:hover { background: var(--brand-primary-hover); }
+    .btn-ghost   { background: var(--bg-elevated); color: var(--fg); border-color: var(--border-strong); }
+    .btn-ghost:hover { background: var(--bg-muted); }
+    .btn-danger  { background: var(--danger); color: #fff; }
+    .btn-danger:hover { background: #DC2626; }
+    .btn-danger-ghost { background: var(--bg-elevated); color: var(--danger); border-color: var(--danger); }
+    .btn-danger-ghost:hover { background: var(--danger-bg); }
+    .btn-sm      { padding: 6px 12px; font-size: 13px; border-radius: 8px; }
+    .btn-xs      { padding: 4px 9px; font-size: 12px; border-radius: 6px; }
+    .btn:disabled { opacity: 0.45; cursor: not-allowed; }
+
+    .iconbtn {
+      display: inline-flex; align-items: center; justify-content: center;
+      width: 32px; height: 32px; border-radius: 8px;
+      background: transparent; border: 1px solid transparent; color: var(--fg-muted);
+      transition: all .12s ease;
+    }
+    .iconbtn:hover { background: var(--bg-muted); color: var(--fg); }
+    .iconbtn svg { width: 16px; height: 16px; }
+
+    /* Toggle switch */
+    .toggle {
+      position: relative; display: inline-block;
+      width: 38px; height: 22px;
+      background: var(--bg-sunken); border-radius: 999px;
+      cursor: pointer; transition: background .15s ease;
+      flex-shrink: 0; border: 0;
+    }
+    .toggle::after {
+      content: ""; position: absolute; top: 3px; left: 3px;
+      width: 16px; height: 16px; border-radius: 50%;
+      background: #fff;
+      box-shadow: 0 1px 2px rgba(0,0,0,0.15);
+      transition: left .15s ease;
+    }
+    .toggle.on { background: var(--brand-primary); }
+    .toggle.on::after { left: 19px; }
+    .toggle.disabled { opacity: 0.5; cursor: not-allowed; }
+
+    /* -----------------------------------------------------------------------
+       Top app bar
+       --------------------------------------------------------------------- */
+    .appbar {
+      position: sticky; top: 0; z-index: 40;
+      background: var(--bg-elevated);
+      border-bottom: 1px solid var(--border);
+      padding: 10px 16px;
+      display: flex; align-items: center; gap: 14px;
+      box-shadow: 0 1px 0 rgba(17,24,39,0.02);
+    }
+    .appbar .brand { display: flex; align-items: center; gap: 10px; }
+    .appbar .brand .wm { font-size: 20px; }
+    .appbar .spacer { flex: 1; }
+    .appbar .handle-pill {
+      display: inline-flex; align-items: center; gap: 8px;
+      padding: 6px 12px; border: 1px solid var(--border); border-radius: 999px;
+      background: var(--bg);
+      font-size: 13px; color: var(--fg-muted);
+    }
+    .appbar .handle-pill b { color: var(--fg); font-weight: 600; }
+    .appbar .handle-pill .live-dot {
+      width: 7px; height: 7px; border-radius: 50%;
+      background: var(--success);
+      box-shadow: 0 0 0 3px rgba(16,185,129,0.18);
+    }
+    .appbar .handle-pill .hide-sm { display: none; }
+    @media (min-width: 640px) { .appbar .handle-pill .hide-sm { display: inline; } }
+    .appbar .theme-toggle { position: relative; }
+    .appbar .theme-toggle svg {
+      width: 18px; height: 18px;
+      transition: opacity .2s ease, transform .3s cubic-bezier(.2,.8,.2,1);
+    }
+    .appbar .theme-icon-moon { position: absolute; opacity: 0; transform: rotate(-30deg) scale(0.6); }
+    body.dark-mode .appbar .theme-icon-sun  { opacity: 0; transform: rotate(30deg) scale(0.6); }
+    body.dark-mode .appbar .theme-icon-moon { opacity: 1; transform: rotate(0) scale(1); }
+
+    /* -----------------------------------------------------------------------
+       Grid layout: sidebar / main
+       --------------------------------------------------------------------- */
+    .layout {
+      display: grid;
+      grid-template-columns: 1fr;
+      min-height: calc(100vh - 54px);
+    }
+    @media (min-width: 720px) {
+      .layout { grid-template-columns: 72px 1fr; }
+    }
+    @media (min-width: 1100px) {
+      .layout { grid-template-columns: 240px 1fr; }
+    }
+
+    /* -----------------------------------------------------------------------
+       Sidebar (left nav — same pattern as app-dashboard.html)
+       --------------------------------------------------------------------- */
+    aside.side {
+      display: none;
+      background: var(--bg-elevated);
+      border-right: 1px solid var(--border);
+      padding: 18px 10px 18px;
+      flex-direction: column; gap: 8px;
+      position: sticky; top: 54px; align-self: start;
+      height: calc(100vh - 54px);
+      overflow-y: auto;
+    }
+    @media (min-width: 720px) { aside.side { display: flex; } }
+
+    .side-user {
+      display: flex; align-items: center; gap: 10px;
+      padding: 8px; border-radius: 10px;
+      border: 1px solid var(--border);
+      background: var(--bg);
+    }
+    .side-user .av {
+      width: 34px; height: 34px; border-radius: 50%;
+      background: var(--hero-gradient);
+      display: flex; align-items: center; justify-content: center;
+      color: #fff; font-family: var(--font-display); font-weight: 600; font-size: 15px;
+      flex-shrink: 0;
+    }
+    .side-user .utxt { min-width: 0; flex: 1; }
+    .side-user .uname { font-size: 13px; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .side-user .uhandle { font-size: 11px; color: var(--fg-muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .side-user .chevron { color: var(--fg-subtle); }
+
+    .nav-group { display: flex; flex-direction: column; gap: 2px; padding-top: 8px; }
+    .nav-group + .nav-group { border-top: 1px solid var(--border); padding-top: 8px; margin-top: 4px; }
+    .nav-item {
+      display: flex; align-items: center; gap: 12px;
+      width: 100%; padding: 9px 10px; border-radius: 9px;
+      font-size: 13.5px; font-weight: 500;
+      background: transparent; border: 0; color: var(--fg);
+      text-align: left; transition: background .12s ease, color .12s ease;
+    }
+    .nav-item svg { width: 17px; height: 17px; flex-shrink: 0; color: var(--fg-muted); }
+    .nav-item:hover { background: var(--bg-muted); }
+    .nav-item.active {
+      background: rgba(99,102,241,0.10);
+      color: var(--brand-primary);
+    }
+    .nav-item.active svg { color: var(--brand-primary); }
+    .nav-item .nav-count {
+      margin-left: auto;
+      font-size: 11px; font-weight: 600;
+      padding: 1px 7px; border-radius: 999px;
+      background: var(--bg-muted); color: var(--fg-muted);
+    }
+    .nav-divider { border-top: 1px solid var(--border); margin: 6px 0; }
+    .nav-add-page {
+      padding-left: 22px !important;
+      cursor: not-allowed !important;
+      opacity: 0.55; font-style: italic;
+    }
+    .nav-add-page .nav-icon { width: 17px; height: 17px; flex-shrink: 0; color: var(--fg-subtle); display: flex; align-items: center; justify-content: center; font-size: 14px; font-weight: 500; }
+    .nav-add-page .nav-pill { margin-left: auto; font-size: 10px; font-weight: 600; padding: 1px 6px; border-radius: 99px; background: var(--bg-muted); color: var(--fg-subtle); white-space: nowrap; }
+    .nav-add-page:hover { background: transparent !important; }
+
+    @media (min-width: 720px) and (max-width: 1099px) {
+      aside.side { padding: 14px 8px; }
+      .side-user .utxt, .side-user .chevron { display: none; }
+      .nav-label { display: none; }
+      .nav-item { justify-content: center; padding: 10px 6px; }
+      .nav-item > span.label, .nav-item .nav-count { display: none; }
+      .nav-item svg { width: 20px; height: 20px; }
+    }
+
+    /* -----------------------------------------------------------------------
+       Main content shell
+       --------------------------------------------------------------------- */
+    main.content {
+      padding: 28px 20px 80px;
+      min-width: 0;
+    }
+    @media (min-width: 720px) { main.content { padding: 28px 32px 60px; } }
+
+    .page-head {
+      display: flex; align-items: flex-end; justify-content: space-between;
+      gap: 16px; flex-wrap: wrap;
+      padding-bottom: 18px; border-bottom: 1px solid var(--border);
+      margin-bottom: 28px;
+    }
+    .page-head h1 {
+      font-family: var(--font-display); font-weight: 600;
+      font-size: 30px; margin: 0; letter-spacing: -0.01em;
+    }
+    .page-head .sub { color: var(--fg-muted); font-size: 13.5px; margin-top: 4px; }
+
+    /* -----------------------------------------------------------------------
+       Settings layout: left sub-nav + right content
+       --------------------------------------------------------------------- */
+    .settings-layout {
+      display: flex;
+      gap: 0;
+      align-items: flex-start;
+    }
+
+    /* Left settings rail */
+    .settings-nav {
+      width: 200px;
+      flex-shrink: 0;
+      display: flex; flex-direction: column; gap: 2px;
+      position: sticky; top: 82px;
+    }
+    .settings-nav-item {
+      display: flex; align-items: center; gap: 10px;
+      width: 100%; padding: 8px 12px; border-radius: 8px;
+      font-size: 13.5px; font-weight: 500;
+      background: transparent; border: 0; color: var(--fg-muted);
+      text-align: left; cursor: pointer;
+      transition: background .12s ease, color .12s ease;
+    }
+    .settings-nav-item svg { width: 16px; height: 16px; flex-shrink: 0; color: var(--fg-subtle); }
+    .settings-nav-item:hover { background: var(--bg-muted); color: var(--fg); }
+    .settings-nav-item.active {
+      background: rgba(99,102,241,0.10);
+      color: var(--brand-primary);
+      font-weight: 600;
+    }
+    .settings-nav-item.active svg { color: var(--brand-primary); }
+    .settings-nav-divider { border-top: 1px solid var(--border); margin: 8px 0; }
+
+    .settings-nav-item .sn-pill {
+      margin-left: auto;
+      font-size: 10px; font-weight: 700; padding: 1px 6px; border-radius: 99px;
+      white-space: nowrap;
+    }
+    .settings-nav-item .sn-pill.pro-pill {
+      background: rgba(245,158,11,0.15); color: var(--brand-warm-dark);
+      border: 1px solid rgba(245,158,11,0.25);
+    }
+    .settings-nav-item .sn-pill.biz-pill {
+      background: rgba(99,102,241,0.12); color: var(--brand-primary);
+      border: 1px solid rgba(99,102,241,0.25);
+    }
+
+    /* Mobile settings nav — horizontal scroll */
+    @media (max-width: 719px) {
+      .settings-layout { flex-direction: column; gap: 0; }
+      .settings-nav {
+        width: 100%; flex-direction: row;
+        overflow-x: auto; -webkit-overflow-scrolling: touch;
+        gap: 4px; padding-bottom: 12px; margin-bottom: 4px;
+        position: static;
+      }
+      .settings-nav-item {
+        white-space: nowrap; flex-shrink: 0;
+        padding: 7px 14px; border-radius: 99px;
+        border: 1px solid var(--border); background: var(--bg-elevated);
+        font-size: 13px;
+      }
+      .settings-nav-item.active {
+        background: rgba(99,102,241,0.10);
+        border-color: rgba(99,102,241,0.25);
+      }
+      .settings-nav-item .sn-pill { display: none; }
+      .settings-nav-divider { display: none; }
+    }
+
+    /* Settings content area */
+    .settings-content {
+      flex: 1;
+      min-width: 0;
+      padding-left: 28px;
+      border-left: 1px solid var(--border);
+      min-height: 400px;
+    }
+    @media (max-width: 719px) {
+      .settings-content { padding-left: 0; border-left: none; padding-top: 20px; }
+    }
+
+    /* -----------------------------------------------------------------------
+       Setting panes (show/hide via JS)
+       --------------------------------------------------------------------- */
+    .settings-pane { display: none; }
+    .settings-pane.active { display: block; }
+
+    /* -----------------------------------------------------------------------
+       Section blocks within a pane
+       --------------------------------------------------------------------- */
+    .settings-section {
+      background: var(--bg-elevated);
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      padding: 20px 22px;
+      margin-bottom: 18px;
+    }
+    .settings-section-title {
+      font-size: 12px; font-weight: 700;
+      text-transform: uppercase; letter-spacing: 0.08em;
+      color: var(--fg-subtle); margin-bottom: 14px;
+    }
+    .settings-section-title.with-action {
+      display: flex; align-items: center; justify-content: space-between;
+    }
+    .settings-section.danger-zone {
+      border-color: rgba(239,68,68,0.3);
+      background: rgba(239,68,68,0.02);
+      position: relative;
+    }
+    .danger-zone-divider {
+      border: 0;
+      border-top: 1px solid rgba(239,68,68,0.25);
+      margin: 0 0 18px;
+    }
+    .settings-section.danger-zone::before {
+      content: '';
+      position: absolute;
+      top: -1px; left: 20px; right: 20px;
+      height: 2px;
+      background: linear-gradient(90deg, transparent, rgba(239,68,68,0.4), transparent);
+      border-radius: 1px;
+    }
+
+    /* Field layout */
+    .field-row {
+      display: flex; align-items: flex-start; gap: 16px;
+      padding: 14px 0;
+      border-bottom: 1px solid var(--border);
+    }
+    .field-row:last-child { border-bottom: 0; padding-bottom: 0; }
+    .field-row:first-child { padding-top: 0; }
+    .field-label {
+      width: 160px; flex-shrink: 0;
+      font-size: 13.5px; font-weight: 600; color: var(--fg);
+      padding-top: 2px;
+    }
+    .field-label .field-hint {
+      display: block; font-size: 12px; font-weight: 400; color: var(--fg-muted); margin-top: 2px;
+    }
+    .field-body { flex: 1; min-width: 0; }
+
+    @media (max-width: 599px) {
+      .field-row { flex-direction: column; gap: 6px; }
+      .field-label { width: auto; }
+    }
+
+    /* Inputs */
+    .field-input {
+      font-family: var(--font-sans); font-size: 14px;
+      padding: 9px 12px; border-radius: 9px;
+      border: 1px solid var(--border-strong);
+      background: var(--bg); color: var(--fg);
+      outline: none; transition: border-color .12s ease, box-shadow .12s ease;
+      width: 100%;
+    }
+    .field-input:focus {
+      border-color: var(--brand-primary);
+      box-shadow: 0 0 0 3px rgba(99,102,241,0.15);
+    }
+    .field-input[readonly] {
+      background: var(--bg-muted); color: var(--fg-muted); cursor: default;
+    }
+    textarea.field-input { resize: vertical; min-height: 72px; }
+    .field-counter { font-size: 11.5px; color: var(--fg-subtle); text-align: right; margin-top: 4px; }
+
+    .avatar-upload-row {
+      display: flex; align-items: center; gap: 14px;
+    }
+    .avatar-circle {
+      width: 64px; height: 64px; border-radius: 50%;
+      background: var(--hero-gradient);
+      display: flex; align-items: center; justify-content: center;
+      color: #fff; font-family: var(--font-display); font-weight: 600; font-size: 24px;
+      flex-shrink: 0;
+      box-shadow: 0 4px 12px rgba(99,102,241,0.2);
+    }
+    .avatar-btns { display: flex; gap: 8px; flex-wrap: wrap; }
+
+    /* Sticky save bar */
+    .save-bar {
+      position: sticky; bottom: 0;
+      background: var(--bg-elevated);
+      border-top: 1px solid var(--border);
+      padding: 12px 22px;
+      display: flex; align-items: center; justify-content: space-between;
+      gap: 12px;
+      margin: 18px -22px -20px;
+      border-radius: 0 0 14px 14px;
+    }
+    .save-bar .save-hint { font-size: 12.5px; color: var(--fg-muted); }
+
+    /* -----------------------------------------------------------------------
+       Billing tab
+       --------------------------------------------------------------------- */
+    .plan-card {
+      display: flex; align-items: flex-start; gap: 16px;
+      padding: 16px 0;
+    }
+    .plan-card .plan-icon {
+      width: 44px; height: 44px; border-radius: 12px;
+      background: rgba(99,102,241,0.1);
+      display: flex; align-items: center; justify-content: center;
+      font-size: 22px; flex-shrink: 0;
+    }
+    .plan-card .plan-name { font-size: 18px; font-family: var(--font-display); font-weight: 600; }
+    .plan-card .plan-price { font-size: 13px; color: var(--fg-muted); margin-top: 2px; }
+    .plan-card .plan-badges { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 6px; }
+
+    .payment-card {
+      display: flex; align-items: center; gap: 12px; padding: 14px 0;
+      border-bottom: 1px solid var(--border);
+    }
+    .payment-card:last-child { border-bottom: 0; }
+    .card-brand-pill {
+      padding: 3px 8px; border-radius: 6px;
+      background: var(--bg-muted); font-size: 12px; font-weight: 600;
+      color: var(--fg-muted); font-family: var(--font-mono);
+    }
+
+    .invoice-table { width: 100%; border-collapse: collapse; }
+    .invoice-table th {
+      text-align: left; font-size: 11px; text-transform: uppercase;
+      letter-spacing: 0.06em; color: var(--fg-subtle); font-weight: 600;
+      padding: 6px 8px; border-bottom: 1px solid var(--border);
+    }
+    .invoice-table td {
+      padding: 10px 8px; font-size: 13px; color: var(--fg-muted);
+      border-bottom: 1px solid var(--border);
+    }
+    .invoice-table tr:last-child td { border-bottom: 0; }
+    .invoice-table td:nth-child(2) { font-family: var(--font-mono); font-size: 12.5px; }
+    .invoice-table .status-paid {
+      display: inline-flex; align-items: center; gap: 4px;
+      font-size: 11px; font-weight: 600;
+      background: var(--success-bg); color: #065F46;
+      padding: 2px 8px; border-radius: 999px;
+    }
+
+    .domain-addon-row {
+      display: flex; align-items: center; gap: 10px;
+      padding: 10px 0; border-bottom: 1px solid var(--border);
+      font-size: 13.5px;
+    }
+    .domain-addon-row:last-child { border-bottom: 0; }
+    .domain-addon-row .da-name { flex: 1; font-weight: 500; }
+    .domain-addon-row .da-price { color: var(--fg-muted); font-size: 12.5px; }
+
+    /* -----------------------------------------------------------------------
+       Security tab
+       --------------------------------------------------------------------- */
+    .session-row {
+      display: flex; align-items: flex-start; gap: 12px;
+      padding: 12px 0; border-bottom: 1px solid var(--border);
+    }
+    .session-row:last-child { border-bottom: 0; }
+    .session-icon {
+      width: 36px; height: 36px; border-radius: 9px;
+      background: var(--bg-muted); color: var(--fg-muted);
+      display: flex; align-items: center; justify-content: center;
+      flex-shrink: 0; font-size: 17px;
+    }
+    .session-info { flex: 1; min-width: 0; }
+    .session-info .s-device { font-size: 13.5px; font-weight: 600; color: var(--fg); }
+    .session-info .s-meta { font-size: 12px; color: var(--fg-muted); margin-top: 2px; }
+    .session-current { font-size: 11px; font-weight: 700; color: var(--brand-primary); background: rgba(99,102,241,0.1); padding: 1px 7px; border-radius: 99px; }
+
+    .log-row {
+      display: flex; align-items: center; gap: 10px;
+      padding: 9px 0; border-bottom: 1px solid var(--border);
+      font-size: 13px;
+    }
+    .log-row:last-child { border-bottom: 0; }
+    .log-row .lr-icon { font-size: 15px; width: 22px; text-align: center; flex-shrink: 0; }
+    .log-row .lr-event { flex: 1; color: var(--fg); }
+    .log-row .lr-time { color: var(--fg-muted); font-size: 12px; white-space: nowrap; }
+    .log-row .lr-ip { color: var(--fg-subtle); font-size: 11.5px; font-family: var(--font-mono); }
+
+    /* -----------------------------------------------------------------------
+       API keys tab
+       --------------------------------------------------------------------- */
+    .api-key-row {
+      display: flex; align-items: flex-start; gap: 12px;
+      padding: 14px 0; border-bottom: 1px solid var(--border);
+    }
+    .api-key-row:last-child { border-bottom: 0; }
+    .api-key-info { flex: 1; min-width: 0; }
+    .api-key-label { font-size: 13.5px; font-weight: 600; color: var(--fg); }
+    .api-key-meta { font-size: 12px; color: var(--fg-muted); margin-top: 3px; }
+    .api-key-token {
+      font-family: var(--font-mono); font-size: 12.5px;
+      color: var(--fg-muted); background: var(--bg-muted);
+      padding: 3px 8px; border-radius: 5px; display: inline-block;
+      margin-top: 4px;
+    }
+
+    .code-block {
+      background: var(--bg-dark); color: #E2E8F0;
+      font-family: var(--font-mono); font-size: 12.5px; line-height: 1.6;
+      padding: 14px 16px; border-radius: 10px;
+      overflow-x: auto; position: relative;
+    }
+    .code-block .code-copy {
+      position: absolute; top: 8px; right: 8px;
+      background: rgba(255,255,255,0.08); border: 1px solid rgba(255,255,255,0.15);
+      color: rgba(255,255,255,0.7); font-size: 11.5px; font-weight: 600;
+      padding: 3px 9px; border-radius: 6px; cursor: pointer; font-family: var(--font-sans);
+    }
+    .code-block .code-copy:hover { background: rgba(255,255,255,0.15); color: #fff; }
+    .code-comment { color: #6B7280; }
+    .code-key { color: #93C5FD; }
+    .code-str { color: #86EFAC; }
+    .code-num { color: #FCA5A5; }
+
+    .webhook-placeholder {
+      border: 2px dashed var(--border-strong);
+      border-radius: 12px; padding: 20px;
+      text-align: center; color: var(--fg-muted);
+      font-size: 13.5px;
+    }
+    .webhook-placeholder .wh-icon { font-size: 28px; margin-bottom: 6px; }
+
+    .rate-info {
+      display: flex; align-items: center; gap: 10px;
+      padding: 10px 14px;
+      background: var(--bg-muted); border-radius: 9px;
+      font-size: 13px; color: var(--fg-muted);
+    }
+    .rate-info svg { width: 15px; height: 15px; color: var(--fg-subtle); flex-shrink: 0; }
+
+    /* Locked state for gated features */
+    .locked-state {
+      padding: 28px 0; text-align: center;
+    }
+    .locked-state .ls-icon { font-size: 36px; margin-bottom: 10px; }
+    .locked-state .ls-title { font-family: var(--font-display); font-size: 20px; font-weight: 600; margin-bottom: 6px; }
+    .locked-state .ls-sub { font-size: 13.5px; color: var(--fg-muted); margin-bottom: 16px; }
+
+    /* -----------------------------------------------------------------------
+       Team tab
+       --------------------------------------------------------------------- */
+    .seats-bar-wrap { margin-bottom: 14px; }
+    .seats-label { font-size: 13px; color: var(--fg-muted); margin-bottom: 6px; display: flex; justify-content: space-between; }
+    .seats-bar {
+      height: 6px; background: var(--bg-sunken); border-radius: 999px;
+      overflow: hidden;
+    }
+    .seats-bar-fill {
+      height: 100%; background: var(--brand-primary); border-radius: 999px;
+    }
+
+    .member-row {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 0; border-bottom: 1px solid var(--border);
+    }
+    .member-row:last-child { border-bottom: 0; }
+    .member-av {
+      width: 32px; height: 32px; border-radius: 50%;
+      background: var(--hero-gradient);
+      display: flex; align-items: center; justify-content: center;
+      color: #fff; font-weight: 600; font-size: 13px;
+      flex-shrink: 0;
+    }
+    .member-info { flex: 1; min-width: 0; }
+    .member-name { font-size: 13.5px; font-weight: 600; }
+    .member-email { font-size: 12px; color: var(--fg-muted); }
+    .member-role {
+      font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 999px;
+      background: var(--bg-muted); color: var(--fg-muted);
+    }
+    .member-role.owner { background: rgba(99,102,241,0.12); color: var(--brand-primary); }
+
+    /* -----------------------------------------------------------------------
+       Modals
+       --------------------------------------------------------------------- */
+    .modal-backdrop {
+      display: none;
+      position: fixed; inset: 0; z-index: 100;
+      background: rgba(0,0,0,0.45);
+      backdrop-filter: blur(3px);
+      -webkit-backdrop-filter: blur(3px);
+      align-items: center; justify-content: center;
+      padding: 16px;
+    }
+    .modal-backdrop.open { display: flex; }
+    .modal {
+      background: var(--bg-elevated);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      padding: 24px 26px;
+      width: 100%; max-width: 440px;
+      box-shadow: 0 24px 60px rgba(17,24,39,0.18);
+      animation: modalIn .18s ease;
+    }
+    @keyframes modalIn {
+      from { opacity: 0; transform: scale(0.97) translateY(6px); }
+      to   { opacity: 1; transform: scale(1) translateY(0); }
+    }
+    .modal h3 { font-family: var(--font-display); font-size: 22px; margin: 0 0 6px; }
+    .modal .modal-sub { font-size: 13.5px; color: var(--fg-muted); margin-bottom: 18px; line-height: 1.5; }
+    .modal .modal-actions { display: flex; gap: 10px; justify-content: flex-end; margin-top: 18px; flex-wrap: wrap; }
+    .modal .modal-close-x {
+      position: absolute; top: 16px; right: 16px;
+      background: transparent; border: 0; color: var(--fg-muted);
+      font-size: 20px; width: 32px; height: 32px; border-radius: 6px;
+      display: flex; align-items: center; justify-content: center;
+    }
+    .modal .modal-close-x:hover { background: var(--bg-muted); color: var(--fg); }
+    .modal { position: relative; }
+
+    .modal-warning {
+      background: rgba(239,68,68,0.06);
+      border: 1px solid rgba(239,68,68,0.2);
+      border-radius: 10px; padding: 12px 14px;
+      font-size: 13px; color: var(--danger);
+      margin-bottom: 14px; line-height: 1.5;
+    }
+
+    /* -----------------------------------------------------------------------
+       GDPR cookie row
+       --------------------------------------------------------------------- */
+    .cookie-row {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 12px 0; border-bottom: 1px solid var(--border);
+    }
+    .cookie-row:last-child { border-bottom: 0; }
+    .cookie-info { flex: 1; padding-right: 12px; }
+    .cookie-name { font-size: 13.5px; font-weight: 600; }
+    .cookie-desc { font-size: 12px; color: var(--fg-muted); margin-top: 2px; }
+
+    /* -----------------------------------------------------------------------
+       Dark mode overrides
+       --------------------------------------------------------------------- */
+    body.dark-mode {
+      --bg:          #0B0F1E;
+      --bg-elevated: #141A2D;
+      --bg-muted:    #1A2236;
+      --bg-sunken:   #222A3E;
+      --fg:          #F3F4F6;
+      --fg-muted:    #9CA3AF;
+      --fg-subtle:   #4B5563;
+      --border:      #1F2937;
+      --border-strong: #374151;
+      --wm-ify: #F3F4F6;
+    }
+    body.dark-mode .appbar { background: rgba(11,15,30,0.9); border-bottom-color: #1F2937; }
+    body.dark-mode .appbar .wm .ify { color: #F3F4F6; }
+    body.dark-mode .appbar .handle-pill { background: #141A2D; border-color: #1F2937; }
+    body.dark-mode .appbar .handle-pill b { color: #F3F4F6; }
+    body.dark-mode aside.side { background: #141A2D; border-right-color: #1F2937; }
+    body.dark-mode .side-user { background: #0B0F1E; border-color: #1F2937; }
+    body.dark-mode .nav-item { color: #9CA3AF; }
+    body.dark-mode .nav-item:hover { background: #1F2937; color: #F3F4F6; }
+    body.dark-mode .nav-item.active { background: rgba(99,102,241,0.18); color: #A5B4FC; }
+    body.dark-mode .nav-item.active svg { color: #A5B4FC; }
+    body.dark-mode .settings-nav-item { color: #9CA3AF; }
+    body.dark-mode .settings-nav-item:hover { background: #1F2937; color: #F3F4F6; }
+    body.dark-mode .settings-nav-item.active { background: rgba(99,102,241,0.18); color: #A5B4FC; }
+    body.dark-mode .settings-nav-item.active svg { color: #A5B4FC; }
+    body.dark-mode .settings-section { background: #141A2D; border-color: #1F2937; }
+    body.dark-mode .field-input { background: #0B0F1E; border-color: #374151; color: #F3F4F6; }
+    body.dark-mode .field-input[readonly] { background: #1A2236; color: #6B7280; }
+    body.dark-mode .invoice-table th { color: #6B7280; border-bottom-color: #1F2937; }
+    body.dark-mode .invoice-table td { border-bottom-color: #1F2937; color: #9CA3AF; }
+    body.dark-mode .modal { background: #141A2D; border-color: #1F2937; }
+    body.dark-mode .save-bar { background: #141A2D; border-top-color: #1F2937; }
+    body.dark-mode .settings-content { border-left-color: #1F2937; }
+    body.dark-mode .page-head { border-bottom-color: #1F2937; }
+  </style>
+</head>
+<body>
+
+<!-- ============================================================
+     TOP APP BAR
+     ============================================================ -->
+<header class="appbar" role="banner">
+  <div class="brand">
+    <a href="./index.html" style="display:flex;align-items:center;gap:10px;text-decoration:none">
+      <span class="logo-mark" data-logo style="width:28px;height:28px"></span>
+      <span class="wm" aria-label="tadaify" style="font-size:20px">
+        <span class="ta">ta</span><span class="da">da!</span><span class="ify">ify</span>
+      </span>
+    </a>
+  </div>
+
+  <a href="./creator-public.html" target="_blank" class="handle-pill" title="View your live page" style="margin-left:10px">
+    <span class="live-dot" aria-hidden="true"></span>
+    <span class="hide-sm">tadaify.com/</span><b id="handle-text">alexandra</b>
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="opacity:0.5"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+  </a>
+
+  <div class="spacer"></div>
+
+  <button class="iconbtn theme-toggle" onclick="toggleTheme()" aria-label="Toggle dark mode" title="Toggle dark mode">
+    <svg class="theme-icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+    <svg class="theme-icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+  </button>
+</header>
+
+<!-- ============================================================
+     LAYOUT
+     ============================================================ -->
+<div class="layout" id="layout">
+
+  <!-- ====== PRIMARY SIDEBAR ====== -->
+  <aside class="side" aria-label="Primary navigation">
+    <div class="side-user">
+      <div class="av">A</div>
+      <div class="utxt">
+        <div class="uname">Alexandra Silva</div>
+        <div class="uhandle">@alexandra · Creator</div>
+      </div>
+      <svg class="chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="8 9 12 5 16 9"/><polyline points="8 15 12 19 16 15"/></svg>
+    </div>
+
+    <!-- GROUP 1: Homepage + Add page -->
+    <div class="nav-group">
+      <a href="./app-dashboard.html?tab=page" class="nav-item" data-tip="Homepage">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+        <span class="label">Homepage</span>
+        <span class="nav-count">3</span>
+      </a>
+      <button class="nav-item nav-add-page" aria-disabled="true">
+        <span class="nav-icon">+</span>
+        <span class="nav-label">Add page</span>
+        <span class="nav-pill">soon</span>
+      </button>
+    </div>
+
+    <div class="nav-divider"></div>
+
+    <!-- GROUP 2: Design + Domain -->
+    <div class="nav-group" style="padding-top:0">
+      <a href="./app-dashboard.html?tab=design" class="nav-item" data-tip="Design">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="13.5" cy="6.5" r=".5" fill="currentColor"/><circle cx="17.5" cy="10.5" r=".5" fill="currentColor"/><circle cx="8.5" cy="7.5" r=".5" fill="currentColor"/><circle cx="6.5" cy="12.5" r=".5" fill="currentColor"/><path d="M12 2A10 10 0 0 0 2 12a10 10 0 0 0 10 10c1.4 0 2-.8 2-1.8 0-.5-.2-.9-.5-1.2-.3-.3-.5-.7-.5-1.2 0-1 .8-1.8 1.8-1.8H17a5 5 0 0 0 5-5c0-4.9-4.5-9-10-9z"/></svg>
+        <span class="label">Design</span>
+      </a>
+      <a href="./app-domain.html" class="nav-item" data-tip="Custom domain">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+        <span class="label">Domain</span>
+      </a>
+    </div>
+
+    <div class="nav-divider"></div>
+
+    <!-- GROUP 3: Insights + Shop (placeholders) -->
+    <div class="nav-group" style="padding-top:0">
+      <button class="nav-item" data-tip="Insights — coming soon" onclick="alert('Mockup — Insights coming Q+1')">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><path d="M7 14l4-4 4 4 5-7"/></svg>
+        <span class="label">Insights</span>
+      </button>
+      <button class="nav-item" data-tip="Shop — coming soon" onclick="alert('Mockup — Shop coming Q+1')">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="21" r="1"/><circle cx="20" cy="21" r="1"/><path d="M1 1h4l2.7 13.4a2 2 0 0 0 2 1.6h9.7a2 2 0 0 0 2-1.6L23 6H6"/></svg>
+        <span class="label">Shop</span>
+        <span class="nav-count">0</span>
+      </button>
+    </div>
+
+    <div class="nav-divider"></div>
+
+    <!-- GROUP 4: Settings ACTIVE + Help -->
+    <div class="nav-group" style="padding-top:0">
+      <a href="./app-settings.html" class="nav-item active" aria-current="page" data-tip="Settings">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1a1.7 1.7 0 0 0-1-1.5 1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1a1.7 1.7 0 0 0 1.5-1 1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.8.3h0a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8v0a1.7 1.7 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1z"/></svg>
+        <span class="label">Settings</span>
+      </a>
+      <button class="nav-item" data-tip="Help &amp; docs" onclick="alert('Mockup — Help & docs')">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M9.1 9a3 3 0 1 1 5.8 1c0 2-3 3-3 3M12 17h.01"/></svg>
+        <span class="label">Help &amp; docs</span>
+      </button>
+    </div>
+  </aside>
+
+  <!-- ====== MAIN CONTENT ====== -->
+  <main class="content">
+
+    <!-- Page header -->
+    <div class="page-head">
+      <div>
+        <h1>Settings</h1>
+        <div class="sub">Manage your account, billing, security, and data.</div>
+      </div>
+    </div>
+
+    <!-- Settings layout: left rail + content -->
+    <div class="settings-layout">
+
+      <!-- Settings sub-navigation (left rail) -->
+      <nav class="settings-nav" aria-label="Settings sections">
+        <button class="settings-nav-item active" data-tab="account" onclick="switchTab('account', this)">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+          Account
+        </button>
+        <button class="settings-nav-item" data-tab="billing" onclick="switchTab('billing', this)">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="4" width="22" height="16" rx="2" ry="2"/><line x1="1" y1="10" x2="23" y2="10"/></svg>
+          Billing
+        </button>
+        <button class="settings-nav-item" data-tab="security" onclick="switchTab('security', this)">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+          Security
+        </button>
+        <button class="settings-nav-item" data-tab="gdpr" onclick="switchTab('gdpr', this)">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><polyline points="9 12 11 14 15 10"/></svg>
+          GDPR &amp; data
+        </button>
+        <div class="settings-nav-divider"></div>
+        <button class="settings-nav-item" data-tab="api" onclick="switchTab('api', this)">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
+          API keys
+          <span class="sn-pill pro-pill">Pro</span>
+        </button>
+        <button class="settings-nav-item" data-tab="team" onclick="switchTab('team', this)">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+          Team
+          <span class="sn-pill biz-pill">Business</span>
+        </button>
+        <div class="settings-nav-divider"></div>
+        <button class="settings-nav-item" data-tab="danger" onclick="switchTab('danger', this)"
+          style="color:var(--danger)">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--danger)"><polygon points="10.29 3.86 1.82 18 22.18 18 13.71 3.86 10.29 3.86"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+          Danger zone
+        </button>
+      </nav>
+
+      <!-- Settings content area -->
+      <div class="settings-content">
+
+        <!-- ==================================================
+             ACCOUNT TAB
+             ================================================== -->
+        <div class="settings-pane active" id="pane-account">
+
+          <!-- Avatar section -->
+          <div class="settings-section">
+            <div class="settings-section-title">Profile photo</div>
+            <div class="avatar-upload-row">
+              <div class="avatar-circle" id="avatar-preview">A</div>
+              <div>
+                <div class="avatar-btns">
+                  <button class="btn btn-ghost btn-sm" onclick="alert('Mockup — would open file picker')">
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="16 16 12 12 8 16"/><line x1="12" y1="12" x2="12" y2="21"/><path d="M20.4 7A8 8 0 1 0 4 11"/></svg>
+                    Upload photo
+                  </button>
+                  <button class="btn btn-ghost btn-sm" onclick="alert('Mockup — would remove photo')">Remove</button>
+                </div>
+                <p style="font-size:12px;color:var(--fg-subtle);margin-top:8px">JPG, PNG, GIF, WebP — max 5 MB</p>
+              </div>
+            </div>
+          </div>
+
+          <!-- Profile fields -->
+          <div class="settings-section">
+            <div class="settings-section-title">Profile</div>
+
+            <div class="field-row">
+              <div class="field-label">Display name</div>
+              <div class="field-body">
+                <input class="field-input" type="text" id="field-name" value="Alexandra Silva"
+                  oninput="markDirty()" placeholder="Your full name or display name">
+              </div>
+            </div>
+
+            <div class="field-row">
+              <div class="field-label">
+                Bio
+                <span class="field-hint">Appears on your public page</span>
+              </div>
+              <div class="field-body">
+                <textarea class="field-input" id="field-bio" oninput="updateCounter(this, 80, 'bio-count'); markDirty()" placeholder="Tell visitors who you are…">Photographer, traveller, and content creator based in Lisbon 🇵🇹</textarea>
+                <div class="field-counter"><span id="bio-count">56</span>/80</div>
+              </div>
+            </div>
+
+            <div class="field-row">
+              <div class="field-label">Pronouns <span class="field-hint">Optional</span></div>
+              <div class="field-body">
+                <input class="field-input" type="text" id="field-pronouns" value="she/her"
+                  oninput="markDirty()" placeholder="e.g. she/her, they/them, he/him">
+              </div>
+            </div>
+
+            <div class="save-bar" id="account-save-bar" style="display:none">
+              <span class="save-hint">You have unsaved changes</span>
+              <div style="display:flex;gap:8px">
+                <button class="btn btn-ghost btn-sm" onclick="discardChanges()">Discard</button>
+                <button class="btn btn-primary btn-sm" onclick="saveChanges()">Save changes</button>
+              </div>
+            </div>
+          </div>
+
+          <!-- Handle & Email (read-only) -->
+          <div class="settings-section">
+            <div class="settings-section-title">Account identity</div>
+
+            <div class="field-row">
+              <div class="field-label">
+                Handle
+                <span class="field-hint">Your public URL slug</span>
+              </div>
+              <div class="field-body">
+                <input class="field-input" type="text" value="@alexandra" readonly>
+                <p style="font-size:12px;color:var(--fg-muted);margin-top:6px">
+                  Handle changes require manual review — <a href="mailto:support@tadaify.com" style="color:var(--brand-primary)">contact support</a>.
+                </p>
+              </div>
+            </div>
+
+            <div class="field-row">
+              <div class="field-label">Email</div>
+              <div class="field-body">
+                <input class="field-input" type="email" value="alexandra@example.com" readonly>
+                <p style="font-size:12px;color:var(--fg-muted);margin-top:6px">
+                  <button onclick="document.getElementById('change-email-modal').classList.add('open')"
+                    style="background:none;border:0;padding:0;color:var(--brand-primary);font-size:12px;cursor:pointer;font-family:var(--font-sans)">
+                    Change email →
+                  </button>
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <!-- Hint cross-link to GDPR -->
+          <p style="font-size:12.5px;color:var(--fg-muted);margin-top:-4px">
+            Want to delete your account?
+            <button onclick="switchTab('gdpr', document.querySelector('[data-tab=gdpr]'))"
+              style="background:none;border:0;padding:0;color:var(--brand-primary);font-size:12.5px;cursor:pointer;font-family:var(--font-sans)">
+              Go to GDPR &amp; data →
+            </button>
+          </p>
+        </div>
+
+        <!-- ==================================================
+             BILLING TAB
+             ================================================== -->
+        <div class="settings-pane" id="pane-billing">
+
+          <!-- Current plan -->
+          <div class="settings-section">
+            <div class="settings-section-title with-action">
+              Current plan
+              <button class="btn btn-ghost btn-sm" onclick="alert('Mockup — would open upgrade modal linking to pricing.html')">Change plan</button>
+            </div>
+            <div class="plan-card">
+              <div class="plan-icon">✨</div>
+              <div>
+                <div class="plan-name">Creator</div>
+                <div class="plan-price">$8/mo · renews Dec 1, 2026</div>
+                <div class="plan-badges">
+                  <span class="chip locked-life">🔒 Locked for life at $8/mo</span>
+                  <span class="chip success">Active</span>
+                </div>
+              </div>
+            </div>
+            <p style="font-size:12px;color:var(--fg-muted);margin-top:6px">
+              Your price is locked forever per our
+              <a href="./pricing.html" style="color:var(--brand-primary)">price-lock-for-life guarantee</a>.
+              Upgrading to a higher tier locks your new price.
+            </p>
+          </div>
+
+          <!-- Payment method -->
+          <div class="settings-section">
+            <div class="settings-section-title with-action">
+              Payment method
+              <button class="btn btn-ghost btn-sm" onclick="alert('Mockup — would open Stripe payment update')">Update</button>
+            </div>
+            <div class="payment-card">
+              <span class="card-brand-pill">Visa</span>
+              <span style="font-size:13.5px;color:var(--fg)">•••• •••• •••• 4242</span>
+              <span style="font-size:12px;color:var(--fg-muted);margin-left:auto">Expires 08/27</span>
+            </div>
+          </div>
+
+          <!-- Invoices -->
+          <div class="settings-section">
+            <div class="settings-section-title">Invoices (last 12 months)</div>
+            <div style="overflow-x:auto">
+              <table class="invoice-table">
+                <thead>
+                  <tr>
+                    <th>Date</th>
+                    <th>Amount</th>
+                    <th>Status</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr><td>Apr 1, 2026</td><td>$8.00</td><td><span class="status-paid">✓ Paid</span></td><td><button class="btn btn-ghost btn-xs" onclick="alert('Mockup — would download PDF')">PDF</button></td></tr>
+                  <tr><td>Mar 1, 2026</td><td>$8.00</td><td><span class="status-paid">✓ Paid</span></td><td><button class="btn btn-ghost btn-xs" onclick="alert('Mockup — would download PDF')">PDF</button></td></tr>
+                  <tr><td>Feb 1, 2026</td><td>$8.00</td><td><span class="status-paid">✓ Paid</span></td><td><button class="btn btn-ghost btn-xs" onclick="alert('Mockup — would download PDF')">PDF</button></td></tr>
+                  <tr><td>Jan 1, 2026</td><td>$8.00</td><td><span class="status-paid">✓ Paid</span></td><td><button class="btn btn-ghost btn-xs" onclick="alert('Mockup — would download PDF')">PDF</button></td></tr>
+                  <tr><td>Dec 1, 2025</td><td>$8.00</td><td><span class="status-paid">✓ Paid</span></td><td><button class="btn btn-ghost btn-xs" onclick="alert('Mockup — would download PDF')">PDF</button></td></tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <!-- Custom domain add-ons -->
+          <div class="settings-section">
+            <div class="settings-section-title with-action">
+              Custom domain add-ons
+              <a href="./app-domain.html" class="btn btn-ghost btn-sm">Manage domains →</a>
+            </div>
+            <div class="domain-addon-row">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+              <span class="da-name">alexandra.com</span>
+              <span class="chip success">Active</span>
+              <span class="da-price">$2/mo</span>
+            </div>
+            <p style="font-size:12px;color:var(--fg-muted);margin-top:8px">
+              Universal $2/mo per domain — every tier. <a href="./app-domain.html" style="color:var(--brand-primary)">Add another domain →</a>
+            </p>
+          </div>
+
+          <!-- Cancel link -->
+          <p style="font-size:12.5px;color:var(--fg-muted);margin-top:-4px">
+            Need to cancel your subscription?
+            <button onclick="switchTab('danger', document.querySelector('[data-tab=danger]'))"
+              style="background:none;border:0;padding:0;color:var(--danger);font-size:12.5px;cursor:pointer;font-family:var(--font-sans)">
+              Go to Danger zone →
+            </button>
+          </p>
+        </div>
+
+        <!-- ==================================================
+             SECURITY TAB
+             ================================================== -->
+        <div class="settings-pane" id="pane-security">
+
+          <!-- Password change -->
+          <div class="settings-section">
+            <div class="settings-section-title">Change password</div>
+            <div class="field-row">
+              <div class="field-label">Current password</div>
+              <div class="field-body"><input class="field-input" type="password" placeholder="••••••••" autocomplete="current-password"></div>
+            </div>
+            <div class="field-row">
+              <div class="field-label">New password</div>
+              <div class="field-body">
+                <input class="field-input" type="password" placeholder="Min. 12 characters" autocomplete="new-password">
+              </div>
+            </div>
+            <div class="field-row">
+              <div class="field-label">Confirm new password</div>
+              <div class="field-body"><input class="field-input" type="password" placeholder="Repeat new password" autocomplete="new-password"></div>
+            </div>
+            <div style="display:flex;justify-content:flex-end;margin-top:14px">
+              <button class="btn btn-primary btn-sm" onclick="alert('Mockup — would update password via API')">Update password</button>
+            </div>
+          </div>
+
+          <!-- 2FA -->
+          <div class="settings-section">
+            <div class="settings-section-title">Two-factor authentication</div>
+            <div class="field-row">
+              <div class="field-label">
+                Authenticator app
+                <span class="field-hint">TOTP (Google Auth, 1Password…)</span>
+              </div>
+              <div class="field-body" style="display:flex;align-items:center;gap:12px">
+                <span style="font-size:13px;color:var(--fg-muted)">Not enabled</span>
+                <button class="btn btn-ghost btn-sm" onclick="alert('Mockup — would start TOTP setup flow (QR code)')">Enable</button>
+              </div>
+            </div>
+            <div class="field-row">
+              <div class="field-label">Backup codes</div>
+              <div class="field-body">
+                <button class="btn btn-ghost btn-sm" onclick="alert('Mockup — would regenerate backup codes (show once)')">Regenerate codes</button>
+                <p style="font-size:12px;color:var(--fg-muted);margin-top:6px">Store these somewhere safe — they can bypass 2FA if you lose your device.</p>
+              </div>
+            </div>
+          </div>
+
+          <!-- Active sessions -->
+          <div class="settings-section">
+            <div class="settings-section-title">Active sessions</div>
+            <div class="session-row">
+              <div class="session-icon">💻</div>
+              <div class="session-info">
+                <div class="s-device">MacBook Pro — Safari 17 <span class="session-current">This session</span></div>
+                <div class="s-meta">Lisbon, Portugal · 212.18.4.22 · Last seen now</div>
+              </div>
+            </div>
+            <div class="session-row">
+              <div class="session-icon">📱</div>
+              <div class="session-info">
+                <div class="s-device">iPhone 15 — Safari Mobile</div>
+                <div class="s-meta">Lisbon, Portugal · 212.18.4.22 · Last seen 2h ago</div>
+              </div>
+              <button class="btn btn-ghost btn-xs" onclick="alert('Mockup — would sign out that session')">Sign out</button>
+            </div>
+            <div class="session-row">
+              <div class="session-icon">💻</div>
+              <div class="session-info">
+                <div class="s-device">Windows 11 — Chrome 124</div>
+                <div class="s-meta">Berlin, Germany · 85.214.38.12 · Last seen 5 days ago</div>
+              </div>
+              <button class="btn btn-ghost btn-xs" onclick="alert('Mockup — would sign out that session')">Sign out</button>
+            </div>
+            <div style="margin-top:12px">
+              <button class="btn btn-ghost btn-sm" onclick="alert('Mockup — would sign out all other sessions')">Sign out all other sessions</button>
+            </div>
+          </div>
+
+          <!-- Login history -->
+          <div class="settings-section">
+            <div class="settings-section-title">Login history (last 30 days)</div>
+            <div class="log-row"><div class="lr-icon">✅</div><div class="lr-event">Signed in — MacBook Pro / Safari</div><div class="lr-ip">212.18.4.22</div><div class="lr-time">Today 09:14</div></div>
+            <div class="log-row"><div class="lr-icon">✅</div><div class="lr-event">Signed in — iPhone 15 / Safari</div><div class="lr-ip">212.18.4.22</div><div class="lr-time">Yesterday 21:02</div></div>
+            <div class="log-row"><div class="lr-icon">✅</div><div class="lr-event">Signed in — MacBook Pro / Safari</div><div class="lr-ip">212.18.4.22</div><div class="lr-time">Apr 22, 08:40</div></div>
+            <div class="log-row"><div class="lr-icon">⚠️</div><div class="lr-event">Failed sign-in attempt</div><div class="lr-ip">85.214.38.12</div><div class="lr-time">Apr 20, 03:17</div></div>
+            <div class="log-row"><div class="lr-icon">✅</div><div class="lr-event">Signed in — Windows 11 / Chrome</div><div class="lr-ip">85.214.38.12</div><div class="lr-time">Apr 18, 22:55</div></div>
+          </div>
+        </div>
+
+        <!-- ==================================================
+             GDPR & DATA TAB
+             ================================================== -->
+        <div class="settings-pane" id="pane-gdpr">
+
+          <!-- Data export -->
+          <div class="settings-section">
+            <div class="settings-section-title">Export your data (GDPR Art. 20)</div>
+            <p style="font-size:13.5px;color:var(--fg-muted);margin-bottom:16px;line-height:1.6">
+              Download everything tadaify holds about you as a single JSON archive.
+              Includes your profile, all pages, all blocks, custom domains, settings, billing history, and consent log.
+            </p>
+            <button class="btn btn-ghost btn-sm" onclick="alert('Mockup — would trigger data export email / download')">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><polyline points="8 17 12 21 16 17"/><line x1="12" y1="12" x2="12" y2="21"/><path d="M20.9 18.6A5 5 0 0 0 18 9h-1.3A8 8 0 1 0 5 17.3"/></svg>
+              Export all my data as JSON
+            </button>
+          </div>
+
+          <!-- Cookie preferences -->
+          <div class="settings-section">
+            <div class="settings-section-title">Cookie preferences</div>
+            <div class="cookie-row">
+              <div class="cookie-info">
+                <div class="cookie-name">Strictly necessary</div>
+                <div class="cookie-desc">Login session, security, CSRF protection. Cannot be disabled.</div>
+              </div>
+              <button class="toggle on disabled" aria-label="Strictly necessary — always on" aria-checked="true" disabled></button>
+            </div>
+            <div class="cookie-row">
+              <div class="cookie-info">
+                <div class="cookie-name">Analytics</div>
+                <div class="cookie-desc">Aggregate usage data to improve tadaify (no personal data sold).</div>
+              </div>
+              <button class="toggle on" id="toggle-analytics" aria-label="Analytics cookies" aria-checked="true"
+                onclick="toggleCookie(this, 'analytics')"></button>
+            </div>
+            <div class="cookie-row">
+              <div class="cookie-info">
+                <div class="cookie-name">Marketing</div>
+                <div class="cookie-desc">Personalised ads and re-marketing. Default off per privacy-by-design.</div>
+              </div>
+              <button class="toggle" id="toggle-marketing" aria-label="Marketing cookies" aria-checked="false"
+                onclick="toggleCookie(this, 'marketing')"></button>
+            </div>
+            <div style="margin-top:14px">
+              <button class="btn btn-ghost btn-sm" onclick="alert('Mockup — would save cookie preferences')">Save preferences</button>
+            </div>
+          </div>
+
+          <!-- Visitor consent log -->
+          <div class="settings-section">
+            <div class="settings-section-title">Visitor consent log</div>
+            <p style="font-size:13.5px;color:var(--fg-muted);margin-bottom:14px;line-height:1.6">
+              We log every cookie consent decision from visitors to your public page — so you can prove GDPR compliance on demand.
+              <a href="#insights-consent" onclick="alert('Mockup — would link to /app/insights/consent-log')" style="color:var(--brand-primary)">View full consent log →</a>
+            </p>
+            <div style="display:flex;gap:20px;flex-wrap:wrap">
+              <div style="text-align:center">
+                <div style="font-family:var(--font-display);font-size:28px;font-weight:600;color:var(--fg)">1,247</div>
+                <div style="font-size:12px;color:var(--fg-muted);margin-top:2px">Total consent events</div>
+              </div>
+              <div style="text-align:center">
+                <div style="font-family:var(--font-display);font-size:28px;font-weight:600;color:var(--success)">94%</div>
+                <div style="font-size:12px;color:var(--fg-muted);margin-top:2px">Accepted analytics</div>
+              </div>
+              <div style="text-align:center">
+                <div style="font-family:var(--font-display);font-size:28px;font-weight:600;color:var(--fg-muted)">12%</div>
+                <div style="font-size:12px;color:var(--fg-muted);margin-top:2px">Accepted marketing</div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Delete account (GDPR section) -->
+          <div class="settings-section danger-zone">
+            <div class="settings-section-title" style="color:var(--danger)">Delete account (GDPR Art. 17)</div>
+            <p style="font-size:13.5px;color:var(--fg-muted);margin-bottom:16px;line-height:1.6">
+              Permanently removes your account, all pages, all blocks, all personal data, and all settings.
+              Custom domains are released immediately. Your subscription is cancelled at the current period end
+              (per AP-029, your pages stay live until then).
+              <strong style="color:var(--fg)">This action cannot be undone.</strong>
+            </p>
+            <button class="btn btn-danger-ghost btn-sm" onclick="document.getElementById('delete-account-modal').classList.add('open')">
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6M14 11v6"/><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/></svg>
+              Delete my account
+            </button>
+          </div>
+        </div>
+
+        <!-- ==================================================
+             API KEYS TAB
+             ================================================== -->
+        <div class="settings-pane" id="pane-api">
+
+          <!-- Tier gate (shown when not on Pro — toggle via demo toolbar) -->
+          <div id="api-locked" class="settings-section" style="display:none">
+            <div class="locked-state">
+              <div class="ls-icon">🔑</div>
+              <div class="ls-title">Creator API is a Pro feature</div>
+              <div class="ls-sub">Programmatically manage your tadaify page, read analytics, and connect Claude / GPT via MCP server.</div>
+              <button class="btn btn-primary" onclick="alert('Mockup — would open upgrade modal linking to pricing.html')">Upgrade to Pro →</button>
+            </div>
+          </div>
+
+          <!-- API keys list (shown when on Pro) -->
+          <div id="api-unlocked">
+            <div class="settings-section">
+              <div class="settings-section-title with-action">
+                API keys
+                <button class="btn btn-primary btn-sm" onclick="document.getElementById('new-key-modal').classList.add('open')">Generate new key</button>
+              </div>
+
+              <div class="api-key-row">
+                <div class="api-key-info">
+                  <div class="api-key-label">My Claude integration</div>
+                  <div class="api-key-meta">Scopes: read, write · Created Apr 10, 2026 · Last used 2h ago</div>
+                  <div class="api-key-token">sk_live_•••••••••••••••••••••abc123</div>
+                </div>
+                <button class="btn btn-ghost btn-xs" onclick="alert('Mockup — would revoke key after confirmation')">Revoke</button>
+              </div>
+
+              <div class="api-key-row">
+                <div class="api-key-info">
+                  <div class="api-key-label">Zapier webhook</div>
+                  <div class="api-key-meta">Scopes: read · Created Mar 28, 2026 · Last used 5 days ago</div>
+                  <div class="api-key-token">sk_live_•••••••••••••••••••••def456</div>
+                </div>
+                <button class="btn btn-ghost btn-xs" onclick="alert('Mockup — would revoke key after confirmation')">Revoke</button>
+              </div>
+
+              <div class="rate-info" style="margin-top:14px">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+                Pro tier rate limit: <strong>1,000 req/h</strong> — resets on the clock hour.
+              </div>
+            </div>
+
+            <!-- MCP server install -->
+            <div class="settings-section">
+              <div class="settings-section-title">MCP server (Claude Desktop)</div>
+              <p style="font-size:13.5px;color:var(--fg-muted);margin-bottom:14px;line-height:1.6">
+                Use your tadaify page as a tool in Claude. The MCP server lets you read/update blocks, query analytics, and publish changes — all from a Claude conversation.
+              </p>
+              <p style="font-size:12.5px;font-weight:600;color:var(--fg-muted);margin-bottom:6px">1. Install</p>
+              <div class="code-block" style="margin-bottom:12px">
+                <button class="code-copy" onclick="alert('Mockup — would copy to clipboard')">Copy</button>
+                npm install -g @tadaify/mcp
+              </div>
+              <p style="font-size:12.5px;font-weight:600;color:var(--fg-muted);margin-bottom:6px">2. Add to Claude Desktop config</p>
+              <div class="code-block">
+                <button class="code-copy" onclick="alert('Mockup — would copy to clipboard')">Copy</button>
+                <span class="code-comment">// ~/.config/claude/claude_desktop_config.json</span><br>
+                {<br>
+                &nbsp;&nbsp;<span class="code-key">"mcpServers"</span>: {<br>
+                &nbsp;&nbsp;&nbsp;&nbsp;<span class="code-key">"tadaify"</span>: {<br>
+                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="code-key">"command"</span>: <span class="code-str">"tadaify-mcp"</span>,<br>
+                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="code-key">"args"</span>: [],<br>
+                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="code-key">"env"</span>: {<br>
+                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="code-key">"TADAIFY_API_KEY"</span>: <span class="code-str">"sk_live_•••abc123"</span><br>
+                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br>
+                &nbsp;&nbsp;&nbsp;&nbsp;}<br>
+                &nbsp;&nbsp;}<br>
+                }
+              </div>
+              <p style="font-size:12px;color:var(--fg-muted);margin-top:10px">
+                Full docs at <a href="#docs-api" style="color:var(--brand-primary)" onclick="alert('Mockup — would link to docs/api')">docs.tadaify.com/api →</a>
+              </p>
+            </div>
+
+            <!-- Custom GPT instructions -->
+            <div class="settings-section">
+              <div class="settings-section-title">Custom GPT instructions template</div>
+              <p style="font-size:13.5px;color:var(--fg-muted);margin-bottom:14px;line-height:1.6">
+                Pre-written system prompt to use tadaify in a Custom GPT. Paste into the "Instructions" field of your GPT builder.
+              </p>
+              <button class="btn btn-ghost btn-sm" onclick="alert('Mockup — would download instructions template .txt')">
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><polyline points="8 17 12 21 16 17"/><line x1="12" y1="12" x2="12" y2="21"/><path d="M20.9 18.6A5 5 0 0 0 18 9h-1.3A8 8 0 1 0 5 17.3"/></svg>
+                Download instructions template
+              </button>
+              <button class="btn btn-ghost btn-sm" onclick="alert('Mockup — would copy instructions to clipboard')">Copy to clipboard</button>
+            </div>
+
+            <!-- Webhooks (placeholder) -->
+            <div class="settings-section">
+              <div class="settings-section-title">Webhook events</div>
+              <div class="webhook-placeholder">
+                <div class="wh-icon">🪝</div>
+                <div style="font-weight:600;margin-bottom:4px">Webhooks — Coming Q+1</div>
+                <div style="font-size:13px">Subscribe to real-time events: page published, block added, domain connected, visitor consent logged.</div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- ==================================================
+             TEAM TAB
+             ================================================== -->
+        <div class="settings-pane" id="pane-team">
+
+          <!-- Tier gate (shown when not on Business) -->
+          <div id="team-locked" style="display:none">
+            <div class="settings-section">
+              <div class="locked-state">
+                <div class="ls-icon">👥</div>
+                <div class="ls-title">Team seats are a Business feature</div>
+                <div class="ls-sub">Invite editors and admins to manage your pages together. Includes audit log and role-based access.</div>
+                <button class="btn btn-primary" onclick="alert('Mockup — would open upgrade modal')">Upgrade to Business →</button>
+              </div>
+            </div>
+          </div>
+
+          <!-- Team view (shown when on Business) -->
+          <div id="team-unlocked">
+            <div class="settings-section">
+              <div class="settings-section-title with-action">
+                Seats
+                <button class="btn btn-primary btn-sm" onclick="document.getElementById('invite-modal').classList.add('open')">Invite member</button>
+              </div>
+              <div class="seats-bar-wrap">
+                <div class="seats-label">
+                  <span>3 of 5 seats used</span>
+                  <span style="color:var(--brand-primary);font-weight:600;font-size:13px">2 available</span>
+                </div>
+                <div class="seats-bar"><div class="seats-bar-fill" style="width:60%"></div></div>
+              </div>
+
+              <div class="member-row">
+                <div class="member-av">A</div>
+                <div class="member-info">
+                  <div class="member-name">Alexandra Silva <span class="member-role owner">Owner</span></div>
+                  <div class="member-email">alexandra@example.com</div>
+                </div>
+                <span style="font-size:12px;color:var(--fg-subtle)">Last active now</span>
+              </div>
+              <div class="member-row">
+                <div class="member-av" style="background:linear-gradient(135deg,#10B981,#059669)">M</div>
+                <div class="member-info">
+                  <div class="member-name">Marta Oliveira <span class="member-role">Editor</span></div>
+                  <div class="member-email">marta@example.com</div>
+                </div>
+                <span style="font-size:12px;color:var(--fg-subtle)">Last active 1h ago</span>
+                <button class="btn btn-ghost btn-xs" style="margin-left:8px" onclick="alert('Mockup — would remove member')">Remove</button>
+              </div>
+              <div class="member-row">
+                <div class="member-av" style="background:linear-gradient(135deg,#F59E0B,#D97706)">J</div>
+                <div class="member-info">
+                  <div class="member-name">João Ferreira <span class="member-role">Viewer</span></div>
+                  <div class="member-email">joao@example.com</div>
+                </div>
+                <span style="font-size:12px;color:var(--fg-subtle)">Last active 3 days ago</span>
+                <button class="btn btn-ghost btn-xs" style="margin-left:8px" onclick="alert('Mockup — would remove member')">Remove</button>
+              </div>
+            </div>
+
+            <!-- Audit log link -->
+            <div class="settings-section">
+              <div class="settings-section-title">Audit log</div>
+              <p style="font-size:13.5px;color:var(--fg-muted);margin-bottom:12px">Full record of member actions: who changed what, when.</p>
+              <button class="btn btn-ghost btn-sm" onclick="alert('Mockup — would link to /app/team/audit-log')">View audit log →</button>
+            </div>
+          </div>
+        </div>
+
+        <!-- ==================================================
+             DANGER ZONE TAB
+             ================================================== -->
+        <div class="settings-pane" id="pane-danger">
+
+          <hr class="danger-zone-divider">
+
+          <!-- Cancel subscription -->
+          <div class="settings-section danger-zone">
+            <div class="settings-section-title" style="color:var(--danger)">Cancel subscription</div>
+            <p style="font-size:13.5px;color:var(--fg-muted);margin-bottom:16px;line-height:1.6">
+              Your subscription stays active until <strong style="color:var(--fg)">Dec 1, 2026</strong>.
+              All your pages remain live during the grace period (AP-029 — pages stay live during dunning).
+              You can reactivate before the period ends and keep your locked price.
+            </p>
+            <button class="btn btn-danger-ghost btn-sm" onclick="document.getElementById('cancel-modal').classList.add('open')">
+              Cancel Creator subscription
+            </button>
+          </div>
+
+          <!-- Reactivate (shown only during cancellation grace period) -->
+          <div class="settings-section" id="reactivate-section" style="display:none;border-color:rgba(245,158,11,0.3);background:rgba(245,158,11,0.02)">
+            <div class="settings-section-title" style="color:var(--brand-warm-dark)">Reactivate subscription</div>
+            <p style="font-size:13.5px;color:var(--fg-muted);margin-bottom:14px;line-height:1.6">
+              Your subscription was cancelled. It expires <strong>Dec 1, 2026</strong>. Reactivate now to keep your locked $8/mo price.
+            </p>
+            <button class="btn btn-primary btn-sm" onclick="alert('Mockup — would reactivate subscription via Stripe')">
+              Reactivate at $8/mo
+            </button>
+          </div>
+
+          <!-- Delete account (cross-link from GDPR) -->
+          <div class="settings-section danger-zone" style="margin-top:18px">
+            <div class="settings-section-title" style="color:var(--danger)">Delete account</div>
+            <p style="font-size:13.5px;color:var(--fg-muted);margin-bottom:14px;line-height:1.6">
+              Permanently removes your account and all associated data. This is separate from cancelling your subscription.
+              For full details see the <button onclick="switchTab('gdpr', document.querySelector('[data-tab=gdpr]'))" style="background:none;border:0;padding:0;color:var(--brand-primary);font-size:13.5px;cursor:pointer;font-family:var(--font-sans)">GDPR &amp; data tab →</button>
+            </p>
+            <button class="btn btn-danger btn-sm" onclick="document.getElementById('delete-account-modal').classList.add('open')">
+              Delete my account
+            </button>
+          </div>
+        </div>
+
+      </div><!-- /.settings-content -->
+    </div><!-- /.settings-layout -->
+
+  </main>
+
+</div><!-- /.layout -->
+
+
+<!-- ============================================================
+     MODALS
+     ============================================================ -->
+
+<!-- Change email modal -->
+<div class="modal-backdrop" id="change-email-modal" onclick="closeModal(this, event)">
+  <div class="modal">
+    <button class="modal-close-x" onclick="this.closest('.modal-backdrop').classList.remove('open')">×</button>
+    <h3>Change email</h3>
+    <p class="modal-sub">We'll send a verification link to your new address. Your current email stays active until you click the link.</p>
+    <div style="display:flex;flex-direction:column;gap:10px">
+      <input class="field-input" type="email" placeholder="New email address" autocomplete="email">
+      <input class="field-input" type="password" placeholder="Confirm your password" autocomplete="current-password">
+    </div>
+    <div class="modal-actions">
+      <button class="btn btn-ghost btn-sm" onclick="this.closest('.modal-backdrop').classList.remove('open')">Cancel</button>
+      <button class="btn btn-primary btn-sm" onclick="alert('Mockup — would send verification email'); this.closest('.modal-backdrop').classList.remove('open')">Send verification link</button>
+    </div>
+  </div>
+</div>
+
+<!-- Cancel subscription modal (AP-010 one-click) -->
+<div class="modal-backdrop" id="cancel-modal" onclick="closeModal(this, event)">
+  <div class="modal">
+    <button class="modal-close-x" onclick="this.closest('.modal-backdrop').classList.remove('open')">×</button>
+    <h3>Cancel Creator subscription?</h3>
+    <p class="modal-sub">
+      Your subscription will remain active until <strong>Dec 1, 2026</strong>. Your pages stay live during that period (AP-029). You can reactivate before then and keep your locked $8/mo price.
+    </p>
+    <div class="modal-warning">
+      No surveys, no guilt trips. If you want to share feedback we'd love to hear it —
+      <a href="mailto:feedback@tadaify.com" style="color:var(--danger)">feedback@tadaify.com</a>
+    </div>
+    <div class="modal-actions">
+      <button class="btn btn-ghost btn-sm" onclick="this.closest('.modal-backdrop').classList.remove('open')">Keep subscription</button>
+      <button class="btn btn-danger btn-sm" onclick="alert('Mockup — would cancel via Stripe API'); this.closest('.modal-backdrop').classList.remove('open')">Cancel subscription</button>
+    </div>
+  </div>
+</div>
+
+<!-- Delete account modal -->
+<div class="modal-backdrop" id="delete-account-modal" onclick="closeModal(this, event)">
+  <div class="modal">
+    <button class="modal-close-x" onclick="this.closest('.modal-backdrop').classList.remove('open')">×</button>
+    <h3 style="color:var(--danger)">Delete account</h3>
+    <p class="modal-sub">
+      This is permanent. All pages, blocks, custom domains, and data will be deleted.
+      Your subscription will be cancelled at the current period end.
+      <strong>There is no undo.</strong>
+    </p>
+    <div class="modal-warning">
+      Type your email address to confirm deletion:
+    </div>
+    <input class="field-input" type="email" id="delete-confirm-email" placeholder="alexandra@example.com" autocomplete="off">
+    <div class="modal-actions">
+      <button class="btn btn-ghost btn-sm" onclick="this.closest('.modal-backdrop').classList.remove('open')">Cancel</button>
+      <button class="btn btn-danger btn-sm" onclick="confirmDelete()">Permanently delete account</button>
+    </div>
+  </div>
+</div>
+
+<!-- New API key modal -->
+<div class="modal-backdrop" id="new-key-modal" onclick="closeModal(this, event)">
+  <div class="modal">
+    <button class="modal-close-x" onclick="this.closest('.modal-backdrop').classList.remove('open')">×</button>
+    <h3>Generate API key</h3>
+    <p class="modal-sub">Give this key a label and choose its scopes. The key value is shown only once after creation.</p>
+    <div style="display:flex;flex-direction:column;gap:12px">
+      <div>
+        <label style="font-size:12.5px;font-weight:600;color:var(--fg-muted);margin-bottom:5px;display:block">Label</label>
+        <input class="field-input" type="text" placeholder="e.g. Claude integration, Zapier webhook">
+      </div>
+      <div>
+        <label style="font-size:12.5px;font-weight:600;color:var(--fg-muted);margin-bottom:8px;display:block">Scopes</label>
+        <div style="display:flex;flex-direction:column;gap:6px">
+          <label style="display:flex;align-items:center;gap:8px;font-size:13.5px;font-weight:400;cursor:pointer">
+            <input type="checkbox" checked> <strong>Read</strong> — query page content, analytics
+          </label>
+          <label style="display:flex;align-items:center;gap:8px;font-size:13.5px;font-weight:400;cursor:pointer">
+            <input type="checkbox"> <strong>Write</strong> — update blocks, publish changes
+          </label>
+          <label style="display:flex;align-items:center;gap:8px;font-size:13.5px;font-weight:400;cursor:pointer">
+            <input type="checkbox"> <strong>Webhooks</strong> — register event subscriptions
+          </label>
+        </div>
+      </div>
+    </div>
+    <div class="modal-actions">
+      <button class="btn btn-ghost btn-sm" onclick="this.closest('.modal-backdrop').classList.remove('open')">Cancel</button>
+      <button class="btn btn-primary btn-sm" onclick="alert('Mockup — would generate key + show once. Copy it now!'); this.closest('.modal-backdrop').classList.remove('open')">Generate key</button>
+    </div>
+  </div>
+</div>
+
+<!-- Invite team member modal -->
+<div class="modal-backdrop" id="invite-modal" onclick="closeModal(this, event)">
+  <div class="modal">
+    <button class="modal-close-x" onclick="this.closest('.modal-backdrop').classList.remove('open')">×</button>
+    <h3>Invite team member</h3>
+    <p class="modal-sub">They'll receive an email invitation. 1 seat will be used.</p>
+    <div style="display:flex;flex-direction:column;gap:12px">
+      <div>
+        <label style="font-size:12.5px;font-weight:600;color:var(--fg-muted);margin-bottom:5px;display:block">Email</label>
+        <input class="field-input" type="email" placeholder="colleague@example.com" autocomplete="email">
+      </div>
+      <div>
+        <label style="font-size:12.5px;font-weight:600;color:var(--fg-muted);margin-bottom:8px;display:block">Role</label>
+        <div style="display:flex;gap:8px;flex-wrap:wrap">
+          <label style="display:flex;align-items:center;gap:6px;font-size:13px;cursor:pointer;padding:8px 12px;border:1px solid var(--border);border-radius:9px">
+            <input type="radio" name="invite-role" value="admin"> <div><strong>Admin</strong><div style="font-size:11.5px;color:var(--fg-muted)">Full access incl. billing</div></div>
+          </label>
+          <label style="display:flex;align-items:center;gap:6px;font-size:13px;cursor:pointer;padding:8px 12px;border:1px solid var(--border);border-radius:9px">
+            <input type="radio" name="invite-role" value="editor" checked> <div><strong>Editor</strong><div style="font-size:11.5px;color:var(--fg-muted)">Edit pages, no billing</div></div>
+          </label>
+          <label style="display:flex;align-items:center;gap:6px;font-size:13px;cursor:pointer;padding:8px 12px;border:1px solid var(--border);border-radius:9px">
+            <input type="radio" name="invite-role" value="viewer"> <div><strong>Viewer</strong><div style="font-size:11.5px;color:var(--fg-muted)">Read-only access</div></div>
+          </label>
+        </div>
+      </div>
+    </div>
+    <div class="modal-actions">
+      <button class="btn btn-ghost btn-sm" onclick="this.closest('.modal-backdrop').classList.remove('open')">Cancel</button>
+      <button class="btn btn-primary btn-sm" onclick="alert('Mockup — would send invite email'); this.closest('.modal-backdrop').classList.remove('open')">Send invitation</button>
+    </div>
+  </div>
+</div>
+
+<!-- ============================================================
+     DEMO HELPER TOOLBAR (mockup reviewer only — hidden from UX)
+     ============================================================ -->
+<div aria-hidden="true" style="position:fixed;bottom:16px;right:16px;z-index:999">
+  <div style="background:var(--bg-elevated);border:1px solid var(--border);border-radius:12px;padding:10px 12px;font-size:11px;font-weight:600;color:var(--fg-subtle);display:flex;flex-direction:column;gap:6px;box-shadow:0 8px 24px rgba(17,24,39,0.12)">
+    <div style="color:var(--fg-subtle);text-transform:uppercase;letter-spacing:.06em;font-size:10px">Mockup: tier switcher</div>
+    <div style="display:flex;gap:4px;flex-wrap:wrap">
+      <button onclick="setTier('free')" style="padding:3px 9px;border-radius:7px;border:1px solid var(--border);background:var(--bg);font-size:11px;font-weight:600;cursor:pointer;font-family:var(--font-sans)">Free</button>
+      <button onclick="setTier('creator')" style="padding:3px 9px;border-radius:7px;border:1px solid var(--border-strong);background:var(--brand-primary);color:#fff;font-size:11px;font-weight:600;cursor:pointer;font-family:var(--font-sans)">Creator ✓</button>
+      <button onclick="setTier('pro')" style="padding:3px 9px;border-radius:7px;border:1px solid var(--border);background:var(--bg);font-size:11px;font-weight:600;cursor:pointer;font-family:var(--font-sans)">Pro</button>
+      <button onclick="setTier('business')" style="padding:3px 9px;border-radius:7px;border:1px solid var(--border);background:var(--bg);font-size:11px;font-weight:600;cursor:pointer;font-family:var(--font-sans)">Business</button>
+    </div>
+    <div style="display:flex;gap:4px;flex-wrap:wrap;border-top:1px solid var(--border);padding-top:6px">
+      <button onclick="document.getElementById('reactivate-section').style.display='block'" style="padding:3px 9px;border-radius:7px;border:1px solid var(--border);background:var(--bg);font-size:11px;cursor:pointer;font-family:var(--font-sans)">Show reactivate</button>
+    </div>
+  </div>
+</div>
+
+<script src="./shared/tokens.js"></script>
+<script>
+  /* ── Theme ── */
+  function toggleTheme() {
+    document.body.classList.toggle('dark-mode');
+  }
+
+  /* ── Settings tab switcher ── */
+  function switchTab(tabId, btnEl) {
+    // Update nav buttons
+    document.querySelectorAll('.settings-nav-item').forEach(function(b) {
+      b.classList.remove('active');
+    });
+    btnEl.classList.add('active');
+
+    // Show/hide panes
+    document.querySelectorAll('.settings-pane').forEach(function(p) {
+      p.classList.remove('active');
+    });
+    var pane = document.getElementById('pane-' + tabId);
+    if (pane) pane.classList.add('active');
+  }
+
+  /* ── Bio character counter ── */
+  function updateCounter(el, max, counterId) {
+    var count = el.value.length;
+    var counter = document.getElementById(counterId);
+    if (counter) {
+      counter.textContent = count;
+      counter.style.color = count > max ? 'var(--danger)' : 'var(--fg-subtle)';
+    }
+  }
+
+  /* ── Dirty state for Account save bar ── */
+  var isDirty = false;
+  function markDirty() {
+    isDirty = true;
+    var bar = document.getElementById('account-save-bar');
+    if (bar) bar.style.display = 'flex';
+  }
+  function saveChanges() {
+    alert('Mockup — would persist to API');
+    isDirty = false;
+    var bar = document.getElementById('account-save-bar');
+    if (bar) bar.style.display = 'none';
+  }
+  function discardChanges() {
+    isDirty = false;
+    document.getElementById('field-name').value = 'Alexandra Silva';
+    document.getElementById('field-bio').value = 'Photographer, traveller, and content creator based in Lisbon 🇵🇹';
+    document.getElementById('field-pronouns').value = 'she/her';
+    document.getElementById('bio-count').textContent = '56';
+    var bar = document.getElementById('account-save-bar');
+    if (bar) bar.style.display = 'none';
+  }
+
+  /* ── Cookie toggles ── */
+  function toggleCookie(btn, name) {
+    btn.classList.toggle('on');
+    var isOn = btn.classList.contains('on');
+    btn.setAttribute('aria-checked', String(isOn));
+  }
+
+  /* ── Modal close on backdrop click ── */
+  function closeModal(backdrop, event) {
+    if (event.target === backdrop) {
+      backdrop.classList.remove('open');
+    }
+  }
+
+  /* ── Delete account confirmation ── */
+  function confirmDelete() {
+    var input = document.getElementById('delete-confirm-email');
+    if (!input) return;
+    if (input.value.toLowerCase().trim() !== 'alexandra@example.com') {
+      input.style.borderColor = 'var(--danger)';
+      input.focus();
+      return;
+    }
+    alert('Mockup — would trigger account deletion via API. Goodbye, alexandra!');
+    document.getElementById('delete-account-modal').classList.remove('open');
+  }
+
+  /* ── Tier switcher (demo toolbar) ── */
+  function setTier(tier) {
+    var apiLocked   = document.getElementById('api-locked');
+    var apiUnlocked = document.getElementById('api-unlocked');
+    var teamLocked  = document.getElementById('team-locked');
+    var teamUnlocked = document.getElementById('team-unlocked');
+    var handleEl = document.getElementById('handle-text');
+
+    // API keys: locked on Free + Creator, unlocked on Pro + Business
+    var apiOn = (tier === 'pro' || tier === 'business');
+    if (apiLocked)   apiLocked.style.display   = apiOn ? 'none'  : 'block';
+    if (apiUnlocked) apiUnlocked.style.display  = apiOn ? 'block' : 'none';
+
+    // Team: locked on Free + Creator + Pro, unlocked on Business
+    var teamOn = (tier === 'business');
+    if (teamLocked)   teamLocked.style.display   = teamOn ? 'none'  : 'block';
+    if (teamUnlocked) teamUnlocked.style.display  = teamOn ? 'block' : 'none';
+
+    // Update handle pill tier label
+    var tierLabels = { free: 'Free', creator: 'Creator', pro: 'Pro', business: 'Business' };
+    var userHandleEl = document.querySelector('.side-user .uhandle');
+    if (userHandleEl) userHandleEl.textContent = '@alexandra · ' + (tierLabels[tier] || tier);
+
+    // Re-render toolbar buttons
+    var btns = document.querySelectorAll('[aria-hidden="true"] button');
+    btns.forEach(function(b) {
+      b.style.background = 'var(--bg)';
+      b.style.color = 'var(--fg)';
+      b.style.borderColor = 'var(--border)';
+    });
+  }
+
+  /* ── Keyboard Esc closes modals ── */
+  document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape') {
+      document.querySelectorAll('.modal-backdrop.open').forEach(function(m) {
+        m.classList.remove('open');
+      });
+    }
+  });
+</script>
+</body>
+</html>

--- a/mockups/tadaify-mvp/app-settings.html
+++ b/mockups/tadaify-mvp/app-settings.html
@@ -247,6 +247,34 @@
     .nav-add-page .nav-pill { margin-left: auto; font-size: 10px; font-weight: 600; padding: 1px 6px; border-radius: 99px; background: var(--bg-muted); color: var(--fg-subtle); white-space: nowrap; }
     .nav-add-page:hover { background: transparent !important; }
 
+    /* Pages accordion (always-expanded read-only on Settings page) */
+    .nav-pages-parent { position: relative; }
+    .nav-pages-parent .nav-caret {
+      margin-left: 6px; flex-shrink: 0;
+      width: 14px; height: 14px;
+      color: var(--fg-subtle);
+      transform: rotate(90deg);
+    }
+    .nav-sub-list {
+      display: flex; flex-direction: column; gap: 1px;
+      margin: 2px 0 4px 17px;
+      padding-left: 8px;
+      border-left: 1px solid var(--border);
+    }
+    .nav-sub-item {
+      display: flex; align-items: center; gap: 9px;
+      width: 100%; padding: 6px 10px; border-radius: 7px;
+      font-size: 12.5px; font-weight: 500;
+      background: transparent; border: 0; color: var(--fg-muted);
+      text-align: left; text-decoration: none;
+      transition: background .12s ease, color .12s ease;
+      cursor: pointer;
+    }
+    .nav-sub-item svg { width: 14px; height: 14px; flex-shrink: 0; color: var(--fg-subtle); }
+    .nav-sub-item:hover { background: var(--bg-muted); color: var(--fg); }
+    .nav-sub-item.is-disabled { cursor: not-allowed; opacity: 0.55; font-style: italic; }
+    .nav-sub-item.is-disabled:hover { background: transparent; color: var(--fg-muted); }
+
     @media (min-width: 720px) and (max-width: 1099px) {
       aside.side { padding: 14px 8px; }
       .side-user .utxt, .side-user .chevron { display: none; }
@@ -254,6 +282,9 @@
       .nav-item { justify-content: center; padding: 10px 6px; }
       .nav-item > span.label, .nav-item .nav-count { display: none; }
       .nav-item svg { width: 20px; height: 20px; }
+      .nav-pages-parent .nav-caret { display: none; }
+      .nav-pages-parent .nav-count { display: none; }
+      .nav-sub-list { display: none; }
     }
 
     /* -----------------------------------------------------------------------
@@ -794,18 +825,25 @@
       <svg class="chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="8 9 12 5 16 9"/><polyline points="8 15 12 19 16 15"/></svg>
     </div>
 
-    <!-- GROUP 1: Homepage + Add page -->
+    <!-- GROUP 1: Pages (parent always expanded — no JS toggle on Settings page) -->
     <div class="nav-group">
-      <a href="./app-dashboard.html?tab=page" class="nav-item" data-tip="Homepage">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
-        <span class="label">Homepage</span>
-        <span class="nav-count">3</span>
+      <a href="./app-dashboard.html?tab=page" class="nav-item nav-pages-parent" data-tip="Pages">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+        <span class="label">Pages</span>
+        <span class="nav-count">1</span>
+        <svg class="nav-caret" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
       </a>
-      <button class="nav-item nav-add-page" aria-disabled="true">
-        <span class="nav-icon">+</span>
-        <span class="nav-label">Add page</span>
-        <span class="nav-pill">soon</span>
-      </button>
+      <div class="nav-sub-list">
+        <a href="./app-dashboard.html?tab=page" class="nav-sub-item" data-tip="Home">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+          <span>Home</span>
+        </a>
+        <button class="nav-sub-item is-disabled" aria-disabled="true" data-tip="Multi-page coming Q+1 — DEC-MULTIPAGE-01">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+          <span>Add page</span>
+          <span class="nav-pill" style="margin-left:auto;font-size:10px;font-weight:600;padding:1px 6px;border-radius:99px;background:var(--bg-muted);color:var(--fg-subtle);white-space:nowrap">soon</span>
+        </button>
+      </div>
     </div>
 
     <div class="nav-divider"></div>
@@ -969,19 +1007,32 @@
             </div>
           </div>
 
-          <!-- Handle & Email (read-only) -->
+          <!-- Handle (editable, 1/30d cap) & Email -->
           <div class="settings-section">
             <div class="settings-section-title">Account identity</div>
 
             <div class="field-row">
               <div class="field-label">
                 Handle
-                <span class="field-hint">Your public URL slug</span>
+                <span class="field-hint">Your public URL slug · 1 change per 30 days</span>
               </div>
               <div class="field-body">
-                <input class="field-input" type="text" value="@alexandra" readonly>
-                <p style="font-size:12px;color:var(--fg-muted);margin-top:6px">
-                  Handle changes require manual review — <a href="mailto:support@tadaify.com" style="color:var(--brand-primary)">contact support</a>.
+                <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">
+                  <div style="position:relative;flex:1;min-width:240px">
+                    <span style="position:absolute;left:12px;top:50%;transform:translateY(-50%);color:var(--fg-muted);font-size:14px;pointer-events:none;font-family:var(--font-sans)">tadaify.com/</span>
+                    <input class="field-input" type="text" id="handle-input" value="alexandra"
+                           oninput="checkHandle(this.value)"
+                           style="padding-left:96px;padding-right:96px"
+                           maxlength="30" autocomplete="off" autocapitalize="off" spellcheck="false">
+                    <span id="handle-status" style="position:absolute;right:10px;top:50%;transform:translateY(-50%);font-size:11px;font-weight:600;padding:3px 8px;border-radius:999px;background:var(--surface-2);color:var(--fg-muted)">current</span>
+                  </div>
+                  <button class="btn btn-primary btn-sm" id="handle-save-btn" disabled
+                          onclick="openHandleConfirm()">
+                    Save handle
+                  </button>
+                </div>
+                <p id="handle-hint" style="font-size:12px;color:var(--fg-muted);margin-top:6px">
+                  Lowercase letters, numbers, and dashes. 3–30 chars. Last changed: <strong>never</strong>.
                 </p>
               </div>
             </div>
@@ -1039,22 +1090,14 @@
             </p>
           </div>
 
-          <!-- Payment method -->
+          <!-- Recent invoices (read-only — Stripe is source of truth) -->
           <div class="settings-section">
-            <div class="settings-section-title with-action">
-              Payment method
-              <button class="btn btn-ghost btn-sm" onclick="alert('Mockup — would open Stripe payment update')">Update</button>
-            </div>
-            <div class="payment-card">
-              <span class="card-brand-pill">Visa</span>
-              <span style="font-size:13.5px;color:var(--fg)">•••• •••• •••• 4242</span>
-              <span style="font-size:12px;color:var(--fg-muted);margin-left:auto">Expires 08/27</span>
-            </div>
-          </div>
-
-          <!-- Invoices -->
-          <div class="settings-section">
-            <div class="settings-section-title">Invoices (last 12 months)</div>
+            <div class="settings-section-title">Recent invoices</div>
+            <p style="font-size:12.5px;color:var(--fg-muted);margin:-2px 0 12px;line-height:1.55">
+              Last 3 charges. Click a row to open the Stripe-hosted PDF in a new tab.
+              Full history, card update, and cancellation live in the
+              <a href="#" onclick="openStripePortal('invoices'); return false;" style="color:var(--brand-primary)">Stripe billing portal</a>.
+            </p>
             <div style="overflow-x:auto">
               <table class="invoice-table">
                 <thead>
@@ -1066,13 +1109,44 @@
                   </tr>
                 </thead>
                 <tbody>
-                  <tr><td>Apr 1, 2026</td><td>$8.00</td><td><span class="status-paid">✓ Paid</span></td><td><button class="btn btn-ghost btn-xs" onclick="alert('Mockup — would download PDF')">PDF</button></td></tr>
-                  <tr><td>Mar 1, 2026</td><td>$8.00</td><td><span class="status-paid">✓ Paid</span></td><td><button class="btn btn-ghost btn-xs" onclick="alert('Mockup — would download PDF')">PDF</button></td></tr>
-                  <tr><td>Feb 1, 2026</td><td>$8.00</td><td><span class="status-paid">✓ Paid</span></td><td><button class="btn btn-ghost btn-xs" onclick="alert('Mockup — would download PDF')">PDF</button></td></tr>
-                  <tr><td>Jan 1, 2026</td><td>$8.00</td><td><span class="status-paid">✓ Paid</span></td><td><button class="btn btn-ghost btn-xs" onclick="alert('Mockup — would download PDF')">PDF</button></td></tr>
-                  <tr><td>Dec 1, 2025</td><td>$8.00</td><td><span class="status-paid">✓ Paid</span></td><td><button class="btn btn-ghost btn-xs" onclick="alert('Mockup — would download PDF')">PDF</button></td></tr>
+                  <tr>
+                    <td>Apr 1, 2026</td><td>$8.00</td>
+                    <td><span class="status-paid">✓ Paid</span></td>
+                    <td><a href="#" onclick="openStripeInvoice('in_1Q9aLE...', event)" class="btn btn-ghost btn-xs">View on Stripe ↗</a></td>
+                  </tr>
+                  <tr>
+                    <td>Mar 1, 2026</td><td>$8.00</td>
+                    <td><span class="status-paid">✓ Paid</span></td>
+                    <td><a href="#" onclick="openStripeInvoice('in_1Q9aJX...', event)" class="btn btn-ghost btn-xs">View on Stripe ↗</a></td>
+                  </tr>
+                  <tr>
+                    <td>Feb 1, 2026</td><td>$8.00</td>
+                    <td><span class="status-paid">✓ Paid</span></td>
+                    <td><a href="#" onclick="openStripeInvoice('in_1Q9aHk...', event)" class="btn btn-ghost btn-xs">View on Stripe ↗</a></td>
+                  </tr>
                 </tbody>
               </table>
+            </div>
+          </div>
+
+          <!-- Manage in Stripe -->
+          <div class="settings-section">
+            <div class="settings-section-title">Manage in Stripe</div>
+            <p style="font-size:13px;color:var(--fg-muted);margin:-2px 0 14px;line-height:1.6">
+              Card on file, full invoice history (PDF), tax IDs and address, and one-click cancel
+              are managed inside the Stripe-hosted Customer Portal — we never see or store your card details.
+              You'll be redirected to Stripe and brought right back here when you're done.
+            </p>
+            <div style="display:flex;flex-wrap:wrap;gap:10px">
+              <button class="btn btn-primary btn-sm" onclick="openStripePortal('billing')">
+                Manage billing in Stripe ↗
+              </button>
+              <button class="btn btn-ghost btn-sm" onclick="openStripePortal('payment_method_update')">
+                Update card
+              </button>
+              <button class="btn btn-ghost btn-sm" onclick="openStripePortal('invoices')">
+                All invoices
+              </button>
             </div>
           </div>
 
@@ -1528,6 +1602,36 @@
   </div>
 </div>
 
+<!-- Change handle modal (1/30d cap, 30d redirect then released) -->
+<div class="modal-backdrop" id="change-handle-modal" onclick="closeModal(this, event)">
+  <div class="modal">
+    <button class="modal-close-x" onclick="this.closest('.modal-backdrop').classList.remove('open')">×</button>
+    <h3>Change handle?</h3>
+    <p class="modal-sub">
+      Your tadaify slug changes from <strong>tadaify.com/<span id="handle-old">alexandra</span></strong>
+      to <strong>tadaify.com/<span id="handle-new">—</span></strong>.
+    </p>
+    <div class="modal-warning" style="display:flex;flex-direction:column;gap:10px">
+      <div>
+        <strong>What happens to the old URL</strong><br>
+        For 30 days, <code>tadaify.com/<span class="handle-old-mirror">alexandra</span></code> will <strong>301-redirect to your primary page</strong>:
+        <span id="redirect-target-line" style="display:block;margin-top:4px">→ <code>https://alexandra.com/</code> <span style="color:var(--fg-muted);font-size:11.5px">(your active custom domain)</span></span>
+        After 30 days the old slug is released and someone else can claim it.
+      </div>
+      <div style="font-size:12.5px;color:var(--fg-muted);border-top:1px solid var(--border);padding-top:10px">
+        <strong>Custom domains stay bound to your account</strong> — they're not tied to your handle, so
+        <code class="handle-custom-mirror">alexandra.com</code> keeps working with no DNS change.
+        Only the tadaify.com slug needs a redirect.<br><br>
+        You can change your handle again in <strong>30 days</strong>.
+      </div>
+    </div>
+    <div class="modal-actions">
+      <button class="btn btn-ghost btn-sm" onclick="this.closest('.modal-backdrop').classList.remove('open')">Cancel</button>
+      <button class="btn btn-primary btn-sm" onclick="alert('Mockup — would update handle, start 30d redirect, and lock further changes for 30d'); this.closest('.modal-backdrop').classList.remove('open')">Confirm change</button>
+    </div>
+  </div>
+</div>
+
 <!-- Cancel subscription modal (AP-010 one-click) -->
 <div class="modal-backdrop" id="cancel-modal" onclick="closeModal(this, event)">
   <div class="modal">
@@ -1737,6 +1841,7 @@
 
   /* ── Tier switcher (demo toolbar) ── */
   function setTier(tier) {
+    DEMO_TIER = tier;
     var apiLocked   = document.getElementById('api-locked');
     var apiUnlocked = document.getElementById('api-unlocked');
     var teamLocked  = document.getElementById('team-locked');
@@ -1765,6 +1870,120 @@
       b.style.color = 'var(--fg)';
       b.style.borderColor = 'var(--border)';
     });
+  }
+
+  /* ── Handle availability check (mockup demo, no network) ── */
+  var RESERVED_HANDLES = ['admin','api','app','www','support','blog','help','docs','login','register','signin','signup','about','pricing','terms','privacy','legal','contact','tadaify','settings','dashboard','onboarding','mail','email','status','assets','static','public','admin-panel'];
+  var TAKEN_DEMO = ['alex','john','test','demo','taken','sarah','emma','mike'];
+  // Handles whose previous owner changed their slug; redirect window still active.
+  // Keys = handle, values = days until release (30d policy → released and free to claim).
+  var EXPIRING_HANDLES = { 'taylor': 22, 'oldalex': 7, 'jess': 3 };
+  var CURRENT_HANDLE = 'alexandra';
+  var HANDLE_VALID_RE = /^[a-z0-9](?:[a-z0-9-]{1,28}[a-z0-9])?$/;
+
+  function checkHandle(value) {
+    var status  = document.getElementById('handle-status');
+    var hint    = document.getElementById('handle-hint');
+    var saveBtn = document.getElementById('handle-save-btn');
+    var v = (value || '').toLowerCase().trim();
+
+    var setState = function(label, tone, msg) {
+      status.textContent = label;
+      if (tone === 'ok') {
+        status.style.background = 'rgba(34,197,94,.18)';
+        status.style.color = '#16a34a';
+      } else if (tone === 'err') {
+        status.style.background = 'rgba(239,68,68,.15)';
+        status.style.color = 'var(--danger)';
+      } else {
+        status.style.background = 'var(--surface-2)';
+        status.style.color = 'var(--fg-muted)';
+      }
+      hint.innerHTML = msg;
+      hint.style.color = (tone === 'err') ? 'var(--danger)' : 'var(--fg-muted)';
+    };
+
+    if (v === CURRENT_HANDLE) {
+      saveBtn.disabled = true;
+      setState('current', 'neutral', 'Lowercase letters, numbers, and dashes. 3–30 chars. Last changed: <strong>never</strong>.');
+      return;
+    }
+    if (v.length < 3) {
+      saveBtn.disabled = true;
+      setState('too short', 'err', 'Minimum 3 characters.');
+      return;
+    }
+    if (!HANDLE_VALID_RE.test(v)) {
+      saveBtn.disabled = true;
+      setState('invalid', 'err', 'Use lowercase letters, numbers, and dashes (no leading/trailing dash).');
+      return;
+    }
+    if (RESERVED_HANDLES.indexOf(v) !== -1) {
+      saveBtn.disabled = true;
+      setState('reserved', 'err', 'This handle is reserved for system use.');
+      return;
+    }
+    if (Object.prototype.hasOwnProperty.call(EXPIRING_HANDLES, v)) {
+      var days = EXPIRING_HANDLES[v];
+      saveBtn.disabled = true;
+      setState('expiring · ' + days + 'd', 'err',
+        'Taken — releases in <strong>' + days + ' day' + (days === 1 ? '' : 's') + '</strong>. ' +
+        'Previous owner changed handle; we hold a 30-day redirect so their old links keep working. ' +
+        'Come back after release to claim it.');
+      return;
+    }
+    if (TAKEN_DEMO.indexOf(v) !== -1) {
+      saveBtn.disabled = true;
+      setState('taken', 'err', 'Someone already uses this handle.');
+      return;
+    }
+    saveBtn.disabled = false;
+    setState('available', 'ok',
+      'Available — old slug 301s to your primary page for 30 days, then released. ' +
+      'Custom domain (if any) keeps working unchanged. You can change again in 30 days.');
+  }
+
+  /* ── Stripe Customer Portal redirects (mockup demo) ──
+     Real impl: POST /create-billing-portal-session →
+     stripe.billingPortal.sessions.create({ customer, return_url, flow_data: {...} }) → redirect. */
+  function openStripePortal(flow) {
+    var labels = {
+      billing: 'overview',
+      payment_method_update: 'card update',
+      invoices: 'invoice history',
+      subscription_cancel: 'cancellation flow'
+    };
+    alert('Mockup — would redirect to Stripe Customer Portal (' + (labels[flow] || flow) + ').\nReturn URL: /app/settings#billing');
+  }
+  function openStripeInvoice(invoiceId, event) {
+    if (event) event.preventDefault();
+    alert('Mockup — would open Stripe-hosted invoice PDF for ' + invoiceId + ' in a new tab.');
+  }
+
+  /* Demo state for redirect-target preview. setTier() updates DEMO_TIER below. */
+  var DEMO_TIER = 'creator';
+  var DEMO_CUSTOM_DOMAIN = 'alexandra.com';
+
+  function openHandleConfirm() {
+    var v = document.getElementById('handle-input').value.toLowerCase().trim();
+    document.getElementById('handle-old').textContent = CURRENT_HANDLE;
+    document.getElementById('handle-new').textContent = v;
+    document.querySelectorAll('.handle-old-mirror').forEach(function(el){ el.textContent = CURRENT_HANDLE; });
+    document.querySelectorAll('.handle-custom-mirror').forEach(function(el){ el.textContent = DEMO_CUSTOM_DOMAIN; });
+
+    // Free tier in this demo = no custom domain → fallback to new slug.
+    var hasCustomDomain = (DEMO_TIER !== 'free');
+    var line = document.getElementById('redirect-target-line');
+    if (line) {
+      if (hasCustomDomain) {
+        line.innerHTML = '→ <code>https://' + DEMO_CUSTOM_DOMAIN + '/</code> ' +
+          '<span style="color:var(--fg-muted);font-size:11.5px">(your active custom domain — primary)</span>';
+      } else {
+        line.innerHTML = '→ <code>https://tadaify.com/' + v + '</code> ' +
+          '<span style="color:var(--fg-muted);font-size:11.5px">(no custom domain on file — fallback to new slug)</span>';
+      }
+    }
+    document.getElementById('change-handle-modal').classList.add('open');
   }
 
   /* ── Keyboard Esc closes modals ── */


### PR DESCRIPTION
## Summary

- `app-settings.html` (NEW, 1780 lines) — full authenticated creator settings panel covering F-180..199 Admin & Trust scope
- Settings nav-item wired in both `app-dashboard.html` and `app-domain.html` (were `<button>` placeholders; now `<a href="./app-settings.html">`)
- `README.md` updated with new row + 2026-04-25 changelog entry
- Cross-mockup link audit completed (out-of-tree: `/tmp/mockup-link-audit.md`)

## Business requirements implemented

- **F-COMPLIANCE-001** — GDPR data export (Art. 20 JSON download), delete account (Art. 17 confirmation modal with email type-to-confirm), cookie preferences panel (strictly necessary always on, analytics + marketing toggles, privacy-by-design defaults)
- **F-LEGAL-003** — ToS acceptance audit cross-link placeholder in GDPR tab
- **F-PRO-CREATOR-API-001** — API keys management (list, generate, revoke), MCP server install snippet, Custom GPT instructions download, rate limit info (1000 req/h Pro)
- **AP-010** — One-click cancel: single-confirm modal with no survey cascade ("No surveys, no guilt trips")
- **AP-029** — Pages stay live during cancellation grace period (shown in cancel modal + danger zone copy)
- **DEC-PRICELOCK-01** — "Locked for life at $8/mo" amber pill on Billing plan card
- **DEC-PRICELOCK-02** — Custom domain add-on line items in Billing tab ($2/mo per domain)
- **DEC-CREATOR-API-01** — API keys section Pro-gated; locked state with upgrade CTA for Free/Creator tiers
- **DEC-TADAIFY-BILLING-01** — Stripe billing surface (plan card, payment method, invoices table)

## Technical requirements introduced or relied on

- **TR-MOCKUP-SHELL** — Same appbar + sidebar + `shared/tokens.css` + `shared/tokens.js` pattern as `app-dashboard.html` and `app-domain.html`
- **TR-SETTINGS-SUBNAV** — Vertical pill sub-nav (left rail inside content area) for settings tabs; collapses to horizontal scroll on mobile (≤720px)
- **TR-DEMO-TOOLBAR** — `aria-hidden` bottom-right tier switcher (Free/Creator/Pro/Business) to preview gated states without code changes — consistent with `app-domain.html` state toolbar pattern
- **TR-DARKMODE** — Full dark mode CSS overrides matching existing dashboard pattern

## Acceptance criteria from issue

Settings panel not yet tracked in a GitHub issue (story [F-SETTINGS-001 — TBD]). Acceptance criteria per task spec:

- ✅ Same dashboard shell (sidebar + topbar) with Settings nav-item ACTIVE
- ✅ 7 tabs: Account / Billing / Security / GDPR & data / API keys (Pro) / Team (Business) / Danger zone
- ✅ Account: avatar upload/remove, display name, bio (80-char counter), pronouns, handle (read-only), email (read-only + change modal)
- ✅ Billing: plan card with price-lock pill, payment method, invoices table (last 12), custom-domain add-on line items, "Change plan" link to pricing.html
- ✅ Security: password change form, 2FA TOTP toggle + backup codes, active sessions list, login history (30 days)
- ✅ GDPR & data: JSON export, cookie preferences (3 rows), visitor consent log with aggregate stats, delete account section (Art. 17)
- ✅ API keys: Pro-gated locked state + unlocked state (key list, generate modal with scope picker, MCP install snippet, Custom GPT template, rate limit, webhook placeholder)
- ✅ Team: Business-gated locked state + unlocked state (seats bar, members table, invite modal with role picker, audit log link)
- ✅ Danger zone: one-click cancel modal (AP-010), reactivate section (grace period), delete account (cross-link to GDPR tab)
- ✅ Cross-links wired: sidebar links out to dashboard/domain/insights/shop; topbar logo → index.html; handle pill → creator-public.html; Billing → pricing.html
- ✅ Light/dark mode toggle functional
- ✅ All modals open/close correctly (cancel subscription, delete account, change email, generate API key, invite member)
- ✅ Client-side form validation (delete account: must type email to confirm; bio counter; dirty-state save bar)
- ✅ Demo toolbar for tier switcher (aria-hidden)
- ✅ Mobile-responsive: settings sub-nav → horizontal pill scroll; field rows stack on narrow viewports
- ✅ Frontmatter comment block with full DEC trail

## Test plan

This is a static HTML mockup — no automated tests apply. Visual review checklist:

- [ ] Open in browser, verify light mode renders correctly
- [ ] Toggle dark mode — all surfaces, text, and borders should update
- [ ] Click each of 7 settings tabs — pane switches, left rail highlights active item
- [ ] On mobile (≤720px): settings sub-nav becomes horizontal pill row
- [ ] Billing tab: "Change plan" links to `pricing.html`; "Manage domains" links to `app-domain.html`
- [ ] Cancel modal (Danger zone): opens, shows grace-period copy, "Keep subscription" closes modal, "Cancel subscription" shows alert
- [ ] Delete account modal (GDPR tab + Danger zone): type wrong email → border turns red; type correct email → alert fires
- [ ] API keys tab: switch to Free tier via toolbar — locked state visible; switch to Pro — unlocked list visible
- [ ] Team tab: switch to Business via toolbar — members table visible; switch to Creator — locked state visible
- [ ] Generate API key modal: checkboxes, label field, generate button
- [ ] Sidebar Settings link is `<a>` (not button), href="./app-settings.html"
- [ ] Topbar handle pill links to `./creator-public.html` target="_blank"
- [ ] `grep -c 'app-settings.html' app-dashboard.html` ≥ 1 ✅
- [ ] `grep -c 'app-settings.html' app-domain.html` ≥ 1 ✅

## Mockup

https://github.com/graspsoftwarepw/tadaify-app/blob/mockup/settings-and-link-audit/mockups/tadaify-mvp/app-settings.html

## Rollback

`git revert 250bc00` — reverts the single commit cleanly. No DB migrations, no Edge Function deploys.

---

### Cross-mockup link audit (from `/tmp/mockup-link-audit.md`)

**17 HTML files scanned · 0 broken refs · 1 self-link (landing.html → itself, harmless)**

**Orphan candidates** (files with 0 inbound `<a href>` links from other mockups):

| File | Verdict |
|---|---|
| `app-dashboard-variants.html` | **Flag for deletion** — 10-layout reference from v1 exploration. v2 IA is now canonical. User should decide: keep for docs or delete in a follow-up PR. NOT deleted here. |
| `app-dashboard.html` | **Not a real orphan** — legitimate app entry point post-login; `index.html` hub reaches it via flow. |
| `app-domain.html` | **Not a real orphan** — wired via `onclick="window.location.href='./app-domain.html'"` button in dashboard sidebar (not `<a href>`). Navigation works; convert to `<a>` in a follow-up. |

**Fixed in this PR:**
- `app-dashboard.html` Settings → `./app-settings.html` (was `<button>` with no href)
- `app-domain.html` Settings → `./app-settings.html` (same fix)
