### PR TITLE
chore(links): link audit + fixes across all mockups (28 fixes, 1079 links scanned)

### DIFF
--- a/mockups/tadaify-mvp/LINK-AUDIT-2026-04-27.md
+++ b/mockups/tadaify-mvp/LINK-AUDIT-2026-04-27.md
@@ -1,0 +1,148 @@
+# Mockup link audit — 2026-04-27
+
+Cross-link audit of `mockups/tadaify-mvp/` (49 standalone pages + 12 email templates + 1 shared partials JS + 1 shared header partial).
+
+**Branch:** `chore/link-audit-and-fixes`
+**Tool:** `/tmp/link-audit.py` (custom Python discovery + validator). Raw inventory at `/tmp/link-audit-inventory.json`, per-link verdicts at `/tmp/link-audit-results.json`.
+
+---
+
+## Summary
+
+| Metric | Pre-audit | Post-fix |
+|---|---:|---:|
+| Total links scanned | 1079 | 1079 |
+| ok | 988 | 1016 |
+| broken-file | 61 | 58 |
+| broken-hash | 30 | 5 |
+
+**Net: 28 broken links repaired across 9 files. 5 broken-hash + 58 broken-file remain — all are intentional placeholders (template variables, mockup stubs, semantic mismatches needing a separate design decision).**
+
+### By category (post-fix)
+
+| Category | Count |
+|---|---:|
+| internal (file/path) | 547 |
+| skip (`#`, `mailto:`, `tel:`, `javascript:`) | 190 |
+| external (non-graspsoftwarepw URLs) | 171 |
+| hash-route (in-file SPA `#/route`) | 89 |
+| hash-only (in-file `#anchor`) | 63 |
+| issue-url (graspsoftwarepw/tadaify-app issues) | 18 |
+| gh-other (graspsoftwarepw/tadaify-app issue index) | 1 |
+
+External links + in-file hash routes were not opened (no internet probes); only graspsoftwarepw issue URLs were live-checked via `gh issue view`.
+
+### Issue URL validation
+
+All 18 in-mockup references to `https://github.com/graspsoftwarepw/tadaify-app/issues/N` resolve to live issues (#5, #6, #14, #15, #16, #17, #19, #20, #21, #22, #23, #33, #35, #39, #52, #53, #55, #62). No dead-issue references found.
+
+### GitHub blob URLs
+
+Zero `https://github.com/graspsoftwarepw/tadaify-app/blob/<branch>/...` references in the mockup library — the `feedback_story_refs_main_not_branch.md` rule is naturally satisfied since the mockups don't link to repo source files. No `/blob/feat/` or `/blob/chore/` URLs to retarget.
+
+---
+
+## Fixes applied
+
+### 1. File-path drift `app-settings-api.html` → `app-settings-apikeys.html` (commit `43181b1`)
+
+The canonical file is `app-settings-apikeys.html`. Two settings sidebar entries pointed at the never-existed `app-settings-api.html`.
+
+| File | Before | After |
+|---|---|---|
+| `app-settings-billing.html:782` | `./app-settings-api.html` | `./app-settings-apikeys.html` |
+| `app-settings-team.html:1083` | `./app-settings-api.html` | `./app-settings-apikeys.html` |
+
+### 2. Cross-page settings hash links → standalone sub-pages (commit `471f1f8`)
+
+`app-settings.html` does not have `id="<tab>"` attributes nor a hash router — `switchTab()` ignores the URL hash. Links from sibling settings pages used `app-settings.html#TAB` and silently 404 the user to the default tab. Each tab has a dedicated standalone page; retarget the 20 cross-page navs.
+
+Mapping:
+
+| Hash | New target |
+|---|---|
+| `#api` | `app-settings-apikeys.html` |
+| `#team` | `app-settings-team.html` |
+| `#danger` | `app-settings-danger.html` |
+| `#account` | `app-settings-account.html` |
+| `#security` | `app-settings-security.html` |
+| `#gdpr` | `app-settings-gdpr.html` |
+| `#billing` | `app-settings-billing.html` |
+
+Files touched (20 individual link replacements): `app-insights.html`, `app-settings-account.html`, `app-settings-danger.html`, `app-settings-gdpr.html`, `app-settings-security.html`, `app-settings-theme.html`.
+
+### 3. Internal hash anchors + relative paths (commit `8226a52`)
+
+| File:line | Before | After | Reason |
+|---|---|---|---|
+| `creator-legal-public.html:992` | `<a href="../landing.html">` | `<a href="./landing.html">` | Wrong relative path — file is in same dir as `landing.html` |
+| `error-pages.html:618` | `./landing.html#how-it-works` | `./landing.html` | `#how-it-works` doesn't exist on landing; drop hash so link still lands |
+| `app-settings-billing.html:1156` | `./app-settings-account.html#contact` | `mailto:support@tadaify.com?subject=Billing%20question` | No `#contact` anchor on account page; switch to mailto pattern used elsewhere (`app-settings-security.html`, `app-settings-team.html`) |
+| `pricing.html:554` | `<tr class="category-row">` | `<tr class="category-row" id="guarantee">` | Added anchor — referenced by `app-settings-billing.html:888` "price-lock-for-life guarantee" |
+| `pricing.html:425` | `<div class="tier">` | `<div class="tier" id="business">` | Added anchor — referenced by `app-settings-team.html:1139` and `app-settings-team.html:1484` ("Business plan ($49/mo)") |
+
+### 4. Shared header partial alignment (commit `0eb7fed`)
+
+`shared/partials.js` (the actual injector code) already used `./index.html` with a TODO comment for the templates/trust nav items. The documentation-mirror file `shared/header.html` had drifted to `./landing.html#templates` and `./landing.html#trust` which don't exist as anchors anywhere on `landing.html`. Aligned the static partial with the JS source.
+
+| File:line | Before | After |
+|---|---|---|
+| `shared/header.html:21` | `./landing.html#templates` | `./index.html` (with TODO comment) |
+| `shared/header.html:22` | `./landing.html#trust` | `./index.html` |
+
+---
+
+## Report-only items (intentional, NOT fixed)
+
+These show as broken to a naive validator but are intentional placeholders. Listed for traceability — no PR action needed.
+
+### Mockup `alert()` stubs for unbuilt pages
+
+| File:line | Link | Why intentional |
+|---|---|---|
+| `app-settings-team.html:1439` | `./app-team-audit-log.html` | Wrapped in `onclick="event.preventDefault();alert('Mockup: would link to /app/team/audit-log full page (paginated 50/page)')"`. Explicit stub for a page that hasn't been mocked yet. |
+| `app-page-legal.html:1594` | `./app-settings.html#cookie-banner` | Wrapped in `onclick="alert('Mockup — opens cookie banner config in Settings')"`. Target settings sub-section doesn't exist anywhere; needs a design decision about which settings page should host cookie-banner config. |
+
+### Placeholder text inside form fields
+
+| File:line | Link | Why intentional |
+|---|---|---|
+| `app-page-newsletter-signup.html:1373` | `/privacy` (inside `<textarea>` showing default consent copy) | Sample copy displayed to creators inside a textarea — represents what their visitors will see. The actual URL is rendered dynamically when the page is published. Changing it would break the preview's intent. |
+
+### Semantic mismatch (need design decision, not link fix)
+
+| File:line | Link | Issue |
+|---|---|---|
+| `app-settings-gdpr.html:1221` | `./app-page-legal.html#tos` | Wants tadaify's own ToS but `app-page-legal.html` is the **creator's editor** for THEIR brand's legal text. tadaify's own ToS / Subprocessors / AUP pages don't exist as mockups yet. |
+| `app-settings-gdpr.html:1246` | `./app-page-legal.html#subprocessors` | Same as above — refers to tadaify's subprocessor list, no mockup exists. |
+| `app-settings-gdpr.html:1255` | `./app-page-legal.html#aup` | Same as above — refers to tadaify's Acceptable Use Policy. |
+| `app-settings-gdpr.html:1338` | `./app-page-legal.html#subprocessors` | Same as above (second occurrence in the same file). |
+
+**Suggested follow-up:** create a separate `tadaify-legal.html` mockup (or a section on `landing.html`) hosting tadaify's own platform terms, then retarget these 4 links.
+
+### Email template variables
+
+`mockups/tadaify-mvp/emails/resend/*.html` and `mockups/tadaify-mvp/emails/supabase-auth/*.html` contain placeholders like `{{download_url}}`, `{{ .ConfirmationURL }}`, `{{ .SiteURL }}/privacy`. These are Resend / Supabase template syntax — substituted at send time. 31 occurrences across 11 email templates. NOT broken — leave as-is.
+
+### `shared/partials.js` + `shared/header.html` relative paths (false positives)
+
+The audit tool resolves paths relative to the file that **contains** the link. For `shared/partials.js` and `shared/header.html`, the contained HTML is **injected into** consumer pages in `mockups/tadaify-mvp/`, where `./landing.html` etc. correctly resolves. 27 broken-file flags in this category are false positives, not real navigation bugs.
+
+---
+
+## Tooling
+
+Re-run the audit at any time:
+
+```bash
+python3 /tmp/link-audit.py 2>&1 | tail -80
+```
+
+Inputs:
+- Scans every `*.html` under `mockups/tadaify-mvp/` recursively + `shared/*.js`.
+- Captures: `href=`, `action=`, `formaction=`, `data-href=`, `window.location*=`, `window.open(...)`, raw `https://github.com/...` URLs in text/comments.
+- Skips: empty `#`, `mailto:`, `tel:`, `javascript:`, `data:` URIs.
+
+Outputs:
+- `/tmp/link-audit-inventory.json` — every raw match (file, line, link_type, target).
+- `/tmp/link-audit-results.json` — per-link verdict (`ok` / `broken-file` / `broken-hash` / `wrong-blob-path` / `dead-issue`).

--- a/mockups/tadaify-mvp/app-insights.html
+++ b/mockups/tadaify-mvp/app-insights.html
@@ -1382,14 +1382,14 @@
           </button>
 
           <!-- API tile — Pro 100/h, Business 1000/h, otherwise locked upgrade pill (DEC-080) -->
-          <a id="api-tile-active" href="./app-settings.html#api" class="api-tile active tooltip-wrap" style="display:inline-flex">
+          <a id="api-tile-active" href="./app-settings-apikeys.html" class="api-tile active tooltip-wrap" style="display:inline-flex">
             <span class="api-icon">🔌</span>
             <span class="api-text-long">API · <span id="api-meta-used">47</span> / <span id="api-meta-cap">100</span> req/h</span>
             <span class="api-text-short">🔌 47/100</span>
             <span class="tooltip-popover tooltip-right">
               <strong>API access — Pro tier</strong><br>
               Build your own dashboards, Slack bots, iOS widgets. First creator analytics API in link-in-bio.<br><br>
-              <a href="./app-settings.html#api">Manage API keys →</a>
+              <a href="./app-settings-apikeys.html">Manage API keys →</a>
             </span>
           </a>
           <button id="api-tile-locked" class="api-tile locked tooltip-wrap" onclick="alert('Mockup — would open upgrade flow')" style="display:none">

--- a/mockups/tadaify-mvp/app-settings-account.html
+++ b/mockups/tadaify-mvp/app-settings-account.html
@@ -858,18 +858,18 @@
           GDPR &amp; data
         </a>
         <div class="settings-nav-divider"></div>
-        <a href="./app-settings.html#api" class="settings-nav-item">
+        <a href="./app-settings-apikeys.html" class="settings-nav-item">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
           API keys
           <span class="sn-pill pro-pill">Pro</span>
         </a>
-        <a href="./app-settings.html#team" class="settings-nav-item">
+        <a href="./app-settings-team.html" class="settings-nav-item">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
           Team
           <span class="sn-pill biz-pill">Business</span>
         </a>
         <div class="settings-nav-divider"></div>
-        <a href="./app-settings.html#danger" class="settings-nav-item" style="color:var(--danger)">
+        <a href="./app-settings-danger.html" class="settings-nav-item" style="color:var(--danger)">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--danger)"><polygon points="10.29 3.86 1.82 18 22.18 18 13.71 3.86 10.29 3.86"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
           Danger zone
         </a>

--- a/mockups/tadaify-mvp/app-settings-billing.html
+++ b/mockups/tadaify-mvp/app-settings-billing.html
@@ -1153,7 +1153,7 @@
 
         <!-- Help footer -->
         <div class="help-footer">
-          Questions about your invoice? <a href="./app-settings-account.html#contact">Contact billing support</a> · all charges shown in USD unless noted.
+          Questions about your invoice? <a href="mailto:support@tadaify.com?subject=Billing%20question">Contact billing support</a> · all charges shown in USD unless noted.
           <br>
           Powered by Stripe · GDPR-compliant · 30-day money-back guarantee on first charge.
         </div>

--- a/mockups/tadaify-mvp/app-settings-billing.html
+++ b/mockups/tadaify-mvp/app-settings-billing.html
@@ -779,7 +779,7 @@
           GDPR &amp; data
         </a>
         <div class="settings-nav-divider"></div>
-        <a class="settings-nav-item" href="./app-settings-api.html">
+        <a class="settings-nav-item" href="./app-settings-apikeys.html">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
           API keys
           <span class="sn-pill pro-pill">Pro</span>

--- a/mockups/tadaify-mvp/app-settings-danger.html
+++ b/mockups/tadaify-mvp/app-settings-danger.html
@@ -996,12 +996,12 @@
           GDPR &amp; data
         </a>
         <div class="settings-nav-divider"></div>
-        <a href="./app-settings.html#api" class="settings-nav-item">
+        <a href="./app-settings-apikeys.html" class="settings-nav-item">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
           API keys
           <span class="sn-pill pro-pill">Pro</span>
         </a>
-        <a href="./app-settings.html#team" class="settings-nav-item">
+        <a href="./app-settings-team.html" class="settings-nav-item">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
           Team
           <span class="sn-pill biz-pill">Business</span>

--- a/mockups/tadaify-mvp/app-settings-gdpr.html
+++ b/mockups/tadaify-mvp/app-settings-gdpr.html
@@ -836,15 +836,15 @@
 
       <!-- Settings sub-navigation (mirror of app-settings.html) -->
       <nav class="settings-nav" aria-label="Settings sections">
-        <a class="settings-nav-item" href="./app-settings.html#account">
+        <a class="settings-nav-item" href="./app-settings-account.html">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
           Account
         </a>
-        <a class="settings-nav-item" href="./app-settings.html#billing">
+        <a class="settings-nav-item" href="./app-settings-billing.html">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="4" width="22" height="16" rx="2" ry="2"/><line x1="1" y1="10" x2="23" y2="10"/></svg>
           Billing
         </a>
-        <a class="settings-nav-item" href="./app-settings.html#security">
+        <a class="settings-nav-item" href="./app-settings-security.html">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
           Security
         </a>
@@ -853,18 +853,18 @@
           GDPR &amp; data
         </a>
         <div class="settings-nav-divider"></div>
-        <a class="settings-nav-item" href="./app-settings.html#api">
+        <a class="settings-nav-item" href="./app-settings-apikeys.html">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
           API keys
           <span class="sn-pill pro-pill">Pro</span>
         </a>
-        <a class="settings-nav-item" href="./app-settings.html#team">
+        <a class="settings-nav-item" href="./app-settings-team.html">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
           Team
           <span class="sn-pill biz-pill">Business</span>
         </a>
         <div class="settings-nav-divider"></div>
-        <a class="settings-nav-item" href="./app-settings.html#danger" style="color:var(--danger)">
+        <a class="settings-nav-item" href="./app-settings-danger.html" style="color:var(--danger)">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--danger)"><polygon points="10.29 3.86 1.82 18 22.18 18 13.71 3.86 10.29 3.86"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
           Danger zone
         </a>
@@ -1357,7 +1357,7 @@
                 That flow cancels any active subscription, releases custom domains, removes all your pages and blocks,
                 and deletes every record listed in the <em>Personal data</em> section above. Action cannot be undone.
               </div>
-              <a href="./app-settings.html#danger" class="ec-link">
+              <a href="./app-settings-danger.html" class="ec-link">
                 Go to Danger zone tab
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
               </a>

--- a/mockups/tadaify-mvp/app-settings-security.html
+++ b/mockups/tadaify-mvp/app-settings-security.html
@@ -876,12 +876,12 @@
     <!-- Sub-tab nav: Account / Billing / Security (active) / GDPR -->
     <nav class="settings-tabs" aria-label="Settings sections">
       <a class="settings-tab" href="./app-settings-account.html"
-         onclick="if(!fileExists(this.href)){event.preventDefault();window.location.href='./app-settings.html#account';}">
+         onclick="if(!fileExists(this.href)){event.preventDefault();window.location.href='./app-settings-account.html';}">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
         Account
       </a>
       <a class="settings-tab" href="./app-settings-billing.html"
-         onclick="if(!fileExists(this.href)){event.preventDefault();window.location.href='./app-settings.html#billing';}">
+         onclick="if(!fileExists(this.href)){event.preventDefault();window.location.href='./app-settings-billing.html';}">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="4" width="22" height="16" rx="2" ry="2"/><line x1="1" y1="10" x2="23" y2="10"/></svg>
         Billing
       </a>
@@ -890,7 +890,7 @@
         Security
       </a>
       <a class="settings-tab" href="./app-settings-gdpr.html"
-         onclick="if(!fileExists(this.href)){event.preventDefault();window.location.href='./app-settings.html#gdpr';}">
+         onclick="if(!fileExists(this.href)){event.preventDefault();window.location.href='./app-settings-gdpr.html';}">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><polyline points="9 12 11 14 15 10"/></svg>
         GDPR &amp; data
       </a>

--- a/mockups/tadaify-mvp/app-settings-team.html
+++ b/mockups/tadaify-mvp/app-settings-team.html
@@ -1080,7 +1080,7 @@
           GDPR &amp; data
         </a>
         <div class="settings-nav-divider"></div>
-        <a class="settings-nav-item" href="./app-settings-api.html">
+        <a class="settings-nav-item" href="./app-settings-apikeys.html">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
           API keys
           <span class="sn-pill pro-pill">Pro</span>

--- a/mockups/tadaify-mvp/app-settings-theme.html
+++ b/mockups/tadaify-mvp/app-settings-theme.html
@@ -1224,18 +1224,18 @@
           <span class="sn-pill new-pill">New</span>
         </a>
         <div class="settings-nav-divider"></div>
-        <a href="./app-settings.html#api" class="settings-nav-item">
+        <a href="./app-settings-apikeys.html" class="settings-nav-item">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
           API keys
           <span class="sn-pill pro-pill">Pro</span>
         </a>
-        <a href="./app-settings.html#team" class="settings-nav-item">
+        <a href="./app-settings-team.html" class="settings-nav-item">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
           Team
           <span class="sn-pill biz-pill">Business</span>
         </a>
         <div class="settings-nav-divider"></div>
-        <a href="./app-settings.html#danger" class="settings-nav-item" style="color:var(--danger)">
+        <a href="./app-settings-danger.html" class="settings-nav-item" style="color:var(--danger)">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--danger)"><polygon points="10.29 3.86 1.82 18 22.18 18 13.71 3.86 10.29 3.86"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
           Danger zone
         </a>

--- a/mockups/tadaify-mvp/creator-legal-public.html
+++ b/mockups/tadaify-mvp/creator-legal-public.html
@@ -989,7 +989,7 @@
         </a>
       </div>
       <div class="cf-tdf">
-        Built with <a href="../landing.html">tadaify</a>
+        Built with <a href="./landing.html">tadaify</a>
       </div>
     </div>
   </footer>

--- a/mockups/tadaify-mvp/error-pages.html
+++ b/mockups/tadaify-mvp/error-pages.html
@@ -615,7 +615,7 @@
 
           <p class="err-secondary-help">
             Looking for a specific creator? Try the search above, or
-            <a href="./landing.html#how-it-works">browse popular pages</a>.
+            <a href="./landing.html">browse popular pages</a>.
           </p>
         </div>
       </div>

--- a/mockups/tadaify-mvp/pricing.html
+++ b/mockups/tadaify-mvp/pricing.html
@@ -422,7 +422,7 @@
       </div>
 
       <!-- BUSINESS — $49/mo, DEC-083: 5 handles + 10 team members -->
-      <div class="tier">
+      <div class="tier" id="business">
         <h3>Business</h3>
         <div class="price">
           <span class="currency">$</span><span class="amount" data-price-annual="49" data-price-monthly="49">49</span><span class="cadence">/mo · locked for life</span>
@@ -551,7 +551,7 @@
           <tr><td>99.95% uptime SLA</td><td class="cross">✗</td><td class="cross">✗</td><td class="cross">✗</td><td class="check">✓</td></tr>
 
           <!-- Price guarantee -->
-          <tr class="category-row"><td colspan="5">Guarantee</td></tr>
+          <tr class="category-row" id="guarantee"><td colspan="5">Guarantee</td></tr>
           <tr><td>Price locked for life</td><td>—</td><td class="check">✓</td><td class="check">✓</td><td class="check">✓</td></tr>
           <tr><td>30-day money-back</td><td>—</td><td class="check">✓</td><td class="check">✓</td><td class="check">✓</td></tr>
         </tbody>

--- a/mockups/tadaify-mvp/shared/header.html
+++ b/mockups/tadaify-mvp/shared/header.html
@@ -18,8 +18,9 @@
     <div class="nav-links">
       <a href="./landing.html">Home</a>
       <a href="./pricing.html">Pricing</a>
-      <a href="./landing.html#templates">Templates</a>
-      <a href="./landing.html#trust">Trust</a>
+      <!-- TODO: replace when templates/trust mockups exist -->
+      <a href="./index.html">Templates</a>
+      <a href="./index.html">Trust</a>
       <a href="./index.html">Mockup hub</a>
       <a href="./try.html" class="btn btn-ghost btn-sm">Try it free</a>
       <a href="./register.html" class="btn btn-primary btn-sm">Claim your handle</a>


### PR DESCRIPTION
## Summary

Cross-link audit of every HTML file in `mockups/tadaify-mvp/` (49 standalone pages, 12 email templates, 1 shared partials JS, 1 shared header partial). Discovered 91 broken links pre-audit; **28 repaired in this PR across 9 files**. Remaining 63 broken matches are intentional placeholders (Resend / Supabase template vars, explicit `alert()` mockup stubs, semantic mismatches needing a separate design decision) and are listed in the audit report for traceability.

Full report committed at `mockups/tadaify-mvp/LINK-AUDIT-2026-04-27.md`.

## Business requirements implemented

None — this is a docs/mockup hygiene PR. No BR diff. The fixed cross-page nav supports the canonical sidebar grouping pattern (per `feedback_sidebar_pages_grouping.md`) by ensuring settings-tab nav lands on the correct sub-page.

## Technical requirements introduced or relied on

None new. Relies on:
- Existing convention: every settings tab has a dedicated standalone HTML page (`app-settings-apikeys.html`, `app-settings-team.html`, `app-settings-danger.html`, etc.).
- Existing convention: tadaify support contact is `mailto:support@tadaify.com?subject=...` (used across `app-settings-security.html`, `app-settings-team.html`, etc.).
- `feedback_story_refs_main_not_branch.md` — verified zero `blob/<branch>/` URLs in the mockup library.

## Acceptance criteria

This PR was a self-initiated audit (no story issue) covering the audit prompt's success criteria:

- ✅ Discover every link form (`href`, `onclick`, `window.location`, `window.open`, `data-href`, `formaction`, raw GH URLs in text).
- ✅ Categorize: internal mockup link / GitHub blob URL / GitHub issue URL / external / hash-only / placeholder.
- ✅ Validate: file-exists for internal, `/blob/main/` per memory rule for blob URLs, live `gh issue view` for issue URLs.
- ✅ Live-validate all 18 issue URL references — 100% resolve to live issues.
- ✅ Detect zero `/blob/<branch>/` URLs (memory rule satisfied).
- ✅ Apply fixes only where they preserve semantic meaning; document report-only items in the audit doc.
- ✅ Audit report file committed (`mockups/tadaify-mvp/LINK-AUDIT-2026-04-27.md`).
- ✅ Pre/post-audit re-validation: broken-file 61 → 58 (3 false-positive removals + 3 mockup stubs documented), broken-hash 30 → 5 (25 fixed + 5 documented as report-only).

## Test plan

This PR only touches mockup HTML — no unit-testable logic, no Playwright surface change. Spot-check by clicking through the most-touched flows:

- [ ] Open `mockups/tadaify-mvp/app-settings-account.html` in browser → click "API keys" sidebar entry → lands on `app-settings-apikeys.html` (was: `app-settings.html` ignoring `#api`).
- [ ] Open `mockups/tadaify-mvp/app-settings-team.html` → click "API keys" sidebar entry → lands on `app-settings-apikeys.html`.
- [ ] Open `mockups/tadaify-mvp/app-settings-billing.html` → click "Contact billing support" → triggers mail client with `support@tadaify.com` (was: 404 `#contact` anchor).
- [ ] Open `mockups/tadaify-mvp/app-insights.html` → click 🔌 API tile → lands on `app-settings-apikeys.html`.
- [ ] Open `mockups/tadaify-mvp/creator-legal-public.html` → footer "Built with tadaify" → lands on `landing.html` (was: 404 `../landing.html`).
- [ ] Open `mockups/tadaify-mvp/error-pages.html` → "browse popular pages" → lands on `landing.html` (was: 404 fragment).
- [ ] Open `mockups/tadaify-mvp/pricing.html#guarantee` directly → scrolls to Guarantee row in comparison table.
- [ ] Open `mockups/tadaify-mvp/pricing.html#business` directly → scrolls to Business tier card.

Re-run audit any time:

```bash
python3 /tmp/link-audit.py 2>&1 | tail -50
```

## Mockup

No UI change — mockup not required. This PR only fixes link `href` targets; visual design is unchanged across all touched files.

## Rollback

```bash
git revert 33c5e52 0eb7fed 8226a52 471f1f8 43181b1
```

(One revert per commit, in reverse chronological order — or `git revert <PR-merge-commit>` after merge.)
