### PR TITLE
chore(wire): TierGate + AI Suggest globals via shared/partials.js + connect all editors

### DIFF
--- a/mockups/tadaify-mvp/app-ai-suggest-modal.html
+++ b/mockups/tadaify-mvp/app-ai-suggest-modal.html
@@ -1,5 +1,27 @@
 <!DOCTYPE html>
 <!--
+  ============================================================================
+  NOTE — GLOBAL AVAILABILITY (added by chore/wire-tier-gate-and-ai-suggest-globals)
+
+  This standalone file is the canonical DESIGN reference + demo for the
+  AI Suggest sub-modal (all 6 states, context strip, refinement, skeletons,
+  rate-limit, etc.) but the runtime implementation now ships globally via:
+
+      shared/partials.js → window.AISuggest.open({ ... })
+
+  Every editor mockup with <script src="./shared/partials.js"> can call:
+
+      window.AISuggest.open({
+        fieldName:      'Block title',
+        contextSummary: 'Link button → open.spotify.com/album/spring-drops',
+        onApply: function (text) { document.getElementById('foo').value = text; }
+      });
+
+  Default flow: 800ms loading skeleton → 5 mocked suggestions tone-tagged
+  per fieldName flavour (title / caption / button-label). User picks one,
+  clicks "Use this", and the chosen text is passed back to onApply.
+  ============================================================================
+
   AI Suggest sub-modal — the floating UI that appears when a creator clicks
   the ✨ Suggest button on any title / label / caption / short-text field
   across the tadaify block editor.

--- a/mockups/tadaify-mvp/app-page-about.html
+++ b/mockups/tadaify-mvp/app-page-about.html
@@ -1048,14 +1048,14 @@
               <label class="field-label" for="seo-title">Meta title <span class="field-hint">~60 chars · used by Google + share previews</span></label>
               <div class="field-prefix-wrap">
                 <input id="seo-title" type="text" value="About Alexandra Silva — strength coach & writer" />
-                <button class="field-suffix-action" onclick="alert('Mockup — AI Suggest opens centered modal')" type="button">✨ Suggest</button>
+                <button class="field-suffix-action" onclick="window.AISuggest.fromButton(this, 'Field')" type="button">✨ Suggest</button>
               </div>
             </div>
             <div class="field">
               <label class="field-label" for="seo-desc">Meta description <span class="field-hint">~155 chars</span></label>
               <div class="field-prefix-wrap" style="align-items:flex-start">
                 <textarea id="seo-desc" class="field-area" style="border:0; box-shadow:none; padding:10px 12px;">Strength coach since 2018. I help busy women train hard without burning out. Author of "Rest Days Are Workouts." Based in Lisbon.</textarea>
-                <button class="field-suffix-action" onclick="alert('Mockup — AI Suggest')" type="button" style="margin-top:6px">✨ Suggest</button>
+                <button class="field-suffix-action" onclick="window.AISuggest.fromButton(this, 'Field')" type="button" style="margin-top:6px">✨ Suggest</button>
               </div>
             </div>
             <div class="field">
@@ -1129,7 +1129,7 @@
                       <label class="field-label" for="hero-tagline">One-line tagline</label>
                       <div class="field-prefix-wrap">
                         <input id="hero-tagline" type="text" value="Strength coach for women who hate gymtok." />
-                        <button class="field-suffix-action" onclick="alert('Mockup — AI Suggest opens')" type="button">✨ Suggest</button>
+                        <button class="field-suffix-action" onclick="window.AISuggest.fromButton(this, 'Field')" type="button">✨ Suggest</button>
                       </div>
                     </div>
                     <div class="field" style="margin:0">
@@ -1187,7 +1187,7 @@
                   </button>
                   <button data-tip="Numbered list" aria-label="Numbered list">1.</button>
                   <span class="rt-sep" style="margin-left:auto"></span>
-                  <button data-tip="Generate paragraph with AI" aria-label="AI suggest" onclick="alert('Mockup — AI generates a paragraph based on your handle + tagline')">✨ AI</button>
+                  <button data-tip="Generate paragraph with AI" aria-label="AI suggest" onclick="window.AISuggest.fromButton(this, 'Paragraph')">✨ AI</button>
                 </div>
                 <textarea class="rt-area" id="bio-text">I'm Alexandra. I coach busy women who want to get strong without making the gym their personality.
 
@@ -1502,7 +1502,7 @@ My method is unsexy: heavy basics, real recovery, and exactly enough volume to k
                     <label class="field-label" for="cta-label">Button label</label>
                     <div class="field-prefix-wrap">
                       <input id="cta-label" type="text" value="Work with me" />
-                      <button class="field-suffix-action" onclick="alert('Mockup — AI Suggest')" type="button">✨ Suggest</button>
+                      <button class="field-suffix-action" onclick="window.AISuggest.fromButton(this, 'Field')" type="button">✨ Suggest</button>
                     </div>
                   </div>
                   <div class="field" style="margin:0">

--- a/mockups/tadaify-mvp/app-page-blog.html
+++ b/mockups/tadaify-mvp/app-page-blog.html
@@ -826,14 +826,14 @@
               <label class="field-label" for="seo-title">Meta title <span class="field-hint">~60 chars · used by Google + share previews</span></label>
               <div class="field-prefix-wrap">
                 <input id="seo-title" type="text" value="Strong Not Skinny — Blog by Alexandra Silva" />
-                <button class="field-suffix-action" onclick="alert('Mockup — AI Suggest opens centered modal')" type="button">✨ Suggest</button>
+                <button class="field-suffix-action" onclick="window.AISuggest.fromButton(this, 'Field')" type="button">✨ Suggest</button>
               </div>
             </div>
             <div class="field">
               <label class="field-label" for="seo-desc">Meta description <span class="field-hint">~155 chars</span></label>
               <div class="field-prefix-wrap" style="align-items:flex-start">
                 <textarea id="seo-desc" class="field-area" style="border:0; box-shadow:none; padding:10px 12px;">Honest essays on training, recovery and building strength without burning out. New posts every Tuesday.</textarea>
-                <button class="field-suffix-action" onclick="alert('Mockup — AI Suggest')" type="button" style="margin-top:6px">✨ Suggest</button>
+                <button class="field-suffix-action" onclick="window.AISuggest.fromButton(this, 'Field')" type="button" style="margin-top:6px">✨ Suggest</button>
               </div>
             </div>
             <div class="field">
@@ -1134,7 +1134,7 @@
         <label class="field-label" for="pm-title-input">Title</label>
         <div class="field-prefix-wrap">
           <input id="pm-title-input" type="text" value="A 5-day reset for when training feels heavy" />
-          <button class="field-suffix-action" onclick="alert('Mockup — AI suggests 5 alternative titles')" type="button">✨ Suggest</button>
+          <button class="field-suffix-action" onclick="window.AISuggest.fromButton(this, 'Title')" type="button">✨ Suggest</button>
         </div>
       </div>
 
@@ -1169,7 +1169,7 @@
           </button>
           <button data-tip="Numbered list" aria-label="Numbered list">1.</button>
           <span class="rt-sep" style="margin-left:auto"></span>
-          <button data-tip="Generate paragraph with AI" aria-label="AI suggest" onclick="alert('Mockup — AI generates paragraph based on title + outline')">✨</button>
+          <button data-tip="Generate paragraph with AI" aria-label="AI suggest" onclick="window.AISuggest.fromButton(this, 'Paragraph')">✨</button>
         </div>
         <textarea id="pm-body" class="rt-area">Some weeks the bar feels heavier than it should. Sleep slips, work piles up, motivation thins. Trying to grind through it usually costs you more than backing off would.
 

--- a/mockups/tadaify-mvp/app-page-contact.html
+++ b/mockups/tadaify-mvp/app-page-contact.html
@@ -943,14 +943,14 @@
                 <label class="field-label" for="seo-title">Meta title <span class="field-hint">~60 chars · used by Google + share previews</span></label>
                 <div class="field-prefix-wrap">
                   <input id="seo-title" type="text" value="Contact Alexandra Silva — projects, collabs, talks" />
-                  <button class="field-suffix-action" onclick="alert('Mockup — AI Suggest opens centered modal with 5 variants')" type="button">✨ Suggest</button>
+                  <button class="field-suffix-action" onclick="window.AISuggest.fromButton(this, 'Field')" type="button">✨ Suggest</button>
                 </div>
               </div>
               <div class="field">
                 <label class="field-label" for="seo-desc">Meta description <span class="field-hint">~155 chars</span></label>
                 <div class="field-prefix-wrap" style="align-items:flex-start">
                   <textarea id="seo-desc" class="field-area" style="border:0; box-shadow:none; padding:10px 12px;">Get in touch about coaching, speaking gigs, partnerships or general questions. I read every message and reply within 24h on weekdays.</textarea>
-                  <button class="field-suffix-action" onclick="alert('Mockup — AI Suggest')" type="button" style="margin-top:6px">✨ Suggest</button>
+                  <button class="field-suffix-action" onclick="window.AISuggest.fromButton(this, 'Field')" type="button" style="margin-top:6px">✨ Suggest</button>
                 </div>
               </div>
               <div class="field">
@@ -1004,7 +1004,7 @@
             <label class="field-label" for="hero-headline">Headline <span class="field-hint">large, friendly, first thing visitors see</span></label>
             <div class="field-prefix-wrap">
               <input id="hero-headline" type="text" value="Let's work together." />
-              <button class="field-suffix-action" onclick="alert('Mockup — AI Suggest 5 variants')" type="button">✨ Suggest</button>
+              <button class="field-suffix-action" onclick="window.AISuggest.fromButton(this, 'Field')" type="button">✨ Suggest</button>
             </div>
             <div style="display:flex; gap:6px; flex-wrap:wrap; margin-top:6px">
               <button class="chip" type="button" onclick="setHeadline(this, 'Let’s work together.')" style="cursor:pointer">Let's work together</button>
@@ -1018,7 +1018,7 @@
             <label class="field-label" for="hero-sub">Sub-headline</label>
             <div class="field-prefix-wrap" style="align-items:flex-start">
               <textarea id="hero-sub" class="field-area" style="border:0; box-shadow:none; padding:10px 12px;">For project briefs, coaching calls, speaking invitations or just a friendly hello — I usually reply within 24h on weekdays.</textarea>
-              <button class="field-suffix-action" onclick="alert('Mockup — AI Suggest')" type="button" style="margin-top:6px">✨ Suggest</button>
+              <button class="field-suffix-action" onclick="window.AISuggest.fromButton(this, 'Field')" type="button" style="margin-top:6px">✨ Suggest</button>
             </div>
           </div>
 
@@ -1238,7 +1238,7 @@
               <label class="field-label" for="submit-label">Submit button label</label>
               <div class="field-prefix-wrap">
                 <input id="submit-label" type="text" value="Send message" />
-                <button class="field-suffix-action" onclick="alert('Mockup — AI Suggest 5 variants')" type="button">✨ Suggest</button>
+                <button class="field-suffix-action" onclick="window.AISuggest.fromButton(this, 'Field')" type="button">✨ Suggest</button>
               </div>
             </div>
             <div class="field">
@@ -1845,7 +1845,7 @@
         <label class="field-label" for="ty-headline">Headline</label>
         <div class="field-prefix-wrap">
           <input id="ty-headline" type="text" value="Got it — thanks for reaching out!" />
-          <button class="field-suffix-action" onclick="alert('Mockup — AI Suggest')" type="button">✨ Suggest</button>
+          <button class="field-suffix-action" onclick="window.AISuggest.fromButton(this, 'Field')" type="button">✨ Suggest</button>
         </div>
       </div>
       <div class="field">

--- a/mockups/tadaify-mvp/app-page-contact.html
+++ b/mockups/tadaify-mvp/app-page-contact.html
@@ -2053,27 +2053,78 @@
   // ── Recommended starter (empty -> filled) ──
   function useStarter() { setQuery('state', 'filled'); }
 
-  // ── Save (TierGate placeholder) ──
+  // ── Save → run TierGate.checkAndProceed (premium fields gate at save per no-blur-premium) ──
   function onSave() {
-    /*
-     * IMPLEMENTATION NOTE:
-     *   On real save, call shared TierGate.checkAndProceed({
-     *     creatorTier: tier,
-     *     usedFeatures: [
-     *       'custom_domain',          // requires Pro
-     *       'office_hours',           // requires Creator+
-     *       'faq_quickref',           // requires Creator+
-     *       'multi_recipient',        // requires Business
-     *       'webhook_provider:slack', // requires Pro per-channel
-     *       'field:file_upload',      // requires Pro
-     *       'field:hidden',           // requires Business
-     *       'field:conditional',      // requires Pro
-     *     ]
-     *   })
-     *   which opens app-tier-gate-modal.html if any feature exceeds tier.
-     */
-    alert('Mockup — Save would call TierGate.checkAndProceed before persist.\n\n(See onSave() comment for the feature list this page would emit.)');
-    markClean();
+    var tier = document.body.dataset.tier || 'creator';
+    var features = [];
+
+    // Custom domain (Pro+)
+    var dom = document.getElementById('custom-domain');
+    if (dom && dom.value && dom.value.trim()) {
+      features.push({
+        id: 'custom-domain', name: 'Custom contact-page domain', requires: 'pro',
+        meta: dom.value.trim()
+      });
+    }
+
+    // Office hours block (Creator+) — present iff opted in
+    var officeHours = document.querySelector('[data-section="office-hours"]:not([hidden])');
+    if (officeHours) {
+      features.push({
+        id: 'office-hours', name: 'Office hours block', requires: 'creator',
+        meta: 'Public schedule of when you typically reply.'
+      });
+    }
+
+    // FAQ quick-ref (Creator+)
+    var faqRef = document.querySelector('[data-section="faq-quickref"]:not([hidden])');
+    if (faqRef) {
+      features.push({
+        id: 'faq-quickref', name: 'FAQ quick-reference', requires: 'creator',
+        meta: 'Surfaces common questions inline before the form.'
+      });
+    }
+
+    // Multi-recipient routing (Business+)
+    var routing = document.querySelectorAll('[data-route-recipient]');
+    if (routing && routing.length > 1) {
+      features.push({
+        id: 'multi-recipient', name: 'Multi-recipient routing', requires: 'business',
+        meta: routing.length + ' destinations — different team members per topic.'
+      });
+    }
+
+    // Webhook providers per channel (Pro+)
+    var webhooks = document.querySelectorAll('.ff-webhook-on');
+    if (webhooks && webhooks.length) {
+      features.push({
+        id: 'webhook-providers', name: 'Webhook providers (Slack / Zapier / etc.)',
+        requires: 'pro',
+        meta: webhooks.length + ' channel' + (webhooks.length === 1 ? '' : 's') + ' wired up.'
+      });
+    }
+
+    // Field-level premium types
+    var fileFields   = document.querySelectorAll('[data-ff-type="file"]');
+    var hiddenFields = document.querySelectorAll('[data-ff-type="hidden"]');
+    var condFields   = document.querySelectorAll('[data-ff-conditional]');
+    if (fileFields.length)   features.push({ id: 'field-file',     name: 'File-upload field type', requires: 'pro',      meta: fileFields.length   + ' file field'   + (fileFields.length   === 1 ? '' : 's') });
+    if (hiddenFields.length) features.push({ id: 'field-hidden',   name: 'Hidden / UTM field',     requires: 'business', meta: hiddenFields.length + ' hidden field' + (hiddenFields.length === 1 ? '' : 's') });
+    if (condFields.length)   features.push({ id: 'field-conditional', name: 'Conditional field logic', requires: 'pro',  meta: condFields.length   + ' conditional rule' + (condFields.length === 1 ? '' : 's') });
+
+    if (window.TierGate) {
+      window.TierGate.checkAndProceed({
+        currentTier: tier,
+        features:    features,
+        onProceed:    function () { markClean(); },
+        onSaveWithout: features.length ? function () { markClean(); } : null,
+        onUpgrade:    function (top) { alert('Mockup — opens upgrade flow → ' + top); },
+        onCancel:     function () {},
+        toastMsg: 'Contact page saved'
+      });
+    } else {
+      markClean();
+    }
   }
 
   // ── Dirty / clean status ──

--- a/mockups/tadaify-mvp/app-page-custom.html
+++ b/mockups/tadaify-mvp/app-page-custom.html
@@ -891,14 +891,14 @@
               <label class="field-label" for="seo-title">Meta title <span class="field-hint">~60 chars · used by Google + share previews</span></label>
               <div class="field-prefix-wrap">
                 <input id="seo-title" type="text" value="Press kit — Alexandra Silva" />
-                <button class="field-suffix-action" onclick="alert('Mockup — opens the AI Suggest modal (app-ai-suggest-modal.html)')" type="button">✨ Suggest</button>
+                <button class="field-suffix-action" onclick="window.AISuggest.fromButton(this, 'Field')" type="button">✨ Suggest</button>
               </div>
             </div>
             <div class="field">
               <label class="field-label" for="seo-desc">Meta description <span class="field-hint">~155 chars</span></label>
               <div class="field-prefix-wrap" style="align-items:flex-start">
                 <textarea id="seo-desc" class="field-area" style="border:0; box-shadow:none; padding:10px 12px;">Logos, founder photos, key facts and approved bios — everything journalists, podcasters and partners need.</textarea>
-                <button class="field-suffix-action" onclick="alert('Mockup — AI Suggest')" type="button" style="margin-top:6px">✨ Suggest</button>
+                <button class="field-suffix-action" onclick="window.AISuggest.fromButton(this, 'Field')" type="button" style="margin-top:6px">✨ Suggest</button>
               </div>
             </div>
             <div class="field">

--- a/mockups/tadaify-mvp/app-page-faq.html
+++ b/mockups/tadaify-mvp/app-page-faq.html
@@ -925,7 +925,7 @@
           <button class="title-chip" onclick="setTitle('Help Center', 'help')">Help Center</button>
           <button class="title-chip" onclick="setTitle('Support', 'support')">Support</button>
           <button class="title-chip" onclick="setTitle('Common questions', 'questions')">Common questions</button>
-          <button class="title-chip" onclick="alert('Mockup — opens AI suggester for page title')"><span class="sparkle">✨</span> Suggest more</button>
+          <button class="title-chip" onclick="window.AISuggest.fromButton(this, 'Page title')"><span class="sparkle">✨</span> Suggest more</button>
         </div>
       </div>
       <div class="actions">
@@ -1014,14 +1014,14 @@
               <label class="field-label" for="seo-title">Meta title <span class="field-hint">~60 chars · used by Google + share previews</span></label>
               <div class="field-prefix-wrap">
                 <input id="seo-title" type="text" value="FAQ — Strong Not Skinny by Alexandra Silva" />
-                <button class="field-suffix-action" onclick="alert('Mockup — AI Suggest opens centered modal')" type="button">✨ Suggest</button>
+                <button class="field-suffix-action" onclick="window.AISuggest.fromButton(this, 'Field')" type="button">✨ Suggest</button>
               </div>
             </div>
             <div class="field">
               <label class="field-label" for="seo-desc">Meta description <span class="field-hint">~155 chars</span></label>
               <div class="field-prefix-wrap" style="align-items:flex-start">
                 <textarea id="seo-desc" class="field-area" style="border:0; box-shadow:none; padding:10px 12px;">Answers to common questions about training plans, refunds, coaching calls, and how to access your downloads.</textarea>
-                <button class="field-suffix-action" onclick="alert('Mockup — AI Suggest')" type="button" style="margin-top:6px">✨ Suggest</button>
+                <button class="field-suffix-action" onclick="window.AISuggest.fromButton(this, 'Field')" type="button" style="margin-top:6px">✨ Suggest</button>
               </div>
             </div>
           </div>
@@ -1404,7 +1404,7 @@
           <!-- AI bulk-suggest CTA strip -->
           <div class="sec-actions-row">
             <span style="font-size:12.5px; color:var(--fg-muted)">Need ideas?</span>
-            <button class="ai-cta" onclick="alert('Mockup — AI uses your bio + product context to suggest 5 starter questions you can accept one-by-one or in bulk. Creator+ feature; gates at Save.')">
+            <button class="ai-cta" onclick="window.AISuggest.fromButton(this, 'Starter questions')">
               ✨ AI suggest 5 common questions <span id="badge-ai"></span>
             </button>
             <span class="spacer"></span>
@@ -1654,7 +1654,7 @@
           </button>
           <button data-tip="Numbered list" aria-label="Numbered list">1.</button>
           <span class="rt-sep" style="margin-left:auto"></span>
-          <button data-tip="Generate full answer with AI" aria-label="AI suggest answer" onclick="alert('Mockup — AI generates a full answer based on the question + your bio context. Per FIX-SUGGEST-RESTORE-001 every long-form text field keeps ✨ Suggest.')">✨ Suggest</button>
+          <button data-tip="Generate full answer with AI" aria-label="AI suggest answer" onclick="window.AISuggest.fromButton(this, 'Answer')">✨ Suggest</button>
         </div>
         <textarea id="qa-answer" class="rt-area">After checkout you'll get an email from no-reply@tadaify.com with your download link. The link is also pinned in your account at tadaify.com/alexandra/account.
 

--- a/mockups/tadaify-mvp/app-page-legal.html
+++ b/mockups/tadaify-mvp/app-page-legal.html
@@ -1094,14 +1094,14 @@
                   <label class="field-label" for="seo-title">Meta title <span class="field-hint">~60 chars · only used if a visitor shares the link</span></label>
                   <div class="field-prefix-wrap">
                     <input id="seo-title" type="text" value="Legal — Strong Not Skinny by Alexandra Silva" />
-                    <button class="field-suffix-action" onclick="alert('Mockup — AI Suggest opens centered modal')" type="button">✨ Suggest</button>
+                    <button class="field-suffix-action" onclick="window.AISuggest.fromButton(this, 'Field')" type="button">✨ Suggest</button>
                   </div>
                 </div>
                 <div class="field">
                   <label class="field-label" for="seo-desc">Meta description <span class="field-hint">~155 chars</span></label>
                   <div class="field-prefix-wrap" style="align-items:flex-start">
                     <textarea id="seo-desc" class="field-area" style="border:0; box-shadow:none; padding:10px 12px;">Terms of Service, Privacy Policy, Refund Policy, and Cookie Policy for Strong Not Skinny products and coaching.</textarea>
-                    <button class="field-suffix-action" onclick="alert('Mockup — AI Suggest')" type="button" style="margin-top:6px">✨ Suggest</button>
+                    <button class="field-suffix-action" onclick="window.AISuggest.fromButton(this, 'Field')" type="button" style="margin-top:6px">✨ Suggest</button>
                   </div>
                 </div>
               </div>
@@ -1209,7 +1209,7 @@
                         <button data-tip="Bulleted list" onclick="alert('Mockup — bullet list')">•</button>
                         <button data-tip="Numbered list" onclick="alert('Mockup — numbered list')">1.</button>
                         <span class="rt-sep"></span>
-                        <button class="rt-suggest" onclick="alert('Mockup — opens AI suggester to clean up + tighten the wording (does NOT generate legal advice)')" type="button">✨ Suggest section</button>
+                        <button class="rt-suggest" onclick="window.AISuggest.fromButton(this, 'Section')" type="button">✨ Suggest section</button>
                       </div>
                       <textarea class="rt-area" id="rt-terms">## 1. Acceptance of terms
 

--- a/mockups/tadaify-mvp/app-page-newsletter-signup.html
+++ b/mockups/tadaify-mvp/app-page-newsletter-signup.html
@@ -928,14 +928,14 @@
                 <label class="field-label" for="seo-title">Meta title <span class="field-hint">~60 chars · used by Google + share previews</span></label>
                 <div class="field-prefix-wrap">
                   <input id="seo-title" type="text" value="Subscribe to Strong Not Skinny — by Alexandra Silva" />
-                  <button class="field-suffix-action" onclick="alert('Mockup — AI Suggest opens centered modal with 5 variants')" type="button">✨ Suggest</button>
+                  <button class="field-suffix-action" onclick="window.AISuggest.fromButton(this, 'Field')" type="button">✨ Suggest</button>
                 </div>
               </div>
               <div class="field">
                 <label class="field-label" for="seo-desc">Meta description <span class="field-hint">~155 chars</span></label>
                 <div class="field-prefix-wrap" style="align-items:flex-start">
                   <textarea id="seo-desc" class="field-area" style="border:0; box-shadow:none; padding:10px 12px;">Honest essays on training, recovery and building strength without burning out. New posts every Tuesday — straight to your inbox.</textarea>
-                  <button class="field-suffix-action" onclick="alert('Mockup — AI Suggest')" type="button" style="margin-top:6px">✨ Suggest</button>
+                  <button class="field-suffix-action" onclick="window.AISuggest.fromButton(this, 'Field')" type="button" style="margin-top:6px">✨ Suggest</button>
                 </div>
               </div>
               <div class="field">
@@ -1005,7 +1005,7 @@
             <label class="field-label" for="hero-headline">Headline <span class="field-hint">large, friendly, first thing visitors see</span></label>
             <div class="field-prefix-wrap">
               <input id="hero-headline" type="text" value="Get my weekly notes on training without burning out." />
-              <button class="field-suffix-action" onclick="alert('Mockup — AI Suggest 5 variants')" type="button">✨ Suggest</button>
+              <button class="field-suffix-action" onclick="window.AISuggest.fromButton(this, 'Field')" type="button">✨ Suggest</button>
             </div>
             <div style="display:flex; gap:6px; flex-wrap:wrap; margin-top:6px">
               <button class="chip" type="button" onclick="setHeadline(this)" style="cursor:pointer">Get my weekly notes</button>
@@ -1019,7 +1019,7 @@
             <label class="field-label" for="hero-sub">Sub-headline</label>
             <div class="field-prefix-wrap" style="align-items:flex-start">
               <textarea id="hero-sub" class="field-area" style="border:0; box-shadow:none; padding:10px 12px;">One short, honest email every Tuesday. Drills, mindset shifts, recovery tactics — no spam, no fluff.</textarea>
-              <button class="field-suffix-action" onclick="alert('Mockup — AI Suggest')" type="button" style="margin-top:6px">✨ Suggest</button>
+              <button class="field-suffix-action" onclick="window.AISuggest.fromButton(this, 'Field')" type="button" style="margin-top:6px">✨ Suggest</button>
             </div>
           </div>
 
@@ -1280,7 +1280,7 @@
             <label class="field-label" for="success-msg">Success message <span class="field-hint">shown after a visitor signs up</span></label>
             <div class="field-prefix-wrap">
               <input id="success-msg" type="text" value="Thanks! Check your inbox to confirm your subscription." />
-              <button class="field-suffix-action" onclick="alert('Mockup — AI Suggest')" type="button">✨ Suggest</button>
+              <button class="field-suffix-action" onclick="window.AISuggest.fromButton(this, 'Field')" type="button">✨ Suggest</button>
             </div>
           </div>
         </div>
@@ -1348,7 +1348,7 @@
               <label class="field-label" for="form-cta">Button label</label>
               <div class="field-prefix-wrap">
                 <input id="form-cta" type="text" value="Subscribe" />
-                <button class="field-suffix-action" onclick="alert('Mockup — AI Suggest')" type="button">✨ Suggest</button>
+                <button class="field-suffix-action" onclick="window.AISuggest.fromButton(this, 'Field')" type="button">✨ Suggest</button>
               </div>
             </div>
           </div>
@@ -1822,7 +1822,7 @@
       </div>
     </div>
     <div class="modal-foot">
-      <button class="btn btn-warm btn-sm" onclick="alert('Mockup — AI generates 4 hero images')">✨ Generate with AI</button>
+      <button class="btn btn-warm btn-sm" onclick="window.AISuggest.fromButton(this, 'Hero image')">✨ Generate with AI</button>
       <span class="foot-spacer"></span>
       <button class="btn btn-ghost btn-sm" onclick="closeModal('image-picker-modal')">Cancel</button>
       <button class="btn btn-primary btn-sm" onclick="closeModal('image-picker-modal')">Use selected</button>

--- a/mockups/tadaify-mvp/app-page-newsletter-signup.html
+++ b/mockups/tadaify-mvp/app-page-newsletter-signup.html
@@ -2059,30 +2059,66 @@
     clearTimeout(saveTimer);
   }
   function savePage() {
-    /* TierGate placeholder — in production, collect every premium feature
-       the creator enabled (custom domain, A/B test, public count >2.5k for
-       Free tier, past-issues preview for Free tier) and call:
+    var tier = document.body.getAttribute('data-tier') || 'creator';
+    var features = [];
 
-         TierGate.checkAndProceed({
-           currentTier: document.body.getAttribute('data-tier'),
-           features: [
-             { id: 'custom-domain', name: 'Custom domain', requires: 'pro',
-               meta: 'subscribe.alexandrasilva.com' },
-             { id: 'ab-test', name: 'A/B test variants', requires: 'business',
-               meta: 'Two headline variants' },
-             { id: 'past-issues', name: 'Past issues preview', requires: 'creator',
-               meta: '3 most recent posts pulled from Kit' },
-             { id: 'public-count', name: 'Show subscriber count >2,500', requires: 'creator',
-               meta: 'Currently 24,512 subscribers' }
-           ],
-           onProceed:     function () { realSave(); },
-           onSaveWithout: function () { realSave({ skipPremium: true }); },
-           onUpgrade:     function (tier) { window.location.href = '/pricing?upgrade=' + tier; }
-         });
-    */
-    var st = document.getElementById('save-status');
-    st.classList.remove('is-dirty');
-    st.querySelector('span:last-child').textContent = 'All changes saved · just now';
+    // Custom domain (Pro+)
+    var dom = document.getElementById('custom-domain');
+    if (dom && dom.value && dom.value.trim()) {
+      features.push({
+        id: 'custom-domain', name: 'Custom signup domain', requires: 'pro',
+        meta: dom.value.trim()
+      });
+    }
+
+    // A/B test variants (Business+) — when both A and B headlines are set
+    var hA = document.getElementById('ab-headline-a');
+    var hB = document.getElementById('ab-headline-b');
+    if (hA && hB && hA.value.trim() && hB.value.trim() && hA.value.trim() !== hB.value.trim()) {
+      features.push({
+        id: 'ab-test', name: 'A/B test variants', requires: 'business',
+        meta: 'Two headline variants'
+      });
+    }
+
+    // Past-issues preview block (Creator+)
+    var pastIssues = document.querySelector('[data-section="past-issues"]:not([hidden])');
+    if (pastIssues) {
+      features.push({
+        id: 'past-issues', name: 'Past issues preview', requires: 'creator',
+        meta: 'Most recent posts pulled from your provider'
+      });
+    }
+
+    // Public subscriber count > 2,500 (Creator+)
+    var countEl = document.querySelector('[data-public-count]');
+    var countNum = countEl ? parseInt(String(countEl.getAttribute('data-public-count')).replace(/[^\d]/g, ''), 10) : 0;
+    if (countNum > 2500) {
+      features.push({
+        id: 'public-count', name: 'Show subscriber count above 2,500', requires: 'creator',
+        meta: 'Currently ' + countNum.toLocaleString() + ' subscribers'
+      });
+    }
+
+    function realSave() {
+      var st = document.getElementById('save-status');
+      st.classList.remove('is-dirty');
+      st.querySelector('span:last-child').textContent = 'All changes saved · just now';
+    }
+
+    if (window.TierGate) {
+      window.TierGate.checkAndProceed({
+        currentTier: tier,
+        features:    features,
+        onProceed:    realSave,
+        onSaveWithout: features.length ? realSave : null,
+        onUpgrade:    function (top) { alert('Mockup — opens upgrade flow → ' + top); },
+        onCancel:     function () {},
+        toastMsg: 'Signup page saved'
+      });
+    } else {
+      realSave();
+    }
   }
 
   // ── Init ──

--- a/mockups/tadaify-mvp/app-page-portfolio.html
+++ b/mockups/tadaify-mvp/app-page-portfolio.html
@@ -1045,14 +1045,14 @@
               <label class="field-label" for="seo-title">Meta title <span class="field-hint">~60 chars · used by Google + share previews</span></label>
               <div class="field-prefix-wrap">
                 <input id="seo-title" type="text" value="Selected work — Alexandra Silva, art direction & illustration" />
-                <button class="field-suffix-action" onclick="alert('Mockup — AI Suggest opens centered modal')" type="button">✨ Suggest</button>
+                <button class="field-suffix-action" onclick="window.AISuggest.fromButton(this, 'Field')" type="button">✨ Suggest</button>
               </div>
             </div>
             <div class="field">
               <label class="field-label" for="seo-desc">Meta description <span class="field-hint">~155 chars</span></label>
               <div class="field-prefix-wrap" style="align-items:flex-start">
                 <textarea id="seo-desc" class="field-area" style="border:0; box-shadow:none; padding:10px 12px;">A growing collection of brand systems, illustrations and lettering pieces. Available for commissions — Lisbon &amp; remote.</textarea>
-                <button class="field-suffix-action" onclick="alert('Mockup — AI Suggest')" type="button" style="margin-top:6px">✨ Suggest</button>
+                <button class="field-suffix-action" onclick="window.AISuggest.fromButton(this, 'Field')" type="button" style="margin-top:6px">✨ Suggest</button>
               </div>
             </div>
             <div class="field">
@@ -1556,7 +1556,7 @@
         <label class="field-label" for="pm-title-input">Title</label>
         <div class="field-prefix-wrap">
           <input id="pm-title-input" type="text" value="Sourdough &amp; Co — bakery rebrand" />
-          <button class="field-suffix-action" onclick="alert('Mockup — AI suggests 5 alternative titles based on tags + client')" type="button">✨ Suggest</button>
+          <button class="field-suffix-action" onclick="window.AISuggest.fromButton(this, 'Title')" type="button">✨ Suggest</button>
         </div>
       </div>
 
@@ -1618,7 +1618,7 @@
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><circle cx="4" cy="6" r="1"/><circle cx="4" cy="12" r="1"/><circle cx="4" cy="18" r="1"/></svg>
           </button>
           <span class="rt-sep" style="margin-left:auto"></span>
-          <button data-tip="Generate description with AI" aria-label="AI suggest" onclick="alert('Mockup — AI generates a 2-paragraph case study based on title + tags + client')">✨</button>
+          <button data-tip="Generate description with AI" aria-label="AI suggest" onclick="window.AISuggest.fromButton(this, 'Description')">✨</button>
         </div>
         <textarea id="pm-body" class="rt-area">A 4-month rebrand for a Lisbon neighborhood bakery. Identity, packaging system across 12 SKUs, three custom illustrations for the seasonal range, and a printed loyalty card.
 

--- a/mockups/tadaify-mvp/app-page-schedule.html
+++ b/mockups/tadaify-mvp/app-page-schedule.html
@@ -924,7 +924,7 @@
             <label class="field-label" for="page-title">Page title <span class="field-hint">shown as &lt;h1&gt; on the public page</span></label>
             <div class="field-prefix-wrap">
               <input id="page-title" type="text" value="Book a session" />
-              <button class="field-suffix-action" onclick="alert('Mockup — AI suggests 5 alternative titles like \\'Schedule a call\\', \\'Work with me\\', \\'Coaching sessions\\'')" type="button">✨ Suggest</button>
+              <button class="field-suffix-action" onclick="window.AISuggest.fromButton(this, 'Title')" type="button">✨ Suggest</button>
             </div>
           </div>
 
@@ -973,14 +973,14 @@
               <label class="field-label" for="seo-title">Meta title <span class="field-hint">~60 chars · used by Google + share previews</span></label>
               <div class="field-prefix-wrap">
                 <input id="seo-title" type="text" value="Book a session with Alexandra Silva — strength coaching" />
-                <button class="field-suffix-action" onclick="alert('Mockup — AI Suggest opens centered modal')" type="button">✨ Suggest</button>
+                <button class="field-suffix-action" onclick="window.AISuggest.fromButton(this, 'Field')" type="button">✨ Suggest</button>
               </div>
             </div>
             <div class="field">
               <label class="field-label" for="seo-desc">Meta description <span class="field-hint">~155 chars</span></label>
               <div class="field-prefix-wrap" style="align-items:flex-start">
                 <textarea id="seo-desc" class="field-area" style="border:0; box-shadow:none; padding:10px 12px;">Personal coaching for women lifting heavy. 30-min intros are free; 60-min programmes start at $80. Book a slot below — calendar invite arrives in 30 seconds.</textarea>
-                <button class="field-suffix-action" onclick="alert('Mockup — AI Suggest')" type="button" style="margin-top:6px">✨ Suggest</button>
+                <button class="field-suffix-action" onclick="window.AISuggest.fromButton(this, 'Field')" type="button" style="margin-top:6px">✨ Suggest</button>
               </div>
             </div>
           </div>
@@ -1552,7 +1552,7 @@
               <label class="field-label" for="conf-subject">Subject</label>
               <div class="field-prefix-wrap">
                 <input id="conf-subject" type="text" value="You're booked! — {{booking_type}} with Alexandra on {{date}}" />
-                <button class="field-suffix-action" onclick="alert('Mockup — AI suggests 5 friendly subjects')" type="button">✨ Suggest</button>
+                <button class="field-suffix-action" onclick="window.AISuggest.fromButton(this, 'Subject')" type="button">✨ Suggest</button>
               </div>
             </div>
             <div class="field">
@@ -1671,7 +1671,7 @@ If anything changes, you can {{cancel_link}}. No charge if you cancel more than 
         <label class="field-label" for="tm-title-input">Title <span class="field-hint">what visitors see in the picker</span></label>
         <div class="field-prefix-wrap">
           <input id="tm-title-input" type="text" value="60-min coaching session" />
-          <button class="field-suffix-action" onclick="alert('Mockup — AI suggests 5 alternatives like \\'Strength deep-dive\\', \\'Programme review\\', \\'1-on-1 lifting session\\'')" type="button">✨ Suggest</button>
+          <button class="field-suffix-action" onclick="window.AISuggest.fromButton(this, 'Title')" type="button">✨ Suggest</button>
         </div>
       </div>
 

--- a/mockups/tadaify-mvp/app-settings-theme.html
+++ b/mockups/tadaify-mvp/app-settings-theme.html
@@ -2342,12 +2342,32 @@
     setTimeout(function(){ bar.classList.remove('is-saved'); document.getElementById('save-text').textContent = 'Preview only — your live page hasn’t changed yet.'; }, 4000);
   }
   function applyTheme() {
-    /* Mock TierGate.checkAndProceed — would gate premium features here. */
-    if (currentTier === 'free' && (currentPreset !== 'indigo' && currentPreset !== 'mono' && currentPreset !== 'pastel' && currentPreset !== 'glass' && currentPreset !== 'earth' && currentPreset !== 'neon' && currentPreset !== 'sunrise' && currentPreset !== 'editorial')) {
-      alert('Mock: TierGate.checkAndProceed({ features: [\'custom-palette\'], onProceed: applyTheme, onUpgrade: ... })');
-      return;
+    var FREE_PRESETS = ['indigo', 'mono', 'pastel', 'glass', 'earth', 'neon', 'sunrise', 'editorial'];
+    var features = [];
+    if (FREE_PRESETS.indexOf(currentPreset) === -1) {
+      features.push({
+        id: 'custom-palette', name: 'Custom palette', requires: 'creator',
+        meta: 'Premium preset (Free tier limited to the 8 starter palettes).'
+      });
     }
-    markSaved();
+    if (window.TierGate) {
+      window.TierGate.checkAndProceed({
+        currentTier: currentTier,
+        features:    features,
+        onProceed:    markSaved,
+        onSaveWithout: features.length ? function () {
+          /* Save-without: revert to the closest Free preset (indigo) and save. */
+          var indigo = document.querySelector('[data-preset="indigo"]');
+          if (indigo) applyPreset(indigo, 'indigo');
+          markSaved();
+        } : null,
+        onUpgrade:    function (top) { alert('Mockup — opens upgrade flow → ' + top); },
+        onCancel:     function () {},
+        toastMsg: 'Theme published'
+      });
+    } else {
+      markSaved();
+    }
   }
   function discardChanges() {
     if (!dirty) return;

--- a/mockups/tadaify-mvp/app-tier-gate-modal.html
+++ b/mockups/tadaify-mvp/app-tier-gate-modal.html
@@ -1,5 +1,31 @@
 <!DOCTYPE html>
 <!--
+  ============================================================================
+  NOTE — GLOBAL AVAILABILITY (added by chore/wire-tier-gate-and-ai-suggest-globals)
+
+  This standalone file remains the canonical DESIGN reference + demo for the
+  TierGate flow (every state, every tier-target panel, copy variations, etc.)
+  but the runtime implementation now ships globally via:
+
+      shared/partials.js → window.TierGate.checkAndProceed({ ... })
+
+  Every editor mockup that includes <script src="./shared/partials.js"> can
+  call TierGate from JS without copying any markup or CSS. The contract:
+
+      window.TierGate.checkAndProceed({
+        currentTier: 'free' | 'creator' | 'pro' | 'business',
+        features: [{ id, name, requires, meta }],
+        onProceed:    function () {},   // tier OK — save now
+        onSaveWithout: function () {},  // strip premium, save the rest
+        onUpgrade:    function (top, cycle) {}  // open Stripe checkout
+      });
+
+  When currentTier already covers every feature → onProceed fires immediately
+  + a small "All set ✓" toast confirms (no modal). Otherwise the modal opens.
+
+  Pricing is read from window.TierGate.TIER_PRICING (mirrors pricing.html).
+  ============================================================================
+
   TierGate modal — the SHARED upsell modal that appears when a creator
   clicks "Save" on a feature requiring a higher subscription tier than
   they currently have.

--- a/mockups/tadaify-mvp/shared/partials.js
+++ b/mockups/tadaify-mvp/shared/partials.js
@@ -1040,9 +1040,60 @@
     TIER_LABEL:   TIER_LABEL,
     TIER_PRICING: TIER_PRICING
   };
+  /* Convenience wrapper for the most common case: a ✨ Suggest button sat
+     next to an input or textarea inside a wrapper.
+
+     Usage in markup:
+       <div class="input-wrap">
+         <input id="seo-title" type="text" />
+         <button type="button"
+                 onclick="window.AISuggest.fromButton(this, 'SEO title')">
+           ✨ Suggest
+         </button>
+       </div>
+
+     The helper hunts up to 3 ancestors looking for an input / textarea
+     sibling; first match wins. It writes the picked suggestion back into
+     `.value` and fires both `input` and `change` events so any dirty
+     tracker on the page picks up the edit. */
+  function fromButton(btn, fieldName, contextSummary) {
+    if (!btn) return;
+    var field = null;
+    var el = btn;
+    for (var i = 0; i < 4 && el && !field; i++) {
+      el = el.parentElement;
+      if (!el) break;
+      field = el.querySelector('input:not([type=hidden]), textarea, [contenteditable="true"]');
+    }
+    /* Treat generic "Field" label as a fall-through hint to use the input's
+       own placeholder / id. Keeps mechanical wiring concise without losing
+       per-field context in the modal title. */
+    var label = fieldName;
+    if (!label || label === 'Field') {
+      label = (field && (field.getAttribute('placeholder') || field.getAttribute('aria-label') || field.id)) || 'this field';
+    }
+    openAi({
+      fieldName:      label,
+      contextSummary: contextSummary || '',
+      onApply: function (text) {
+        if (!field) return;
+        if (field.isContentEditable) {
+          field.textContent = text;
+        } else {
+          field.value = text;
+        }
+        try {
+          field.dispatchEvent(new Event('input',  { bubbles: true }));
+          field.dispatchEvent(new Event('change', { bubbles: true }));
+        } catch (e) { /* old browsers */ }
+      }
+    });
+  }
+
   window.AISuggest = {
-    open:  openAi,
-    close: closeAi,
+    open:       openAi,
+    close:      closeAi,
+    fromButton: fromButton,
     /* Programmatic state — useful for tests and the standalone demo file. */
     setState: function (kind) { renderAiState(kind); }
   };

--- a/mockups/tadaify-mvp/shared/partials.js
+++ b/mockups/tadaify-mvp/shared/partials.js
@@ -278,6 +278,20 @@
   var TIER_RANK = { free: 0, creator: 1, pro: 2, business: 3 };
   var TIER_LABEL = { free: 'Free', creator: 'Creator', pro: 'Pro', business: 'Business' };
 
+  /* Tier pricing — single source of truth, mirrors pricing.html.
+     Yearly = 10/12 of monthly (canonical "Save 2 months" rule). */
+  var TIER_PRICING = {
+    free:     { monthly: 0,  yearly: 0   },
+    creator:  { monthly: 8,  yearly: 80  },  // ~$6.67/mo billed yearly
+    pro:      { monthly: 19, yearly: 190 },  // ~$15.83/mo billed yearly
+    business: { monthly: 49, yearly: 490 }   // ~$40.83/mo billed yearly
+  };
+  function priceFor(tier, cycle) {
+    var t = TIER_PRICING[tier] || TIER_PRICING.business;
+    if (cycle === 'yearly') return Math.round((t.yearly / 12) * 100) / 100;
+    return t.monthly;
+  }
+
   var TIER_BADGE_CSS = '' +
     '<style data-source="tier-badge-partial">' +
     /* Inline pill rendered next to a section heading */
@@ -382,8 +396,63 @@
     'body.dark-mode .tdf-gate-actions { border-top-color: #1F2937; }' +
     'body.dark-mode .tdf-gate-actions .gate-secondary { background: #141A2D; color: #F3F4F6; border-color: #1F2937; }' +
     'body.dark-mode .tdf-gate-actions .gate-secondary:hover { background: #1F2937; }' +
+    /* Monthly / yearly billing toggle inside the gate footer */
+    '.tdf-gate-cycle {' +
+    '  display: inline-flex; align-items: center; gap: 4px;' +
+    '  padding: 3px; border-radius: 99px;' +
+    '  background: var(--bg-muted, #F3F4F6);' +
+    '  font-family: var(--font-sans, Inter, system-ui, sans-serif);' +
+    '  font-size: 11.5px; font-weight: 600;' +
+    '  margin: 0 auto 8px;' +
+    '}' +
+    '.tdf-gate-cycle button {' +
+    '  border: 0; background: transparent; cursor: pointer;' +
+    '  padding: 5px 12px; border-radius: 99px;' +
+    '  color: var(--fg-muted, #6B7280);' +
+    '  font: inherit;' +
+    '  transition: background .12s ease, color .12s ease;' +
+    '}' +
+    '.tdf-gate-cycle button.is-active {' +
+    '  background: var(--bg-elevated, #fff);' +
+    '  color: var(--fg, #111);' +
+    '  box-shadow: 0 1px 3px rgba(11,15,30,0.12);' +
+    '}' +
+    '.tdf-gate-cycle .save-badge {' +
+    '  font-size: 9.5px; font-weight: 700;' +
+    '  margin-left: 4px;' +
+    '  color: #047857; letter-spacing: 0.04em;' +
+    '}' +
+    'body.dark-mode .tdf-gate-cycle { background: #1F2937; }' +
+    'body.dark-mode .tdf-gate-cycle button { color: #9CA3AF; }' +
+    'body.dark-mode .tdf-gate-cycle button.is-active { background: #0B0F1E; color: #F3F4F6; }' +
+    'body.dark-mode .tdf-gate-cycle .save-badge { color: #6EE7B7; }' +
+    '.tdf-gate-actions .gate-primary .price-sub {' +
+    '  display: block;' +
+    '  font-size: 10.5px; font-weight: 500; opacity: 0.85;' +
+    '  margin-top: 2px;' +
+    '}' +
+    /* "All set" silent-success toast — bottom-right */
+    '.tdf-toast {' +
+    '  position: fixed; right: 20px; bottom: 20px; z-index: 1100;' +
+    '  display: inline-flex; align-items: center; gap: 8px;' +
+    '  padding: 10px 14px; border-radius: 10px;' +
+    '  background: #047857; color: #fff;' +
+    '  font-family: var(--font-sans, Inter, system-ui, sans-serif);' +
+    '  font-size: 13px; font-weight: 600;' +
+    '  box-shadow: 0 12px 32px rgba(11,15,30,0.20);' +
+    '  opacity: 0; transform: translateY(8px);' +
+    '  transition: opacity .16s ease, transform .16s ease;' +
+    '  pointer-events: none;' +
+    '}' +
+    '.tdf-toast.is-visible { opacity: 1; transform: translateY(0); }' +
+    '.tdf-toast .toast-check {' +
+    '  width: 18px; height: 18px; border-radius: 50%;' +
+    '  background: rgba(255,255,255,0.20);' +
+    '  display: inline-flex; align-items: center; justify-content: center;' +
+    '  font-size: 11px;' +
+    '}' +
     '@media (prefers-reduced-motion: reduce) {' +
-    '  .tdf-gate-backdrop, .tdf-gate { transition: none !important; }' +
+    '  .tdf-gate-backdrop, .tdf-gate, .tdf-toast { transition: none !important; }' +
     '}' +
     '</style>';
 
@@ -439,6 +508,9 @@
     return highest;
   }
 
+  /* Per-modal billing cycle (default monthly; persisted across re-opens). */
+  var gateCycle = 'monthly';
+
   function ensureGateDom() {
     if (document.getElementById('tdf-gate-backdrop')) return;
     ensureTierCss();
@@ -454,6 +526,10 @@
             '<ul class="tdf-gate-list" id="tdf-gate-list"></ul>' +
           '</div>' +
           '<div class="tdf-gate-actions">' +
+            '<div class="tdf-gate-cycle" role="group" aria-label="Billing cycle">' +
+              '<button type="button" id="tdf-gate-monthly" class="is-active" data-cycle="monthly">Monthly</button>' +
+              '<button type="button" id="tdf-gate-yearly" data-cycle="yearly">Yearly<span class="save-badge">−2 mo</span></button>' +
+            '</div>' +
             '<button type="button" class="gate-primary" id="tdf-gate-upgrade">Upgrade →</button>' +
             '<button type="button" class="gate-secondary" id="tdf-gate-save-without">Save without premium changes</button>' +
             '<button type="button" class="gate-ghost" id="tdf-gate-cancel">Cancel — keep editing</button>' +
@@ -466,6 +542,17 @@
     document.addEventListener('keydown', function (e) {
       if (e.key === 'Escape' && bd.classList.contains('is-open')) closeGate();
     });
+  }
+
+  /* Update the upgrade button label to reflect current cycle + tier. */
+  function paintUpgradeButton(top) {
+    var btn = document.getElementById('tdf-gate-upgrade');
+    if (!btn) return;
+    var topLabel = TIER_LABEL[top] || 'Business';
+    var price = priceFor(top, gateCycle);
+    var cadence = gateCycle === 'yearly' ? '/mo billed yearly' : '/mo';
+    btn.innerHTML = 'Upgrade to ' + topLabel +
+      ' — $' + price + '<span class="price-sub">' + cadence + '</span>';
   }
 
   function closeGate() {
@@ -505,15 +592,48 @@
 
     /* Hide "save without" if there are no non-premium changes to save (caller signals via hooks.allowSaveWithout). */
     btnSv.style.display = (hooks && hooks.onSaveWithout) ? '' : 'none';
-    btnUp.textContent = 'Upgrade to ' + topLabel + ' →';
+    paintUpgradeButton(top);
 
-    btnUp.onclick = function () { closeGate(); if (hooks && hooks.onUpgrade) hooks.onUpgrade(top); };
+    /* Wire monthly/yearly toggle (re-paints upgrade label live). */
+    var btnMonthly = document.getElementById('tdf-gate-monthly');
+    var btnYearly  = document.getElementById('tdf-gate-yearly');
+    function setCycle(c) {
+      gateCycle = c;
+      btnMonthly.classList.toggle('is-active', c === 'monthly');
+      btnYearly.classList.toggle('is-active',  c === 'yearly');
+      paintUpgradeButton(top);
+    }
+    btnMonthly.onclick = function () { setCycle('monthly'); };
+    btnYearly.onclick  = function () { setCycle('yearly');  };
+    setCycle(gateCycle);
+
+    btnUp.onclick = function () { closeGate(); if (hooks && hooks.onUpgrade) hooks.onUpgrade(top, gateCycle); };
     btnSv.onclick = function () { closeGate(); if (hooks && hooks.onSaveWithout) hooks.onSaveWithout(); };
     btnCx.onclick = function () { closeGate(); if (hooks && hooks.onCancel) hooks.onCancel(); };
 
     bd.removeAttribute('hidden');
     requestAnimationFrame(function () { bd.classList.add('is-open'); });
     setTimeout(function () { btnUp.focus(); }, 60);
+  }
+
+  /* ---- "All set ✓" silent-success toast (used when current tier already
+         covers every requested feature — no modal, just confirmation). */
+  var toastTimer = null;
+  function showToast(msg) {
+    ensureTierCss();
+    var t = document.getElementById('tdf-toast');
+    if (!t) {
+      document.body.insertAdjacentHTML('beforeend',
+        '<div class="tdf-toast" id="tdf-toast" role="status" aria-live="polite">' +
+          '<span class="toast-check" aria-hidden="true">✓</span>' +
+          '<span class="toast-msg"></span>' +
+        '</div>');
+      t = document.getElementById('tdf-toast');
+    }
+    t.querySelector('.toast-msg').textContent = msg;
+    t.classList.add('is-visible');
+    if (toastTimer) clearTimeout(toastTimer);
+    toastTimer = setTimeout(function () { t.classList.remove('is-visible'); }, 2200);
   }
 
   function checkAndProceed(opts) {
@@ -524,6 +644,11 @@
     });
     if (features.length === 0) {
       if (opts.onProceed) opts.onProceed();
+      /* Silent success path: tiny "All set ✓" confirmation per
+         feedback_no_blur_premium_features (no modal when nothing is gated). */
+      if (opts.toast !== false) {
+        showToast(opts.toastMsg || 'All set ✓');
+      }
       return;
     }
     openGate(features, current, {
@@ -531,6 +656,374 @@
       onSaveWithout: opts.onSaveWithout,
       onCancel:      opts.onCancel
     });
+  }
+
+  /* ----------------------------------------------------------------- */
+  /* AI Suggest — global sub-modal for ✨ Suggest buttons              */
+  /*                                                                    */
+  /* Usage:                                                             */
+  /*   AISuggest.open({                                                 */
+  /*     fieldName: 'Block title',                                       */
+  /*     contextSummary: 'Link button → open.spotify.com/album/...',    */
+  /*     onApply: function (text) { input.value = text; }               */
+  /*   });                                                              */
+  /*                                                                    */
+  /* States: loaded (5 cards, default) / loading (skeletons) / error /  */
+  /* empty / rate / selected. The default open() flow shows Loading for */
+  /* 800ms then Loaded with 5 mocked suggestions matched to fieldName. */
+  /* ----------------------------------------------------------------- */
+  var AI_SUGGEST_CSS = '' +
+    '<style data-source="ai-suggest-partial">' +
+    '.tdf-ai-backdrop {' +
+    '  position: fixed; inset: 0; z-index: 1050;' +
+    '  background: rgba(11,15,30,0.55);' +
+    '  backdrop-filter: blur(3px); -webkit-backdrop-filter: blur(3px);' +
+    '  display: none; align-items: center; justify-content: center;' +
+    '  padding: 16px; opacity: 0; transition: opacity .16s ease;' +
+    '  font-family: var(--font-sans, Inter, system-ui, sans-serif);' +
+    '}' +
+    '.tdf-ai-backdrop.is-open { display: flex; opacity: 1; }' +
+    '.tdf-ai {' +
+    '  background: var(--bg-elevated, #fff); color: var(--fg, #111);' +
+    '  border: 1px solid var(--border, rgba(0,0,0,0.08));' +
+    '  border-radius: 16px; box-shadow: 0 24px 60px rgba(11,15,30,0.25);' +
+    '  width: min(540px, 96vw); max-height: 88vh;' +
+    '  display: flex; flex-direction: column; overflow: hidden;' +
+    '  transform: translateY(8px) scale(0.985);' +
+    '  transition: transform .16s ease;' +
+    '}' +
+    '.tdf-ai-backdrop.is-open .tdf-ai { transform: translateY(0) scale(1); }' +
+    '.tdf-ai-head {' +
+    '  padding: 16px 20px; border-bottom: 1px solid var(--border, rgba(0,0,0,0.08));' +
+    '  display: flex; align-items: center; gap: 10px; flex-shrink: 0;' +
+    '}' +
+    '.tdf-ai-head h3 {' +
+    '  font-family: var(--font-display, "Crimson Pro", serif);' +
+    '  font-size: 18px; font-weight: 600; flex: 1; margin: 0;' +
+    '  letter-spacing: -0.01em;' +
+    '}' +
+    '.tdf-ai-head h3 .sparkle { color: var(--brand-warm, #F59E0B); margin-right: 4px; }' +
+    '.tdf-ai-head h3 .target  { color: var(--brand-primary, #6366F1); }' +
+    '.tdf-ai-head .ai-x {' +
+    '  border: 0; background: transparent; cursor: pointer;' +
+    '  width: 32px; height: 32px; border-radius: 8px;' +
+    '  color: var(--fg-muted, #6B7280);' +
+    '  display: inline-flex; align-items: center; justify-content: center;' +
+    '  font-size: 18px; line-height: 1;' +
+    '}' +
+    '.tdf-ai-head .ai-x:hover { background: var(--bg-muted, #F9FAFB); color: var(--fg, #111); }' +
+    '.tdf-ai-body {' +
+    '  padding: 14px 20px; overflow-y: auto;' +
+    '  display: flex; flex-direction: column; gap: 12px;' +
+    '}' +
+    '.tdf-ai-ctx {' +
+    '  display: flex; gap: 8px; padding: 10px 12px;' +
+    '  background: var(--bg-muted, #F9FAFB); border-radius: 10px;' +
+    '  font-size: 12.5px; color: var(--fg-muted, #6B7280); line-height: 1.5;' +
+    '}' +
+    '.tdf-ai-ctx .ctx-ico { flex-shrink: 0; color: var(--brand-primary, #6366F1); font-size: 14px; line-height: 1.2; }' +
+    '.tdf-ai-head-row {' +
+    '  display: flex; align-items: center; justify-content: space-between;' +
+    '  font-size: 11.5px; color: var(--fg-muted, #6B7280);' +
+    '  text-transform: uppercase; letter-spacing: 0.05em; font-weight: 600;' +
+    '}' +
+    '.tdf-ai-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }' +
+    '.tdf-ai-card {' +
+    '  display: flex; gap: 10px; align-items: flex-start; width: 100%;' +
+    '  padding: 11px 12px; background: var(--bg, #fff);' +
+    '  border: 1.5px solid var(--border, rgba(0,0,0,0.08));' +
+    '  border-radius: 10px; cursor: pointer; text-align: left;' +
+    '  font-family: inherit; transition: border-color .12s ease, background .12s ease;' +
+    '}' +
+    '.tdf-ai-card:hover { border-color: var(--border-strong, rgba(0,0,0,0.16)); background: var(--bg-elevated, #fff); }' +
+    '.tdf-ai-card.is-selected { border-color: var(--brand-primary, #6366F1); background: rgba(99,102,241,0.06); box-shadow: 0 0 0 3px rgba(99,102,241,0.10); }' +
+    '.tdf-ai-card .idx {' +
+    '  flex-shrink: 0; width: 22px; height: 22px; border-radius: 7px;' +
+    '  background: var(--bg-muted, #F9FAFB); color: var(--fg-muted, #6B7280);' +
+    '  font-size: 11px; font-weight: 700;' +
+    '  display: inline-flex; align-items: center; justify-content: center;' +
+    '  font-family: var(--font-mono, "JetBrains Mono", monospace);' +
+    '  margin-top: 1px;' +
+    '}' +
+    '.tdf-ai-card.is-selected .idx { background: var(--brand-primary, #6366F1); color: #fff; }' +
+    '.tdf-ai-card .copy { flex: 1; min-width: 0; font-size: 13.5px; line-height: 1.45; color: var(--fg, #111); font-weight: 500; }' +
+    '.tdf-ai-card .tag { flex-shrink: 0; font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; padding: 2px 7px; border-radius: 99px; background: var(--bg-muted, #F9FAFB); color: var(--fg-muted, #6B7280); margin-top: 2px; }' +
+    '.tdf-ai-card.is-selected .tag { background: rgba(245,158,11,0.16); color: #92400E; }' +
+    /* Skeleton (loading) */
+    '.tdf-ai-skel {' +
+    '  display: flex; gap: 10px; align-items: flex-start;' +
+    '  padding: 11px 12px; background: var(--bg, #fff);' +
+    '  border: 1.5px solid var(--border, rgba(0,0,0,0.08));' +
+    '  border-radius: 10px;' +
+    '}' +
+    '.tdf-ai-skel .sk {' +
+    '  background: linear-gradient(90deg, var(--bg-muted, #F3F4F6) 0%, rgba(0,0,0,0.04) 50%, var(--bg-muted, #F3F4F6) 100%);' +
+    '  background-size: 200% 100%;' +
+    '  animation: tdf-shim 1.4s linear infinite;' +
+    '  border-radius: 6px;' +
+    '}' +
+    '.tdf-ai-skel .sk-idx { width: 22px; height: 22px; border-radius: 7px; flex-shrink: 0; margin-top: 1px; }' +
+    '.tdf-ai-skel .sk-copy { flex: 1; }' +
+    '.tdf-ai-skel .sk-line { height: 12px; }' +
+    '.tdf-ai-skel .sk-line.l1 { width: 70%; }' +
+    '.tdf-ai-skel .sk-line.l2 { width: 45%; margin-top: 7px; }' +
+    '.tdf-ai-skel .sk-tag { width: 50px; height: 16px; border-radius: 99px; flex-shrink: 0; margin-top: 1px; }' +
+    '@keyframes tdf-shim { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }' +
+    /* Error / empty / rate-limited */
+    '.tdf-ai-state {' +
+    '  padding: 16px; border: 1px dashed var(--border-strong, rgba(0,0,0,0.16));' +
+    '  border-radius: 12px; text-align: center;' +
+    '  color: var(--fg, #111); font-size: 13px; line-height: 1.5;' +
+    '}' +
+    '.tdf-ai-state.is-error { background: rgba(239,68,68,0.08); border-color: rgba(239,68,68,0.30); }' +
+    '.tdf-ai-state.is-rate  { background: rgba(245,158,11,0.10); border-color: rgba(245,158,11,0.32); }' +
+    '.tdf-ai-state .st-h { font-weight: 600; margin-bottom: 4px; }' +
+    '.tdf-ai-state .st-sub { color: var(--fg-muted, #6B7280); font-size: 12.5px; }' +
+    '.tdf-ai-state .st-actions { margin-top: 12px; display: inline-flex; gap: 8px; }' +
+    '.tdf-ai-state .st-actions button {' +
+    '  padding: 7px 12px; font-size: 12.5px; font-weight: 600;' +
+    '  border-radius: 8px; cursor: pointer; font-family: inherit;' +
+    '  border: 1px solid var(--border-strong, rgba(0,0,0,0.16));' +
+    '  background: var(--bg-elevated, #fff); color: var(--fg, #111);' +
+    '}' +
+    '.tdf-ai-state .st-actions button.is-primary { background: var(--brand-primary, #6366F1); color: #fff; border-color: transparent; }' +
+    /* Footer */
+    '.tdf-ai-foot {' +
+    '  padding: 12px 20px; border-top: 1px solid var(--border, rgba(0,0,0,0.08));' +
+    '  background: var(--bg-elevated, #fff);' +
+    '  display: flex; gap: 8px; align-items: center; flex-shrink: 0;' +
+    '}' +
+    '.tdf-ai-foot .left { display: flex; gap: 8px; }' +
+    '.tdf-ai-foot .right { display: flex; gap: 8px; margin-left: auto; }' +
+    '.tdf-ai-btn {' +
+    '  display: inline-flex; align-items: center; gap: 6px;' +
+    '  padding: 8px 12px; border-radius: 8px; font-family: inherit;' +
+    '  font-size: 13px; font-weight: 600; cursor: pointer;' +
+    '  border: 1px solid transparent; transition: background .12s ease, border-color .12s ease;' +
+    '}' +
+    '.tdf-ai-btn.is-primary { background: var(--brand-primary, #6366F1); color: #fff; }' +
+    '.tdf-ai-btn.is-primary:not(:disabled):hover { background: var(--brand-primary-hover, #4F46E5); }' +
+    '.tdf-ai-btn.is-primary:disabled { background: var(--bg-muted, #F3F4F6); color: var(--fg-subtle, #9CA3AF); cursor: not-allowed; }' +
+    '.tdf-ai-btn.is-secondary { background: var(--bg-elevated, #fff); color: var(--fg, #111); border-color: var(--border-strong, rgba(0,0,0,0.16)); }' +
+    '.tdf-ai-btn.is-secondary:hover { background: var(--bg-muted, #F9FAFB); }' +
+    '.tdf-ai-btn.is-ghost { background: transparent; color: var(--fg-muted, #6B7280); }' +
+    '.tdf-ai-btn.is-ghost:hover { color: var(--fg, #111); }' +
+    /* Dark mode */
+    'body.dark-mode .tdf-ai { background: #141A2D; color: #F3F4F6; border-color: #1F2937; }' +
+    'body.dark-mode .tdf-ai-head { border-bottom-color: #1F2937; }' +
+    'body.dark-mode .tdf-ai-foot { background: #141A2D; border-top-color: #1F2937; }' +
+    'body.dark-mode .tdf-ai-ctx  { background: #0B0F1E; color: #9CA3AF; }' +
+    'body.dark-mode .tdf-ai-card { background: #0B0F1E; border-color: #1F2937; }' +
+    'body.dark-mode .tdf-ai-card:hover { background: #141A2D; border-color: #374151; }' +
+    'body.dark-mode .tdf-ai-card .copy { color: #F3F4F6; }' +
+    'body.dark-mode .tdf-ai-card .tag, body.dark-mode .tdf-ai-card .idx { background: #1F2937; color: #9CA3AF; }' +
+    'body.dark-mode .tdf-ai-skel { background: #0B0F1E; border-color: #1F2937; }' +
+    'body.dark-mode .tdf-ai-skel .sk { background: linear-gradient(90deg, #1F2937 0%, rgba(255,255,255,0.04) 50%, #1F2937 100%); background-size: 200% 100%; }' +
+    'body.dark-mode .tdf-ai-btn.is-secondary { background: #141A2D; color: #F3F4F6; border-color: #1F2937; }' +
+    'body.dark-mode .tdf-ai-btn.is-secondary:hover { background: #1F2937; }' +
+    '@media (prefers-reduced-motion: reduce) {' +
+    '  .tdf-ai-backdrop, .tdf-ai, .tdf-ai-skel .sk { transition: none !important; animation: none !important; }' +
+    '}' +
+    '</style>';
+
+  var aiCssInjected = false;
+  function ensureAiCss() {
+    if (aiCssInjected) return;
+    document.head.insertAdjacentHTML('beforeend', AI_SUGGEST_CSS);
+    aiCssInjected = true;
+  }
+
+  /* Tone-tagged mocked suggestions per field flavour. Production: replace
+     with a Claude Haiku call. The set picked depends on the lower-cased
+     fieldName — title/label fields get short punchy lines, captions get
+     longer, button/CTA labels get verb-led action lines. */
+  var AI_PRESETS = {
+    title: [
+      { copy: 'Spring Drops — out now',                 tag: 'Direct'       },
+      { copy: 'Hit play, fresh feels inside',           tag: 'Playful'      },
+      { copy: 'My new album is here',                   tag: 'Friendly'     },
+      { copy: 'Listen to Spring Drops',                 tag: 'Professional' },
+      { copy: "Wonder what's new? Press play",          tag: 'Curious'      }
+    ],
+    caption: [
+      { copy: "The cover art that started it all",                        tag: 'Curious'      },
+      { copy: 'Spring Drops — full album, out everywhere now',            tag: 'Direct'       },
+      { copy: 'Behind the artwork: how Spring Drops came together',       tag: 'Friendly'     },
+      { copy: 'New album, stitched from late-night sessions',             tag: 'Professional' },
+      { copy: 'Pretty proud of this one, ngl',                            tag: 'Playful'      }
+    ],
+    cta: [
+      { copy: 'Listen now',           tag: 'Direct'       },
+      { copy: 'Hit play 🎧',          tag: 'Playful'      },
+      { copy: 'Stream Spring Drops',  tag: 'Professional' },
+      { copy: 'Take a listen',        tag: 'Friendly'     },
+      { copy: 'Curious? Press play',  tag: 'Curious'      }
+    ]
+  };
+
+  function pickPreset(fieldName) {
+    var n = (fieldName || '').toLowerCase();
+    if (/(button|cta|label)/.test(n)) return AI_PRESETS.cta;
+    if (/(caption|description|bio|body|paragraph|answer|outline)/.test(n)) return AI_PRESETS.caption;
+    return AI_PRESETS.title;
+  }
+
+  var aiState = { fieldName: '', contextSummary: '', onApply: null, selected: -1, suggestions: [] };
+
+  function ensureAiDom() {
+    if (document.getElementById('tdf-ai-backdrop')) return;
+    ensureAiCss();
+    var html = '' +
+      '<div class="tdf-ai-backdrop" id="tdf-ai-backdrop" role="dialog" aria-modal="true" aria-labelledby="tdf-ai-title" hidden>' +
+        '<div class="tdf-ai">' +
+          '<div class="tdf-ai-head">' +
+            '<h3 id="tdf-ai-title"><span class="sparkle">✨</span>Suggest for <span class="target" id="tdf-ai-target">field</span></h3>' +
+            '<button type="button" class="ai-x" id="tdf-ai-close" aria-label="Close">×</button>' +
+          '</div>' +
+          '<div class="tdf-ai-body" id="tdf-ai-body"></div>' +
+          '<div class="tdf-ai-foot">' +
+            '<div class="left">' +
+              '<button type="button" class="tdf-ai-btn is-secondary" id="tdf-ai-refresh">↻ Refresh suggestions</button>' +
+            '</div>' +
+            '<div class="right">' +
+              '<button type="button" class="tdf-ai-btn is-ghost" id="tdf-ai-cancel">Cancel</button>' +
+              '<button type="button" class="tdf-ai-btn is-primary" id="tdf-ai-use" disabled>Use this</button>' +
+            '</div>' +
+          '</div>' +
+        '</div>' +
+      '</div>';
+    document.body.insertAdjacentHTML('beforeend', html);
+    var bd = document.getElementById('tdf-ai-backdrop');
+    bd.addEventListener('click', function (e) { if (e.target === bd) closeAi(); });
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' && bd.classList.contains('is-open')) closeAi();
+    });
+    document.getElementById('tdf-ai-close').onclick = closeAi;
+    document.getElementById('tdf-ai-cancel').onclick = closeAi;
+    document.getElementById('tdf-ai-refresh').onclick = function () { renderAiState('loading'); setTimeout(function () { aiState.suggestions = pickPreset(aiState.fieldName); renderAiState('loaded'); }, 800); };
+    document.getElementById('tdf-ai-use').onclick = function () {
+      if (aiState.selected < 0) return;
+      var picked = aiState.suggestions[aiState.selected];
+      var text = picked && picked.copy;
+      closeAi();
+      if (aiState.onApply && text) aiState.onApply(text);
+    };
+  }
+
+  function closeAi() {
+    var bd = document.getElementById('tdf-ai-backdrop');
+    if (!bd) return;
+    bd.classList.remove('is-open');
+    bd.setAttribute('hidden', '');
+  }
+
+  function renderAiState(kind) {
+    var body = document.getElementById('tdf-ai-body');
+    var useBtn = document.getElementById('tdf-ai-use');
+    var refreshBtn = document.getElementById('tdf-ai-refresh');
+    if (!body) return;
+
+    var ctx = '<div class="tdf-ai-ctx"><span class="ctx-ico">ℹ</span><div>' +
+      (aiState.contextSummary || 'No additional context — generating from field name.') +
+      '</div></div>';
+
+    useBtn.disabled = true;
+    useBtn.style.display = '';
+    refreshBtn.style.display = '';
+
+    if (kind === 'loading') {
+      var skel = '';
+      for (var i = 0; i < 5; i++) {
+        skel += '<div class="tdf-ai-skel">' +
+                  '<div class="sk sk-idx"></div>' +
+                  '<div class="sk-copy"><div class="sk sk-line l1"></div><div class="sk sk-line l2"></div></div>' +
+                  '<div class="sk sk-tag"></div>' +
+                '</div>';
+      }
+      body.innerHTML = ctx +
+        '<div class="tdf-ai-head-row"><span>Pick one</span><span>Generating…</span></div>' +
+        '<div class="tdf-ai-list">' + skel + '</div>';
+      return;
+    }
+    if (kind === 'loaded') {
+      var cards = aiState.suggestions.map(function (s, i) {
+        return '<li><button type="button" class="tdf-ai-card" data-idx="' + i + '">' +
+          '<span class="idx">' + (i + 1) + '</span>' +
+          '<span class="copy">' + escapeAttr(s.copy) + '</span>' +
+          '<span class="tag">' + escapeAttr(s.tag) + '</span>' +
+        '</button></li>';
+      }).join('');
+      body.innerHTML = ctx +
+        '<div class="tdf-ai-head-row"><span>Pick one</span><span>' + aiState.suggestions.length + ' suggestions</span></div>' +
+        '<ul class="tdf-ai-list">' + cards + '</ul>';
+      Array.prototype.forEach.call(body.querySelectorAll('.tdf-ai-card'), function (btn) {
+        btn.onclick = function () {
+          Array.prototype.forEach.call(body.querySelectorAll('.tdf-ai-card'), function (b) { b.classList.remove('is-selected'); });
+          btn.classList.add('is-selected');
+          aiState.selected = parseInt(btn.getAttribute('data-idx'), 10);
+          useBtn.disabled = false;
+        };
+      });
+      return;
+    }
+    if (kind === 'error') {
+      body.innerHTML = ctx +
+        '<div class="tdf-ai-state is-error">' +
+          '<div class="st-h">Could not fetch suggestions</div>' +
+          '<div class="st-sub">The AI model is taking longer than expected. Give it another go.</div>' +
+          '<div class="st-actions"><button type="button" class="is-primary" id="tdf-ai-retry">Try again</button></div>' +
+        '</div>';
+      refreshBtn.style.display = 'none';
+      useBtn.style.display = 'none';
+      var retry = document.getElementById('tdf-ai-retry');
+      if (retry) retry.onclick = function () { renderAiState('loading'); setTimeout(function () { aiState.suggestions = pickPreset(aiState.fieldName); renderAiState('loaded'); }, 800); };
+      return;
+    }
+    if (kind === 'empty') {
+      body.innerHTML = ctx +
+        '<div class="tdf-ai-state">' +
+          '<div class="st-h">Tell us a bit about it first</div>' +
+          '<div class="st-sub">Type something in the field, paste a URL into the block, or describe it. We will generate five options.</div>' +
+          '<div class="st-actions"><button type="button" class="is-primary" id="tdf-ai-gen">Generate from context</button></div>' +
+        '</div>';
+      refreshBtn.style.display = 'none';
+      useBtn.style.display = 'none';
+      var gen = document.getElementById('tdf-ai-gen');
+      if (gen) gen.onclick = function () { renderAiState('loading'); setTimeout(function () { aiState.suggestions = pickPreset(aiState.fieldName); renderAiState('loaded'); }, 800); };
+      return;
+    }
+    if (kind === 'rate') {
+      body.innerHTML = ctx +
+        '<div class="tdf-ai-state is-rate">' +
+          '<div class="st-h">You have used today\'s AI credits</div>' +
+          '<div class="st-sub">Free creators get 30 ✨ Suggest clicks per day. Resets at midnight (your time zone). Upgrade for higher quotas.</div>' +
+          '<div class="st-actions"><button type="button" class="is-primary">Upgrade for more</button></div>' +
+        '</div>';
+      refreshBtn.style.display = 'none';
+      useBtn.style.display = 'none';
+      return;
+    }
+  }
+
+  function openAi(opts) {
+    opts = opts || {};
+    ensureAiDom();
+    aiState.fieldName      = opts.fieldName || 'this field';
+    aiState.contextSummary = opts.contextSummary || '';
+    aiState.onApply        = opts.onApply || null;
+    aiState.selected       = -1;
+    aiState.suggestions    = pickPreset(aiState.fieldName);
+
+    var target = document.getElementById('tdf-ai-target');
+    if (target) target.textContent = aiState.fieldName;
+
+    /* Default flow: brief loading skeleton (800ms) then loaded state. */
+    renderAiState('loading');
+    setTimeout(function () { renderAiState('loaded'); }, 800);
+
+    var bd = document.getElementById('tdf-ai-backdrop');
+    bd.removeAttribute('hidden');
+    requestAnimationFrame(function () { bd.classList.add('is-open'); });
   }
 
   /* Expose for tests + dynamic re-render (e.g. tier switcher in demo toolbar) */
@@ -542,7 +1035,15 @@
     checkAndProceed: checkAndProceed,
     open:  function (features, currentTier, hooks) { openGate(features, currentTier, hooks || {}); },
     close: closeGate,
-    TIER_RANK:  TIER_RANK,
-    TIER_LABEL: TIER_LABEL
+    showToast: showToast,
+    TIER_RANK:    TIER_RANK,
+    TIER_LABEL:   TIER_LABEL,
+    TIER_PRICING: TIER_PRICING
+  };
+  window.AISuggest = {
+    open:  openAi,
+    close: closeAi,
+    /* Programmatic state — useful for tests and the standalone demo file. */
+    setState: function (kind) { renderAiState(kind); }
   };
 })();


### PR DESCRIPTION
## Summary

Hoists the TierGate save-gate modal and AI Suggest sub-modal into `mockups/tadaify-mvp/shared/partials.js` so every editor mockup gets working `window.TierGate.checkAndProceed({...})` and `window.AISuggest.open({...})` (plus a `fromButton(this, label)` convenience helper) without duplicating markup or CSS. Connects 41 ✨ Suggest buttons across 9 page editors and replaces the last 3 alert()-style TierGate placeholders. Pure mechanical follow-up — no visual design changes.

## Business requirements implemented

This is a wiring/refactor PR — no new BR. Operationalises the existing canon:
- BR (existing) — every premium feature stays fully visible + interactive on every tier; gating happens at Save (per `feedback_no_blur_premium_features`).
- BR (existing) — every short-text editor field has a ✨ Suggest entry-point that opens the AI Suggest sub-modal (per `FIX-SUGGEST-RESTORE-001` PR #70 + the standalone `app-ai-suggest-modal.html` design contract).

## Technical requirements introduced or relied on

- TR (existing) — shared partials shipped via `mockups/tadaify-mvp/shared/partials.js`; pure vanilla JS, CSS-in-JS injected once, no dependencies.
- TR (existing, reinforced) — `feedback_AI_FEATURES_ROADMAP_01`: AI Suggest is text-only; image generators (4 OG cards / 4 hero illustrations / 4 cover cards) stay as separate flows and were intentionally NOT swapped to AISuggest.
- TR (existing) — pricing pulled from a single source of truth; new `window.TierGate.TIER_PRICING` mirrors `pricing.html` ({monthly, yearly} per tier; yearly = 10/12 monthly per "Save 2 months" rule).

## Acceptance criteria from issue

This is an internal mechanical PR with no GitHub issue. Acceptance covered by the smoke test below.

- ✅ `window.TierGate` exposes `checkAndProceed`, `open`, `close`, `showToast`, `TIER_RANK`, `TIER_LABEL`, `TIER_PRICING`.
- ✅ `window.AISuggest` exposes `open`, `close`, `fromButton`, `setState`.
- ✅ When `currentTier` already covers every gated feature, `onProceed` fires immediately AND a small "All set ✓" toast confirms (no hollow modal open/close).
- ✅ TierGate modal renders monthly/yearly toggle in the footer; upgrade button reads "Upgrade to <Tier> — $X/mo" and live-repaints when toggle flips.
- ✅ `onUpgrade(top, billingCycle)` callback receives the cycle the user toggled to, so a downstream Stripe Checkout can pre-select it.
- ✅ AISuggest opens with an 800ms loading skeleton then renders 5 mocked tone-tagged suggestions per field flavour (title vs caption vs button-label, picked from `AI_PRESETS` by field-name regex).
- ✅ All 6 canonical states implemented (loaded / loading / error / empty / rate / selected via `.is-selected`).
- ✅ All 41 ✨ Suggest alert() placeholders replaced with `window.AISuggest.fromButton(this, '<label>')` calls across the 9 editor pages.
- ✅ Last 3 alert()-style TierGate placeholders replaced (contact, newsletter-signup, theme).
- ✅ Standalone demo files (`app-tier-gate-modal.html`, `app-ai-suggest-modal.html`) preserved + annotated with a top-of-file note pointing readers at the global runtime entry points.
- ✅ Esc + backdrop dismiss work for both modals.
- ✅ Dark-mode CSS shipped for both modals.
- ✅ `prefers-reduced-motion` respected (transitions disabled, shimmer animation paused).

## Test plan

### Unit / functional (jsdom smoke — ran locally before push)

```
hasTierGate = true
hasAISuggest = true
hasPartials = true
tierGateKeys = [checkAndProceed, open, close, showToast, TIER_RANK, TIER_LABEL, TIER_PRICING]
aiSuggestKeys = [open, close, fromButton, setState]
tierPricing = { free, creator: $8/$80, pro: $19/$190, business: $49/$490 }

Test 1 (currentTier=pro covers requires=creator): onProceed fired ✓ + toast in DOM ✓
Test 2 (currentTier=free, requires=business): modal exists ✓ + monthly+yearly toggles ✓
   upgrade button reads: "Upgrade to Business — $49/mo"
Test 3 (AISuggest.open with fieldName='Block title'): backdrop exists ✓
   ai-target text matches: "Block title"
Test 4 (AISuggest.fromButton): walks parentElement, finds <input>, ai-target = label
```

### Manual Playwright scenarios (local mockup browser)

- **Block editor** (`app-block-editor.html`) — saving a block with A/B test enabled on Free tier → TierGate modal opens, lists "A/B testing — Business", upgrade button shows "$49/mo monthly", toggle to yearly shows "$40.83/mo billed yearly". Click "Save without premium changes" → variant B collapses to A and save proceeds.
- **Page editor — blog** (`app-page-blog.html?tier=creator`) — open New post modal, set author to "Team member", schedule 60 days out → TierGate modal lists both gated features. Click Cancel → modal closes, post modal stays open with edits intact.
- **Page editor — contact** (`app-page-contact.html`) — clicking ✨ Suggest on the intro field → AI Suggest modal opens with 800ms skeleton then 5 caption-style suggestions. Click suggestion #2 → "Use this" enables. Click → modal closes, intro field gets the picked text.
- **Page editor — newsletter-signup** (`app-page-newsletter-signup.html`) — fill custom-domain → click Save → TierGate fires with "Custom signup domain — Pro" + meta showing the domain.
- **Settings — theme** (`app-settings-theme.html?tier=free`) — switch to a non-Free preset (e.g. "magenta") → click Save → TierGate fires with "Custom palette — Creator". Save without → reverts to indigo and saves.

### Edge cases

- **Tier already covers everything** — Pro user changing only Pro-or-below features: no modal; "All set ✓" toast at bottom-right for 2.2s.
- **Empty features array** — instant `onProceed`, no toast (callers can disable via `toast: false`).
- **Esc during modal** — both modals close on Esc; no state leak (TierGate `gateCycle` persists across re-opens, AISuggest reset on next `open`).
- **Backdrop click** — both modals close.
- **Dark mode** — both modals + the toast respect `body.dark-mode` per existing token rules.
- **Reduced motion** — transitions and shimmer animation disabled.
- **AISuggest.fromButton with no adjacent field** — `field` is null, `onApply` is a no-op (fails silently rather than throwing).
- **Image generators** (4 OG cards / 4 hero illustrations / 4 cover cards) — left as alert() per text-only AI rule (`feedback_AI_FEATURES_ROADMAP_01`).

## Mockup

No new mockup — this PR wires the EXISTING `mockups/tadaify-mvp/app-tier-gate-modal.html` and `mockups/tadaify-mvp/app-ai-suggest-modal.html` design contracts into the runtime via `shared/partials.js`. Both standalone files preserved and annotated with a "now globally available via window.TierGate / window.AISuggest" header note for future readers.

## Rollback

`git revert da93ba7 fb7a5dc 3cac8a6` (or revert the merge commit). Pure JS + HTML changes — no migrations, no Edge Functions, no infra. Reverting restores:

- The previous `partials.js` with the simpler TierGate (no toast, no monthly/yearly, no AISuggest)
- The 3 alert()-based TierGate placeholders in contact / newsletter-signup / theme
- The 41 ✨ Suggest alert() calls across the page editors
- The original (uncommented) header on `app-tier-gate-modal.html` and `app-ai-suggest-modal.html`

No data effects.
