### PR TITLE
chore(responsive): 3-viewport audit + fixes (53 files, 25 fixed)

### DIFF
--- a/mockups/tadaify-mvp/RESPONSIVE-AUDIT-2026-04-27.md
+++ b/mockups/tadaify-mvp/RESPONSIVE-AUDIT-2026-04-27.md
@@ -1,0 +1,190 @@
+# Responsive audit 2026-04-27 — 3 viewports
+
+Coverage: every `mockups/tadaify-mvp/*.html` (53 files) audited against
+the tadaify 3-viewport contract:
+
+| Viewport | Width  | Device target           |
+|----------|--------|-------------------------|
+| Desktop  | 1280px | laptops, monitors       |
+| Tablet   | 820px  | iPad portrait           |
+| Mobile   | 390px  | iPhone 14 Pro portrait  |
+
+Source rule: `feedback_tadaify_three_viewport_support.md` (locked
+2026-04-27).
+
+## Tooling
+
+- **Phase 1 — static analysis**: Python parser of inline `@media` rules
+  per file. Identified missing tablet-tier breakpoints, fixed-width
+  containers without responsive override, multi-col grids without
+  intermediate stop, sidebars without responsive rule, modals without
+  viewport clamp. Output: `/tmp/responsive-audit-static.json`.
+- **Phase 2 — browser preview**: `Claude_Preview` MCP server pointed at
+  a local Python static server rooted at `mockups/tadaify-mvp/` (port
+  4488; entry `tadaify-mockups` in
+  `~/git/claude-project-orchestrator/.claude/launch.json`). Used to
+  validate the partial-sidebar fix (manual click-through on
+  `app-page-blog.html` at 390/820/1280) and one creator-public page
+  before-and-after.
+
+## Phase 1 verdict
+
+| Risk    | Files | Reason                                                            |
+|---------|------:|-------------------------------------------------------------------|
+| High    | 19    | No explicit tablet breakpoint AND multi-col grid OR fixed widths > 700px OR modal without viewport clamp |
+| Medium  | 25    | Sidebar-using app pages — flagged because per-file CSS lacked sidebar mq, but the shared partial DID handle it (false positive on per-file scan; real issue: no mobile hamburger replacement) |
+| Low     | 9     | All 3 viewport tiers covered                                       |
+
+## Fixes applied
+
+### 1. Shared sidebar partial — mobile hamburger + drawer
+
+`shared/partials.js` updated. Affects 23 app pages that use
+`<div data-partial="app-sidebar">`.
+
+Before: at <720px the sidebar set `display: none` with no replacement
+nav. Mobile users had no way to navigate.
+
+After:
+
+- A 65px sticky `.tdf-mobile-topbar` is auto-injected at the top of
+  body when the sidebar partial is present. Visible only at <720px.
+  Contains a 44×44 hamburger button + brand mark.
+- When toggled open, `aside.tdf-side.is-open` becomes a full-screen
+  centered modal sheet (per `feedback_no_right_side_drawers` — modal
+  pattern, not slide-in panel).
+- Backdrop overlay, body scroll-lock, ESC-to-close, link-click
+  auto-close, ARIA expanded/controls wired.
+- Touch-target floor 44px on mobile per WCAG / Apple HIG.
+
+Verified at 390/820/1280 — drawer opens and closes correctly, sidebar
+at 820 is the icon-only 72px rail (existing partial behaviour
+preserved), sidebar at 1280 is the full 240px expanded form.
+
+### 2. Tablet-tier (600–1023px) injection in 24 files
+
+A single inline `<style data-source="responsive-tablet-tier">` block
+injected before `</head>` of each high-risk file. Block targets common
+class names: `.feed`, `.related-grid`, `.grid-3`, `.grid-4`,
+`.features-grid`, `.three-col`, `.four-col`, `.cards-grid`,
+`.links-grid`, `.blocks-grid`, `.shop-grid`, `.testimonial-grid`,
+`.pricing-grid`.
+
+- Tablet: 3+ col grids → 2 col; container padding 24px; hero scaled.
+- Mobile: grids → 1 col with 16px gap; container padding 16px; 44px
+  touch-target floor on `.btn` / `a.btn` / `.nav-links a`.
+- All viewports: modal classes (`.modal`, `.modal-card`,
+  `.modal-dialog`, `.tdf-modal`, `.modal-content`) clamped to
+  `max-width: min(960px, calc(100vw - 32px))` and `max-height:
+  min(92vh, 920px)` with `overflow-y: auto`. At <600px modals get
+  tighter bounds + 14px border-radius.
+
+Marker `data-source="responsive-tablet-tier"` makes the script
+idempotent.
+
+#### Files injected
+
+- creator-public set (8): `creator-about-public.html`,
+  `creator-blog-public.html`, `creator-contact-public.html`,
+  `creator-custom-public.html`, `creator-faq-public.html`,
+  `creator-newsletter-signup-public.html`, `creator-public.html`,
+  `creator-schedule-public.html`
+- modals (2): `app-ai-suggest-modal.html`, `app-tier-gate-modal.html`
+- onboarding (4): `onboarding-complete.html`,
+  `onboarding-social.html`, `onboarding-template.html`,
+  `onboarding-tier.html`
+- auth/landing (5): `login.html`, `pricing.html`, `try.html`,
+  `error-pages.html`, `index.html`
+- app pages with modals lacking viewport clamp (5):
+  `app-dashboard.html`, `app-dashboard-variants.html`,
+  `app-settings.html`, `app-settings-danger.html`,
+  `app-settings-gdpr.html`
+
+## Per-file × per-viewport summary
+
+| File | Desktop | Tablet | Mobile |
+|------|:-------:|:------:|:------:|
+| admin-panel.html | ok | ok | ok |
+| app-ai-suggest-modal.html | ok | fixed | fixed |
+| app-block-editor.html | ok | ok | fixed (sidebar) |
+| app-block-picker.html | ok | ok | fixed (sidebar) |
+| app-dashboard.html | ok | ok | fixed (modal clamp) |
+| app-dashboard-variants.html | ok | ok | fixed (modal clamp) |
+| app-domain.html | ok | ok | fixed (sidebar) |
+| app-insights.html | ok | ok | fixed (sidebar) |
+| app-page-* (12) | ok | ok | fixed (sidebar) |
+| app-settings*.html (8) | ok | ok | fixed (sidebar) |
+| app-settings.html | ok | ok | fixed (sidebar + modal) |
+| app-tier-gate-modal.html | ok | fixed | fixed |
+| creator-about-public.html | ok | fixed | fixed |
+| creator-blog-public.html | ok | fixed | fixed |
+| creator-contact-public.html | ok | fixed | fixed |
+| creator-custom-public.html | ok | fixed | fixed |
+| creator-faq-public.html | ok | fixed | fixed |
+| creator-legal-public.html | ok | ok | ok |
+| creator-links-archive-public.html | ok | ok | ok |
+| creator-newsletter-signup-public.html | ok | fixed | fixed |
+| creator-portfolio-public.html | ok | ok | ok |
+| creator-public.html | ok | fixed | fixed |
+| creator-schedule-public.html | ok | fixed | fixed |
+| error-pages.html | ok | fixed | fixed |
+| index.html | ok | fixed | fixed |
+| landing.html | ok | ok | ok |
+| login.html | ok | fixed | fixed |
+| onboarding-blocks.html | ok | ok | ok |
+| onboarding-complete.html | ok | fixed | fixed |
+| onboarding-social.html | ok | fixed | fixed |
+| onboarding-template.html | ok | fixed | fixed |
+| onboarding-tier.html | ok | fixed | fixed |
+| onboarding-welcome.html | ok | ok | ok |
+| pricing.html | ok | fixed | fixed |
+| product-public.html | ok | ok | ok |
+| register.html | ok | ok | ok |
+| try.html | ok | fixed | fixed |
+
+`fixed (sidebar)` = was broken at <720px (no nav), now mobile drawer
+via shared partial fix.
+`fixed` = added explicit tablet-tier breakpoint + grid clamp.
+`fixed (modal clamp)` = modal would have overflowed; clamp added.
+
+## Report-only / future work
+
+Minor cosmetic items NOT auto-fixed (require designer judgment):
+
+1. **`creator-portfolio-public.html`** — uses
+   `repeat(auto-fit, minmax(...))` already; no fix needed but the
+   minmax floor (currently 280px) could be raised to 320px on tablet
+   to keep cards readable. **Not blocking.**
+2. **`landing.html`** — hero `<h1>` font-size jumps from 56px desktop
+   to 32px mobile via existing media queries. The intermediate at
+   tablet width (820px) is 56px which is fine but tight. **Not
+   blocking.**
+3. **`app-dashboard.html` / `app-dashboard-variants.html`** — these
+   files have their own bespoke `<aside>` (do NOT use the shared
+   sidebar partial). The shared mobile drawer fix does NOT apply to
+   them. The `<aside>` in `app-dashboard.html` has its own `@media
+   (max-width: 1023px)` rules that hide it. **Recommend follow-up**:
+   either migrate them to the shared partial, or replicate the mobile
+   topbar pattern in their inline CSS.
+4. **`shared/header.html`** — marketing nav (`.nav-links`) still wraps
+   to a second line at 600-800px on landing/pricing/etc. Needs a
+   hamburger pattern symmetrical to the app-sidebar fix. Out of scope
+   for this audit. **Recommend follow-up issue.**
+
+## Verification
+
+- Browser preview server at port 4488 (rooted at this directory).
+- Manually verified `app-page-blog.html` and `creator-blog-public.html`
+  at 390×844, 820×1180, 1280×800 — drawer opens/closes, grids reflow
+  correctly, no horizontal scroll, modals fit viewport.
+- Static analysis re-run after fixes: 0 high-risk files remain (all
+  19 either got the tablet-tier injection or are sidebar-only false
+  positives now covered by the partial).
+
+## Commits
+
+1. `chore(responsive): mobile hamburger + drawer for shared sidebar partial`
+   — `shared/partials.js`
+2. `chore(responsive): inject tablet-tier (600-1023px) breakpoints +
+   modal viewport clamp` — 24 mockup HTML files
+3. `docs(audit): responsive audit report 2026-04-27` — this file

--- a/mockups/tadaify-mvp/app-ai-suggest-modal.html
+++ b/mockups/tadaify-mvp/app-ai-suggest-modal.html
@@ -667,6 +667,99 @@
     }
     .selected-banner b { color: var(--fg); font-weight: 600; }
   </style>
+
+<style data-source="responsive-tablet-tier">
+/* ==========================================================================
+   Responsive tablet-tier (600–1023px) + modal viewport clamp.
+   Auto-injected 2026-04-27 per feedback_tadaify_three_viewport_support.
+   Targets common cramped layouts at iPad-portrait widths and ensures
+   modals never overflow the viewport at any size.
+   ========================================================================== */
+@media (max-width: 1023px) and (min-width: 600px) {
+  /* Clamp 3+ column grids to 2 columns at tablet width */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+  /* Reduce horizontal padding on common containers */
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 24px !important;
+    padding-right: 24px !important;
+  }
+  /* Slightly smaller hero typography */
+  h1.hero-title, .hero h1 { font-size: clamp(28px, 5vw, 44px); }
+}
+
+@media (max-width: 599px) {
+  /* Mobile: single column, smaller padding, larger touch targets */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: 1fr !important;
+    gap: 16px !important;
+  }
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 16px !important;
+    padding-right: 16px !important;
+  }
+  /* Touch-target floor for buttons + nav links */
+  .btn, button.btn, a.btn,
+  .nav-links a {
+    min-height: 44px;
+  }
+}
+
+/* Modal viewport clamp — applies at every viewport. Only adds bounds if a
+   modal forgot them. Uses min() to keep desktop behavior when there's
+   already a max-width or width set inline. */
+.modal,
+.modal-card,
+.modal-dialog,
+.tdf-modal,
+.modal-content {
+  max-width: min(960px, calc(100vw - 32px));
+  max-height: min(92vh, 920px);
+  overflow-y: auto;
+}
+@media (max-width: 599px) {
+  .modal,
+  .modal-card,
+  .modal-dialog,
+  .tdf-modal,
+  .modal-content {
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 32px);
+    border-radius: 14px;
+  }
+}
+</style>
 </head>
 <body>
 

--- a/mockups/tadaify-mvp/app-dashboard-variants.html
+++ b/mockups/tadaify-mvp/app-dashboard-variants.html
@@ -1104,6 +1104,99 @@
       color: var(--fg);
     }
   </style>
+
+<style data-source="responsive-tablet-tier">
+/* ==========================================================================
+   Responsive tablet-tier (600–1023px) + modal viewport clamp.
+   Auto-injected 2026-04-27 per feedback_tadaify_three_viewport_support.
+   Targets common cramped layouts at iPad-portrait widths and ensures
+   modals never overflow the viewport at any size.
+   ========================================================================== */
+@media (max-width: 1023px) and (min-width: 600px) {
+  /* Clamp 3+ column grids to 2 columns at tablet width */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+  /* Reduce horizontal padding on common containers */
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 24px !important;
+    padding-right: 24px !important;
+  }
+  /* Slightly smaller hero typography */
+  h1.hero-title, .hero h1 { font-size: clamp(28px, 5vw, 44px); }
+}
+
+@media (max-width: 599px) {
+  /* Mobile: single column, smaller padding, larger touch targets */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: 1fr !important;
+    gap: 16px !important;
+  }
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 16px !important;
+    padding-right: 16px !important;
+  }
+  /* Touch-target floor for buttons + nav links */
+  .btn, button.btn, a.btn,
+  .nav-links a {
+    min-height: 44px;
+  }
+}
+
+/* Modal viewport clamp — applies at every viewport. Only adds bounds if a
+   modal forgot them. Uses min() to keep desktop behavior when there's
+   already a max-width or width set inline. */
+.modal,
+.modal-card,
+.modal-dialog,
+.tdf-modal,
+.modal-content {
+  max-width: min(960px, calc(100vw - 32px));
+  max-height: min(92vh, 920px);
+  overflow-y: auto;
+}
+@media (max-width: 599px) {
+  .modal,
+  .modal-card,
+  .modal-dialog,
+  .tdf-modal,
+  .modal-content {
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 32px);
+    border-radius: 14px;
+  }
+}
+</style>
 </head>
 <body>
 

--- a/mockups/tadaify-mvp/app-dashboard.html
+++ b/mockups/tadaify-mvp/app-dashboard.html
@@ -2292,6 +2292,99 @@
     body.dark-mode .support-preview-frame { background: #141A2D; border-color: #374151; }
     body.dark-mode .support-preview-block { background: #1F2937; color: #9CA3AF; }
   </style>
+
+<style data-source="responsive-tablet-tier">
+/* ==========================================================================
+   Responsive tablet-tier (600–1023px) + modal viewport clamp.
+   Auto-injected 2026-04-27 per feedback_tadaify_three_viewport_support.
+   Targets common cramped layouts at iPad-portrait widths and ensures
+   modals never overflow the viewport at any size.
+   ========================================================================== */
+@media (max-width: 1023px) and (min-width: 600px) {
+  /* Clamp 3+ column grids to 2 columns at tablet width */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+  /* Reduce horizontal padding on common containers */
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 24px !important;
+    padding-right: 24px !important;
+  }
+  /* Slightly smaller hero typography */
+  h1.hero-title, .hero h1 { font-size: clamp(28px, 5vw, 44px); }
+}
+
+@media (max-width: 599px) {
+  /* Mobile: single column, smaller padding, larger touch targets */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: 1fr !important;
+    gap: 16px !important;
+  }
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 16px !important;
+    padding-right: 16px !important;
+  }
+  /* Touch-target floor for buttons + nav links */
+  .btn, button.btn, a.btn,
+  .nav-links a {
+    min-height: 44px;
+  }
+}
+
+/* Modal viewport clamp — applies at every viewport. Only adds bounds if a
+   modal forgot them. Uses min() to keep desktop behavior when there's
+   already a max-width or width set inline. */
+.modal,
+.modal-card,
+.modal-dialog,
+.tdf-modal,
+.modal-content {
+  max-width: min(960px, calc(100vw - 32px));
+  max-height: min(92vh, 920px);
+  overflow-y: auto;
+}
+@media (max-width: 599px) {
+  .modal,
+  .modal-card,
+  .modal-dialog,
+  .tdf-modal,
+  .modal-content {
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 32px);
+    border-radius: 14px;
+  }
+}
+</style>
 </head>
 <body data-state="ready">
 

--- a/mockups/tadaify-mvp/app-settings-danger.html
+++ b/mockups/tadaify-mvp/app-settings-danger.html
@@ -910,6 +910,99 @@
       .modal, .modal-backdrop { animation: none !important; }
     }
   </style>
+
+<style data-source="responsive-tablet-tier">
+/* ==========================================================================
+   Responsive tablet-tier (600–1023px) + modal viewport clamp.
+   Auto-injected 2026-04-27 per feedback_tadaify_three_viewport_support.
+   Targets common cramped layouts at iPad-portrait widths and ensures
+   modals never overflow the viewport at any size.
+   ========================================================================== */
+@media (max-width: 1023px) and (min-width: 600px) {
+  /* Clamp 3+ column grids to 2 columns at tablet width */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+  /* Reduce horizontal padding on common containers */
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 24px !important;
+    padding-right: 24px !important;
+  }
+  /* Slightly smaller hero typography */
+  h1.hero-title, .hero h1 { font-size: clamp(28px, 5vw, 44px); }
+}
+
+@media (max-width: 599px) {
+  /* Mobile: single column, smaller padding, larger touch targets */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: 1fr !important;
+    gap: 16px !important;
+  }
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 16px !important;
+    padding-right: 16px !important;
+  }
+  /* Touch-target floor for buttons + nav links */
+  .btn, button.btn, a.btn,
+  .nav-links a {
+    min-height: 44px;
+  }
+}
+
+/* Modal viewport clamp — applies at every viewport. Only adds bounds if a
+   modal forgot them. Uses min() to keep desktop behavior when there's
+   already a max-width or width set inline. */
+.modal,
+.modal-card,
+.modal-dialog,
+.tdf-modal,
+.modal-content {
+  max-width: min(960px, calc(100vw - 32px));
+  max-height: min(92vh, 920px);
+  overflow-y: auto;
+}
+@media (max-width: 599px) {
+  .modal,
+  .modal-card,
+  .modal-dialog,
+  .tdf-modal,
+  .modal-content {
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 32px);
+    border-radius: 14px;
+  }
+}
+</style>
 </head>
 <body>
 

--- a/mockups/tadaify-mvp/app-settings-gdpr.html
+++ b/mockups/tadaify-mvp/app-settings-gdpr.html
@@ -784,6 +784,99 @@
     body.dark-mode .export-progress { background: #0B0F1E; border-color: #1F2937; }
     body.dark-mode .cookie-row { border-bottom-color: #1F2937; }
   </style>
+
+<style data-source="responsive-tablet-tier">
+/* ==========================================================================
+   Responsive tablet-tier (600–1023px) + modal viewport clamp.
+   Auto-injected 2026-04-27 per feedback_tadaify_three_viewport_support.
+   Targets common cramped layouts at iPad-portrait widths and ensures
+   modals never overflow the viewport at any size.
+   ========================================================================== */
+@media (max-width: 1023px) and (min-width: 600px) {
+  /* Clamp 3+ column grids to 2 columns at tablet width */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+  /* Reduce horizontal padding on common containers */
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 24px !important;
+    padding-right: 24px !important;
+  }
+  /* Slightly smaller hero typography */
+  h1.hero-title, .hero h1 { font-size: clamp(28px, 5vw, 44px); }
+}
+
+@media (max-width: 599px) {
+  /* Mobile: single column, smaller padding, larger touch targets */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: 1fr !important;
+    gap: 16px !important;
+  }
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 16px !important;
+    padding-right: 16px !important;
+  }
+  /* Touch-target floor for buttons + nav links */
+  .btn, button.btn, a.btn,
+  .nav-links a {
+    min-height: 44px;
+  }
+}
+
+/* Modal viewport clamp — applies at every viewport. Only adds bounds if a
+   modal forgot them. Uses min() to keep desktop behavior when there's
+   already a max-width or width set inline. */
+.modal,
+.modal-card,
+.modal-dialog,
+.tdf-modal,
+.modal-content {
+  max-width: min(960px, calc(100vw - 32px));
+  max-height: min(92vh, 920px);
+  overflow-y: auto;
+}
+@media (max-width: 599px) {
+  .modal,
+  .modal-card,
+  .modal-dialog,
+  .tdf-modal,
+  .modal-content {
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 32px);
+    border-radius: 14px;
+  }
+}
+</style>
 </head>
 <body>
 

--- a/mockups/tadaify-mvp/app-settings.html
+++ b/mockups/tadaify-mvp/app-settings.html
@@ -807,6 +807,99 @@
     body.dark-mode .settings-content { border-left-color: #1F2937; }
     body.dark-mode .page-head { border-bottom-color: #1F2937; }
   </style>
+
+<style data-source="responsive-tablet-tier">
+/* ==========================================================================
+   Responsive tablet-tier (600–1023px) + modal viewport clamp.
+   Auto-injected 2026-04-27 per feedback_tadaify_three_viewport_support.
+   Targets common cramped layouts at iPad-portrait widths and ensures
+   modals never overflow the viewport at any size.
+   ========================================================================== */
+@media (max-width: 1023px) and (min-width: 600px) {
+  /* Clamp 3+ column grids to 2 columns at tablet width */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+  /* Reduce horizontal padding on common containers */
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 24px !important;
+    padding-right: 24px !important;
+  }
+  /* Slightly smaller hero typography */
+  h1.hero-title, .hero h1 { font-size: clamp(28px, 5vw, 44px); }
+}
+
+@media (max-width: 599px) {
+  /* Mobile: single column, smaller padding, larger touch targets */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: 1fr !important;
+    gap: 16px !important;
+  }
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 16px !important;
+    padding-right: 16px !important;
+  }
+  /* Touch-target floor for buttons + nav links */
+  .btn, button.btn, a.btn,
+  .nav-links a {
+    min-height: 44px;
+  }
+}
+
+/* Modal viewport clamp — applies at every viewport. Only adds bounds if a
+   modal forgot them. Uses min() to keep desktop behavior when there's
+   already a max-width or width set inline. */
+.modal,
+.modal-card,
+.modal-dialog,
+.tdf-modal,
+.modal-content {
+  max-width: min(960px, calc(100vw - 32px));
+  max-height: min(92vh, 920px);
+  overflow-y: auto;
+}
+@media (max-width: 599px) {
+  .modal,
+  .modal-card,
+  .modal-dialog,
+  .tdf-modal,
+  .modal-content {
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 32px);
+    border-radius: 14px;
+  }
+}
+</style>
 </head>
 <body>
 

--- a/mockups/tadaify-mvp/app-tier-gate-modal.html
+++ b/mockups/tadaify-mvp/app-tier-gate-modal.html
@@ -759,6 +759,99 @@
       max-height: none;
     }
   </style>
+
+<style data-source="responsive-tablet-tier">
+/* ==========================================================================
+   Responsive tablet-tier (600–1023px) + modal viewport clamp.
+   Auto-injected 2026-04-27 per feedback_tadaify_three_viewport_support.
+   Targets common cramped layouts at iPad-portrait widths and ensures
+   modals never overflow the viewport at any size.
+   ========================================================================== */
+@media (max-width: 1023px) and (min-width: 600px) {
+  /* Clamp 3+ column grids to 2 columns at tablet width */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+  /* Reduce horizontal padding on common containers */
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 24px !important;
+    padding-right: 24px !important;
+  }
+  /* Slightly smaller hero typography */
+  h1.hero-title, .hero h1 { font-size: clamp(28px, 5vw, 44px); }
+}
+
+@media (max-width: 599px) {
+  /* Mobile: single column, smaller padding, larger touch targets */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: 1fr !important;
+    gap: 16px !important;
+  }
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 16px !important;
+    padding-right: 16px !important;
+  }
+  /* Touch-target floor for buttons + nav links */
+  .btn, button.btn, a.btn,
+  .nav-links a {
+    min-height: 44px;
+  }
+}
+
+/* Modal viewport clamp — applies at every viewport. Only adds bounds if a
+   modal forgot them. Uses min() to keep desktop behavior when there's
+   already a max-width or width set inline. */
+.modal,
+.modal-card,
+.modal-dialog,
+.tdf-modal,
+.modal-content {
+  max-width: min(960px, calc(100vw - 32px));
+  max-height: min(92vh, 920px);
+  overflow-y: auto;
+}
+@media (max-width: 599px) {
+  .modal,
+  .modal-card,
+  .modal-dialog,
+  .tdf-modal,
+  .modal-content {
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 32px);
+    border-radius: 14px;
+  }
+}
+</style>
 </head>
 <body>
 

--- a/mockups/tadaify-mvp/creator-about-public.html
+++ b/mockups/tadaify-mvp/creator-about-public.html
@@ -401,6 +401,99 @@
       .qc-stage { transition: none; }
     }
   </style>
+
+<style data-source="responsive-tablet-tier">
+/* ==========================================================================
+   Responsive tablet-tier (600–1023px) + modal viewport clamp.
+   Auto-injected 2026-04-27 per feedback_tadaify_three_viewport_support.
+   Targets common cramped layouts at iPad-portrait widths and ensures
+   modals never overflow the viewport at any size.
+   ========================================================================== */
+@media (max-width: 1023px) and (min-width: 600px) {
+  /* Clamp 3+ column grids to 2 columns at tablet width */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+  /* Reduce horizontal padding on common containers */
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 24px !important;
+    padding-right: 24px !important;
+  }
+  /* Slightly smaller hero typography */
+  h1.hero-title, .hero h1 { font-size: clamp(28px, 5vw, 44px); }
+}
+
+@media (max-width: 599px) {
+  /* Mobile: single column, smaller padding, larger touch targets */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: 1fr !important;
+    gap: 16px !important;
+  }
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 16px !important;
+    padding-right: 16px !important;
+  }
+  /* Touch-target floor for buttons + nav links */
+  .btn, button.btn, a.btn,
+  .nav-links a {
+    min-height: 44px;
+  }
+}
+
+/* Modal viewport clamp — applies at every viewport. Only adds bounds if a
+   modal forgot them. Uses min() to keep desktop behavior when there's
+   already a max-width or width set inline. */
+.modal,
+.modal-card,
+.modal-dialog,
+.tdf-modal,
+.modal-content {
+  max-width: min(960px, calc(100vw - 32px));
+  max-height: min(92vh, 920px);
+  overflow-y: auto;
+}
+@media (max-width: 599px) {
+  .modal,
+  .modal-card,
+  .modal-dialog,
+  .tdf-modal,
+  .modal-content {
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 32px);
+    border-radius: 14px;
+  }
+}
+</style>
 </head>
 <body>
 

--- a/mockups/tadaify-mvp/creator-blog-public.html
+++ b/mockups/tadaify-mvp/creator-blog-public.html
@@ -382,6 +382,99 @@
     }
     .mockup-hub-strip a { color: var(--brand-primary); font-weight: 600; }
   </style>
+
+<style data-source="responsive-tablet-tier">
+/* ==========================================================================
+   Responsive tablet-tier (600–1023px) + modal viewport clamp.
+   Auto-injected 2026-04-27 per feedback_tadaify_three_viewport_support.
+   Targets common cramped layouts at iPad-portrait widths and ensures
+   modals never overflow the viewport at any size.
+   ========================================================================== */
+@media (max-width: 1023px) and (min-width: 600px) {
+  /* Clamp 3+ column grids to 2 columns at tablet width */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+  /* Reduce horizontal padding on common containers */
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 24px !important;
+    padding-right: 24px !important;
+  }
+  /* Slightly smaller hero typography */
+  h1.hero-title, .hero h1 { font-size: clamp(28px, 5vw, 44px); }
+}
+
+@media (max-width: 599px) {
+  /* Mobile: single column, smaller padding, larger touch targets */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: 1fr !important;
+    gap: 16px !important;
+  }
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 16px !important;
+    padding-right: 16px !important;
+  }
+  /* Touch-target floor for buttons + nav links */
+  .btn, button.btn, a.btn,
+  .nav-links a {
+    min-height: 44px;
+  }
+}
+
+/* Modal viewport clamp — applies at every viewport. Only adds bounds if a
+   modal forgot them. Uses min() to keep desktop behavior when there's
+   already a max-width or width set inline. */
+.modal,
+.modal-card,
+.modal-dialog,
+.tdf-modal,
+.modal-content {
+  max-width: min(960px, calc(100vw - 32px));
+  max-height: min(92vh, 920px);
+  overflow-y: auto;
+}
+@media (max-width: 599px) {
+  .modal,
+  .modal-card,
+  .modal-dialog,
+  .tdf-modal,
+  .modal-content {
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 32px);
+    border-radius: 14px;
+  }
+}
+</style>
 </head>
 <body>
 

--- a/mockups/tadaify-mvp/creator-contact-public.html
+++ b/mockups/tadaify-mvp/creator-contact-public.html
@@ -492,6 +492,99 @@
         linear-gradient(135deg, #064E3B 0%, #065F46 50%, #047857 100%);
     }
   </style>
+
+<style data-source="responsive-tablet-tier">
+/* ==========================================================================
+   Responsive tablet-tier (600–1023px) + modal viewport clamp.
+   Auto-injected 2026-04-27 per feedback_tadaify_three_viewport_support.
+   Targets common cramped layouts at iPad-portrait widths and ensures
+   modals never overflow the viewport at any size.
+   ========================================================================== */
+@media (max-width: 1023px) and (min-width: 600px) {
+  /* Clamp 3+ column grids to 2 columns at tablet width */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+  /* Reduce horizontal padding on common containers */
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 24px !important;
+    padding-right: 24px !important;
+  }
+  /* Slightly smaller hero typography */
+  h1.hero-title, .hero h1 { font-size: clamp(28px, 5vw, 44px); }
+}
+
+@media (max-width: 599px) {
+  /* Mobile: single column, smaller padding, larger touch targets */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: 1fr !important;
+    gap: 16px !important;
+  }
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 16px !important;
+    padding-right: 16px !important;
+  }
+  /* Touch-target floor for buttons + nav links */
+  .btn, button.btn, a.btn,
+  .nav-links a {
+    min-height: 44px;
+  }
+}
+
+/* Modal viewport clamp — applies at every viewport. Only adds bounds if a
+   modal forgot them. Uses min() to keep desktop behavior when there's
+   already a max-width or width set inline. */
+.modal,
+.modal-card,
+.modal-dialog,
+.tdf-modal,
+.modal-content {
+  max-width: min(960px, calc(100vw - 32px));
+  max-height: min(92vh, 920px);
+  overflow-y: auto;
+}
+@media (max-width: 599px) {
+  .modal,
+  .modal-card,
+  .modal-dialog,
+  .tdf-modal,
+  .modal-content {
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 32px);
+    border-radius: 14px;
+  }
+}
+</style>
 </head>
 <body>
 

--- a/mockups/tadaify-mvp/creator-custom-public.html
+++ b/mockups/tadaify-mvp/creator-custom-public.html
@@ -387,6 +387,99 @@
       .b-link, .creator-foot .cf-social { transition: none !important; }
     }
   </style>
+
+<style data-source="responsive-tablet-tier">
+/* ==========================================================================
+   Responsive tablet-tier (600–1023px) + modal viewport clamp.
+   Auto-injected 2026-04-27 per feedback_tadaify_three_viewport_support.
+   Targets common cramped layouts at iPad-portrait widths and ensures
+   modals never overflow the viewport at any size.
+   ========================================================================== */
+@media (max-width: 1023px) and (min-width: 600px) {
+  /* Clamp 3+ column grids to 2 columns at tablet width */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+  /* Reduce horizontal padding on common containers */
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 24px !important;
+    padding-right: 24px !important;
+  }
+  /* Slightly smaller hero typography */
+  h1.hero-title, .hero h1 { font-size: clamp(28px, 5vw, 44px); }
+}
+
+@media (max-width: 599px) {
+  /* Mobile: single column, smaller padding, larger touch targets */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: 1fr !important;
+    gap: 16px !important;
+  }
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 16px !important;
+    padding-right: 16px !important;
+  }
+  /* Touch-target floor for buttons + nav links */
+  .btn, button.btn, a.btn,
+  .nav-links a {
+    min-height: 44px;
+  }
+}
+
+/* Modal viewport clamp — applies at every viewport. Only adds bounds if a
+   modal forgot them. Uses min() to keep desktop behavior when there's
+   already a max-width or width set inline. */
+.modal,
+.modal-card,
+.modal-dialog,
+.tdf-modal,
+.modal-content {
+  max-width: min(960px, calc(100vw - 32px));
+  max-height: min(92vh, 920px);
+  overflow-y: auto;
+}
+@media (max-width: 599px) {
+  .modal,
+  .modal-card,
+  .modal-dialog,
+  .tdf-modal,
+  .modal-content {
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 32px);
+    border-radius: 14px;
+  }
+}
+</style>
 </head>
 <body>
 

--- a/mockups/tadaify-mvp/creator-faq-public.html
+++ b/mockups/tadaify-mvp/creator-faq-public.html
@@ -426,6 +426,99 @@
       details.qa-item, details.qa-item .qi-caret { transition: none !important; }
     }
   </style>
+
+<style data-source="responsive-tablet-tier">
+/* ==========================================================================
+   Responsive tablet-tier (600–1023px) + modal viewport clamp.
+   Auto-injected 2026-04-27 per feedback_tadaify_three_viewport_support.
+   Targets common cramped layouts at iPad-portrait widths and ensures
+   modals never overflow the viewport at any size.
+   ========================================================================== */
+@media (max-width: 1023px) and (min-width: 600px) {
+  /* Clamp 3+ column grids to 2 columns at tablet width */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+  /* Reduce horizontal padding on common containers */
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 24px !important;
+    padding-right: 24px !important;
+  }
+  /* Slightly smaller hero typography */
+  h1.hero-title, .hero h1 { font-size: clamp(28px, 5vw, 44px); }
+}
+
+@media (max-width: 599px) {
+  /* Mobile: single column, smaller padding, larger touch targets */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: 1fr !important;
+    gap: 16px !important;
+  }
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 16px !important;
+    padding-right: 16px !important;
+  }
+  /* Touch-target floor for buttons + nav links */
+  .btn, button.btn, a.btn,
+  .nav-links a {
+    min-height: 44px;
+  }
+}
+
+/* Modal viewport clamp — applies at every viewport. Only adds bounds if a
+   modal forgot them. Uses min() to keep desktop behavior when there's
+   already a max-width or width set inline. */
+.modal,
+.modal-card,
+.modal-dialog,
+.tdf-modal,
+.modal-content {
+  max-width: min(960px, calc(100vw - 32px));
+  max-height: min(92vh, 920px);
+  overflow-y: auto;
+}
+@media (max-width: 599px) {
+  .modal,
+  .modal-card,
+  .modal-dialog,
+  .tdf-modal,
+  .modal-content {
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 32px);
+    border-radius: 14px;
+  }
+}
+</style>
 </head>
 <body data-route="default" data-tagging="enabled">
 

--- a/mockups/tadaify-mvp/creator-newsletter-signup-public.html
+++ b/mockups/tadaify-mvp/creator-newsletter-signup-public.html
@@ -508,6 +508,99 @@
     body.dark-mode .faq details, body.dark-mode .faq details:first-of-type, body.dark-mode .public-footer { border-color: #1F2937; }
     body.dark-mode .state-strip { border-top-color: #1F2937; }
   </style>
+
+<style data-source="responsive-tablet-tier">
+/* ==========================================================================
+   Responsive tablet-tier (600–1023px) + modal viewport clamp.
+   Auto-injected 2026-04-27 per feedback_tadaify_three_viewport_support.
+   Targets common cramped layouts at iPad-portrait widths and ensures
+   modals never overflow the viewport at any size.
+   ========================================================================== */
+@media (max-width: 1023px) and (min-width: 600px) {
+  /* Clamp 3+ column grids to 2 columns at tablet width */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+  /* Reduce horizontal padding on common containers */
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 24px !important;
+    padding-right: 24px !important;
+  }
+  /* Slightly smaller hero typography */
+  h1.hero-title, .hero h1 { font-size: clamp(28px, 5vw, 44px); }
+}
+
+@media (max-width: 599px) {
+  /* Mobile: single column, smaller padding, larger touch targets */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: 1fr !important;
+    gap: 16px !important;
+  }
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 16px !important;
+    padding-right: 16px !important;
+  }
+  /* Touch-target floor for buttons + nav links */
+  .btn, button.btn, a.btn,
+  .nav-links a {
+    min-height: 44px;
+  }
+}
+
+/* Modal viewport clamp — applies at every viewport. Only adds bounds if a
+   modal forgot them. Uses min() to keep desktop behavior when there's
+   already a max-width or width set inline. */
+.modal,
+.modal-card,
+.modal-dialog,
+.tdf-modal,
+.modal-content {
+  max-width: min(960px, calc(100vw - 32px));
+  max-height: min(92vh, 920px);
+  overflow-y: auto;
+}
+@media (max-width: 599px) {
+  .modal,
+  .modal-card,
+  .modal-dialog,
+  .tdf-modal,
+  .modal-content {
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 32px);
+    border-radius: 14px;
+  }
+}
+</style>
 </head>
 <body>
 

--- a/mockups/tadaify-mvp/creator-public.html
+++ b/mockups/tadaify-mvp/creator-public.html
@@ -155,6 +155,99 @@
     .powered a { color: var(--brand-primary); font-weight: 600; }
     .powered .wordmark { font-size: 14px; }
   </style>
+
+<style data-source="responsive-tablet-tier">
+/* ==========================================================================
+   Responsive tablet-tier (600–1023px) + modal viewport clamp.
+   Auto-injected 2026-04-27 per feedback_tadaify_three_viewport_support.
+   Targets common cramped layouts at iPad-portrait widths and ensures
+   modals never overflow the viewport at any size.
+   ========================================================================== */
+@media (max-width: 1023px) and (min-width: 600px) {
+  /* Clamp 3+ column grids to 2 columns at tablet width */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+  /* Reduce horizontal padding on common containers */
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 24px !important;
+    padding-right: 24px !important;
+  }
+  /* Slightly smaller hero typography */
+  h1.hero-title, .hero h1 { font-size: clamp(28px, 5vw, 44px); }
+}
+
+@media (max-width: 599px) {
+  /* Mobile: single column, smaller padding, larger touch targets */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: 1fr !important;
+    gap: 16px !important;
+  }
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 16px !important;
+    padding-right: 16px !important;
+  }
+  /* Touch-target floor for buttons + nav links */
+  .btn, button.btn, a.btn,
+  .nav-links a {
+    min-height: 44px;
+  }
+}
+
+/* Modal viewport clamp — applies at every viewport. Only adds bounds if a
+   modal forgot them. Uses min() to keep desktop behavior when there's
+   already a max-width or width set inline. */
+.modal,
+.modal-card,
+.modal-dialog,
+.tdf-modal,
+.modal-content {
+  max-width: min(960px, calc(100vw - 32px));
+  max-height: min(92vh, 920px);
+  overflow-y: auto;
+}
+@media (max-width: 599px) {
+  .modal,
+  .modal-card,
+  .modal-dialog,
+  .tdf-modal,
+  .modal-content {
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 32px);
+    border-radius: 14px;
+  }
+}
+</style>
 </head>
 <body>
 

--- a/mockups/tadaify-mvp/creator-schedule-public.html
+++ b/mockups/tadaify-mvp/creator-schedule-public.html
@@ -576,6 +576,99 @@
     body.dark-mode .creator-footer { border-top-color: #1F2937; }
     body.dark-mode .month-strip .ms-day { background: #0B0F1E; border-color: #1F2937; color: #F3F4F6; }
   </style>
+
+<style data-source="responsive-tablet-tier">
+/* ==========================================================================
+   Responsive tablet-tier (600–1023px) + modal viewport clamp.
+   Auto-injected 2026-04-27 per feedback_tadaify_three_viewport_support.
+   Targets common cramped layouts at iPad-portrait widths and ensures
+   modals never overflow the viewport at any size.
+   ========================================================================== */
+@media (max-width: 1023px) and (min-width: 600px) {
+  /* Clamp 3+ column grids to 2 columns at tablet width */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+  /* Reduce horizontal padding on common containers */
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 24px !important;
+    padding-right: 24px !important;
+  }
+  /* Slightly smaller hero typography */
+  h1.hero-title, .hero h1 { font-size: clamp(28px, 5vw, 44px); }
+}
+
+@media (max-width: 599px) {
+  /* Mobile: single column, smaller padding, larger touch targets */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: 1fr !important;
+    gap: 16px !important;
+  }
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 16px !important;
+    padding-right: 16px !important;
+  }
+  /* Touch-target floor for buttons + nav links */
+  .btn, button.btn, a.btn,
+  .nav-links a {
+    min-height: 44px;
+  }
+}
+
+/* Modal viewport clamp — applies at every viewport. Only adds bounds if a
+   modal forgot them. Uses min() to keep desktop behavior when there's
+   already a max-width or width set inline. */
+.modal,
+.modal-card,
+.modal-dialog,
+.tdf-modal,
+.modal-content {
+  max-width: min(960px, calc(100vw - 32px));
+  max-height: min(92vh, 920px);
+  overflow-y: auto;
+}
+@media (max-width: 599px) {
+  .modal,
+  .modal-card,
+  .modal-dialog,
+  .tdf-modal,
+  .modal-content {
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 32px);
+    border-radius: 14px;
+  }
+}
+</style>
 </head>
 <body data-theme="indigo-serif">
 

--- a/mockups/tadaify-mvp/error-pages.html
+++ b/mockups/tadaify-mvp/error-pages.html
@@ -549,6 +549,99 @@
     body.dark-mode .demo-bar select,
     body.dark-mode .demo-bar button.theme-toggle { background: var(--bg); color: var(--fg); border-color: var(--border-strong); }
   </style>
+
+<style data-source="responsive-tablet-tier">
+/* ==========================================================================
+   Responsive tablet-tier (600–1023px) + modal viewport clamp.
+   Auto-injected 2026-04-27 per feedback_tadaify_three_viewport_support.
+   Targets common cramped layouts at iPad-portrait widths and ensures
+   modals never overflow the viewport at any size.
+   ========================================================================== */
+@media (max-width: 1023px) and (min-width: 600px) {
+  /* Clamp 3+ column grids to 2 columns at tablet width */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+  /* Reduce horizontal padding on common containers */
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 24px !important;
+    padding-right: 24px !important;
+  }
+  /* Slightly smaller hero typography */
+  h1.hero-title, .hero h1 { font-size: clamp(28px, 5vw, 44px); }
+}
+
+@media (max-width: 599px) {
+  /* Mobile: single column, smaller padding, larger touch targets */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: 1fr !important;
+    gap: 16px !important;
+  }
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 16px !important;
+    padding-right: 16px !important;
+  }
+  /* Touch-target floor for buttons + nav links */
+  .btn, button.btn, a.btn,
+  .nav-links a {
+    min-height: 44px;
+  }
+}
+
+/* Modal viewport clamp — applies at every viewport. Only adds bounds if a
+   modal forgot them. Uses min() to keep desktop behavior when there's
+   already a max-width or width set inline. */
+.modal,
+.modal-card,
+.modal-dialog,
+.tdf-modal,
+.modal-content {
+  max-width: min(960px, calc(100vw - 32px));
+  max-height: min(92vh, 920px);
+  overflow-y: auto;
+}
+@media (max-width: 599px) {
+  .modal,
+  .modal-card,
+  .modal-dialog,
+  .tdf-modal,
+  .modal-content {
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 32px);
+    border-radius: 14px;
+  }
+}
+</style>
 </head>
 <body>
   <div data-partial="nav"></div>

--- a/mockups/tadaify-mvp/index.html
+++ b/mockups/tadaify-mvp/index.html
@@ -12,6 +12,99 @@
   <title>tadaify — MVP mockups (Phase 1)</title>
   <link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@500;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="./shared/tokens.css"/>
+
+<style data-source="responsive-tablet-tier">
+/* ==========================================================================
+   Responsive tablet-tier (600–1023px) + modal viewport clamp.
+   Auto-injected 2026-04-27 per feedback_tadaify_three_viewport_support.
+   Targets common cramped layouts at iPad-portrait widths and ensures
+   modals never overflow the viewport at any size.
+   ========================================================================== */
+@media (max-width: 1023px) and (min-width: 600px) {
+  /* Clamp 3+ column grids to 2 columns at tablet width */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+  /* Reduce horizontal padding on common containers */
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 24px !important;
+    padding-right: 24px !important;
+  }
+  /* Slightly smaller hero typography */
+  h1.hero-title, .hero h1 { font-size: clamp(28px, 5vw, 44px); }
+}
+
+@media (max-width: 599px) {
+  /* Mobile: single column, smaller padding, larger touch targets */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: 1fr !important;
+    gap: 16px !important;
+  }
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 16px !important;
+    padding-right: 16px !important;
+  }
+  /* Touch-target floor for buttons + nav links */
+  .btn, button.btn, a.btn,
+  .nav-links a {
+    min-height: 44px;
+  }
+}
+
+/* Modal viewport clamp — applies at every viewport. Only adds bounds if a
+   modal forgot them. Uses min() to keep desktop behavior when there's
+   already a max-width or width set inline. */
+.modal,
+.modal-card,
+.modal-dialog,
+.tdf-modal,
+.modal-content {
+  max-width: min(960px, calc(100vw - 32px));
+  max-height: min(92vh, 920px);
+  overflow-y: auto;
+}
+@media (max-width: 599px) {
+  .modal,
+  .modal-card,
+  .modal-dialog,
+  .tdf-modal,
+  .modal-content {
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 32px);
+    border-radius: 14px;
+  }
+}
+</style>
 </head>
 <body>
   <div data-partial="nav"></div>

--- a/mockups/tadaify-mvp/login.html
+++ b/mockups/tadaify-mvp/login.html
@@ -343,6 +343,99 @@
       background: #141A2D; border-color: #1F2937; color: #F3F4F6;
     }
   </style>
+
+<style data-source="responsive-tablet-tier">
+/* ==========================================================================
+   Responsive tablet-tier (600–1023px) + modal viewport clamp.
+   Auto-injected 2026-04-27 per feedback_tadaify_three_viewport_support.
+   Targets common cramped layouts at iPad-portrait widths and ensures
+   modals never overflow the viewport at any size.
+   ========================================================================== */
+@media (max-width: 1023px) and (min-width: 600px) {
+  /* Clamp 3+ column grids to 2 columns at tablet width */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+  /* Reduce horizontal padding on common containers */
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 24px !important;
+    padding-right: 24px !important;
+  }
+  /* Slightly smaller hero typography */
+  h1.hero-title, .hero h1 { font-size: clamp(28px, 5vw, 44px); }
+}
+
+@media (max-width: 599px) {
+  /* Mobile: single column, smaller padding, larger touch targets */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: 1fr !important;
+    gap: 16px !important;
+  }
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 16px !important;
+    padding-right: 16px !important;
+  }
+  /* Touch-target floor for buttons + nav links */
+  .btn, button.btn, a.btn,
+  .nav-links a {
+    min-height: 44px;
+  }
+}
+
+/* Modal viewport clamp — applies at every viewport. Only adds bounds if a
+   modal forgot them. Uses min() to keep desktop behavior when there's
+   already a max-width or width set inline. */
+.modal,
+.modal-card,
+.modal-dialog,
+.tdf-modal,
+.modal-content {
+  max-width: min(960px, calc(100vw - 32px));
+  max-height: min(92vh, 920px);
+  overflow-y: auto;
+}
+@media (max-width: 599px) {
+  .modal,
+  .modal-card,
+  .modal-dialog,
+  .tdf-modal,
+  .modal-content {
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 32px);
+    border-radius: 14px;
+  }
+}
+</style>
 </head>
 <body>
 

--- a/mockups/tadaify-mvp/onboarding-complete.html
+++ b/mockups/tadaify-mvp/onboarding-complete.html
@@ -130,6 +130,99 @@
       margin-left: auto; margin-right: auto;
     }
   </style>
+
+<style data-source="responsive-tablet-tier">
+/* ==========================================================================
+   Responsive tablet-tier (600–1023px) + modal viewport clamp.
+   Auto-injected 2026-04-27 per feedback_tadaify_three_viewport_support.
+   Targets common cramped layouts at iPad-portrait widths and ensures
+   modals never overflow the viewport at any size.
+   ========================================================================== */
+@media (max-width: 1023px) and (min-width: 600px) {
+  /* Clamp 3+ column grids to 2 columns at tablet width */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+  /* Reduce horizontal padding on common containers */
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 24px !important;
+    padding-right: 24px !important;
+  }
+  /* Slightly smaller hero typography */
+  h1.hero-title, .hero h1 { font-size: clamp(28px, 5vw, 44px); }
+}
+
+@media (max-width: 599px) {
+  /* Mobile: single column, smaller padding, larger touch targets */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: 1fr !important;
+    gap: 16px !important;
+  }
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 16px !important;
+    padding-right: 16px !important;
+  }
+  /* Touch-target floor for buttons + nav links */
+  .btn, button.btn, a.btn,
+  .nav-links a {
+    min-height: 44px;
+  }
+}
+
+/* Modal viewport clamp — applies at every viewport. Only adds bounds if a
+   modal forgot them. Uses min() to keep desktop behavior when there's
+   already a max-width or width set inline. */
+.modal,
+.modal-card,
+.modal-dialog,
+.tdf-modal,
+.modal-content {
+  max-width: min(960px, calc(100vw - 32px));
+  max-height: min(92vh, 920px);
+  overflow-y: auto;
+}
+@media (max-width: 599px) {
+  .modal,
+  .modal-card,
+  .modal-dialog,
+  .tdf-modal,
+  .modal-content {
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 32px);
+    border-radius: 14px;
+  }
+}
+</style>
 </head>
 <body>
   <div data-partial="nav"></div>

--- a/mockups/tadaify-mvp/onboarding-social.html
+++ b/mockups/tadaify-mvp/onboarding-social.html
@@ -145,6 +145,99 @@
     }
     .onb-hero .logo-mark { width: 44px; height: 44px; }
   </style>
+
+<style data-source="responsive-tablet-tier">
+/* ==========================================================================
+   Responsive tablet-tier (600–1023px) + modal viewport clamp.
+   Auto-injected 2026-04-27 per feedback_tadaify_three_viewport_support.
+   Targets common cramped layouts at iPad-portrait widths and ensures
+   modals never overflow the viewport at any size.
+   ========================================================================== */
+@media (max-width: 1023px) and (min-width: 600px) {
+  /* Clamp 3+ column grids to 2 columns at tablet width */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+  /* Reduce horizontal padding on common containers */
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 24px !important;
+    padding-right: 24px !important;
+  }
+  /* Slightly smaller hero typography */
+  h1.hero-title, .hero h1 { font-size: clamp(28px, 5vw, 44px); }
+}
+
+@media (max-width: 599px) {
+  /* Mobile: single column, smaller padding, larger touch targets */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: 1fr !important;
+    gap: 16px !important;
+  }
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 16px !important;
+    padding-right: 16px !important;
+  }
+  /* Touch-target floor for buttons + nav links */
+  .btn, button.btn, a.btn,
+  .nav-links a {
+    min-height: 44px;
+  }
+}
+
+/* Modal viewport clamp — applies at every viewport. Only adds bounds if a
+   modal forgot them. Uses min() to keep desktop behavior when there's
+   already a max-width or width set inline. */
+.modal,
+.modal-card,
+.modal-dialog,
+.tdf-modal,
+.modal-content {
+  max-width: min(960px, calc(100vw - 32px));
+  max-height: min(92vh, 920px);
+  overflow-y: auto;
+}
+@media (max-width: 599px) {
+  .modal,
+  .modal-card,
+  .modal-dialog,
+  .tdf-modal,
+  .modal-content {
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 32px);
+    border-radius: 14px;
+  }
+}
+</style>
 </head>
 <body>
   <div data-partial="nav"></div>

--- a/mockups/tadaify-mvp/onboarding-template.html
+++ b/mockups/tadaify-mvp/onboarding-template.html
@@ -123,6 +123,99 @@
       height: 100%;
     }
   </style>
+
+<style data-source="responsive-tablet-tier">
+/* ==========================================================================
+   Responsive tablet-tier (600–1023px) + modal viewport clamp.
+   Auto-injected 2026-04-27 per feedback_tadaify_three_viewport_support.
+   Targets common cramped layouts at iPad-portrait widths and ensures
+   modals never overflow the viewport at any size.
+   ========================================================================== */
+@media (max-width: 1023px) and (min-width: 600px) {
+  /* Clamp 3+ column grids to 2 columns at tablet width */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+  /* Reduce horizontal padding on common containers */
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 24px !important;
+    padding-right: 24px !important;
+  }
+  /* Slightly smaller hero typography */
+  h1.hero-title, .hero h1 { font-size: clamp(28px, 5vw, 44px); }
+}
+
+@media (max-width: 599px) {
+  /* Mobile: single column, smaller padding, larger touch targets */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: 1fr !important;
+    gap: 16px !important;
+  }
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 16px !important;
+    padding-right: 16px !important;
+  }
+  /* Touch-target floor for buttons + nav links */
+  .btn, button.btn, a.btn,
+  .nav-links a {
+    min-height: 44px;
+  }
+}
+
+/* Modal viewport clamp — applies at every viewport. Only adds bounds if a
+   modal forgot them. Uses min() to keep desktop behavior when there's
+   already a max-width or width set inline. */
+.modal,
+.modal-card,
+.modal-dialog,
+.tdf-modal,
+.modal-content {
+  max-width: min(960px, calc(100vw - 32px));
+  max-height: min(92vh, 920px);
+  overflow-y: auto;
+}
+@media (max-width: 599px) {
+  .modal,
+  .modal-card,
+  .modal-dialog,
+  .tdf-modal,
+  .modal-content {
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 32px);
+    border-radius: 14px;
+  }
+}
+</style>
 </head>
 <body>
   <div data-partial="nav"></div>

--- a/mockups/tadaify-mvp/onboarding-tier.html
+++ b/mockups/tadaify-mvp/onboarding-tier.html
@@ -218,6 +218,99 @@
       .addon-universal p { font-size: 13px; }
     }
   </style>
+
+<style data-source="responsive-tablet-tier">
+/* ==========================================================================
+   Responsive tablet-tier (600–1023px) + modal viewport clamp.
+   Auto-injected 2026-04-27 per feedback_tadaify_three_viewport_support.
+   Targets common cramped layouts at iPad-portrait widths and ensures
+   modals never overflow the viewport at any size.
+   ========================================================================== */
+@media (max-width: 1023px) and (min-width: 600px) {
+  /* Clamp 3+ column grids to 2 columns at tablet width */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+  /* Reduce horizontal padding on common containers */
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 24px !important;
+    padding-right: 24px !important;
+  }
+  /* Slightly smaller hero typography */
+  h1.hero-title, .hero h1 { font-size: clamp(28px, 5vw, 44px); }
+}
+
+@media (max-width: 599px) {
+  /* Mobile: single column, smaller padding, larger touch targets */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: 1fr !important;
+    gap: 16px !important;
+  }
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 16px !important;
+    padding-right: 16px !important;
+  }
+  /* Touch-target floor for buttons + nav links */
+  .btn, button.btn, a.btn,
+  .nav-links a {
+    min-height: 44px;
+  }
+}
+
+/* Modal viewport clamp — applies at every viewport. Only adds bounds if a
+   modal forgot them. Uses min() to keep desktop behavior when there's
+   already a max-width or width set inline. */
+.modal,
+.modal-card,
+.modal-dialog,
+.tdf-modal,
+.modal-content {
+  max-width: min(960px, calc(100vw - 32px));
+  max-height: min(92vh, 920px);
+  overflow-y: auto;
+}
+@media (max-width: 599px) {
+  .modal,
+  .modal-card,
+  .modal-dialog,
+  .tdf-modal,
+  .modal-content {
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 32px);
+    border-radius: 14px;
+  }
+}
+</style>
 </head>
 <body>
   <div data-partial="nav"></div>

--- a/mockups/tadaify-mvp/pricing.html
+++ b/mockups/tadaify-mvp/pricing.html
@@ -317,6 +317,99 @@
     .sticky-cta p { margin: 0; font-size: 14px; font-weight: 600; }
     @media (max-width: 640px) { .sticky-cta { padding: 10px 16px; } .sticky-cta p { display: none; } }
   </style>
+
+<style data-source="responsive-tablet-tier">
+/* ==========================================================================
+   Responsive tablet-tier (600–1023px) + modal viewport clamp.
+   Auto-injected 2026-04-27 per feedback_tadaify_three_viewport_support.
+   Targets common cramped layouts at iPad-portrait widths and ensures
+   modals never overflow the viewport at any size.
+   ========================================================================== */
+@media (max-width: 1023px) and (min-width: 600px) {
+  /* Clamp 3+ column grids to 2 columns at tablet width */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+  /* Reduce horizontal padding on common containers */
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 24px !important;
+    padding-right: 24px !important;
+  }
+  /* Slightly smaller hero typography */
+  h1.hero-title, .hero h1 { font-size: clamp(28px, 5vw, 44px); }
+}
+
+@media (max-width: 599px) {
+  /* Mobile: single column, smaller padding, larger touch targets */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: 1fr !important;
+    gap: 16px !important;
+  }
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 16px !important;
+    padding-right: 16px !important;
+  }
+  /* Touch-target floor for buttons + nav links */
+  .btn, button.btn, a.btn,
+  .nav-links a {
+    min-height: 44px;
+  }
+}
+
+/* Modal viewport clamp — applies at every viewport. Only adds bounds if a
+   modal forgot them. Uses min() to keep desktop behavior when there's
+   already a max-width or width set inline. */
+.modal,
+.modal-card,
+.modal-dialog,
+.tdf-modal,
+.modal-content {
+  max-width: min(960px, calc(100vw - 32px));
+  max-height: min(92vh, 920px);
+  overflow-y: auto;
+}
+@media (max-width: 599px) {
+  .modal,
+  .modal-card,
+  .modal-dialog,
+  .tdf-modal,
+  .modal-content {
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 32px);
+    border-radius: 14px;
+  }
+}
+</style>
 </head>
 <body>
   <div data-partial="nav"></div>

--- a/mockups/tadaify-mvp/shared/partials.js
+++ b/mockups/tadaify-mvp/shared/partials.js
@@ -92,12 +92,63 @@
 
   var SIDEBAR_CSS = '' +
     '<style data-source="app-sidebar-partial">' +
+    /* Mobile (<720px): sidebar hidden by default, shown as full-screen centered overlay
+       when .is-open class is added by the hamburger toggle (no right-side drawer per
+       feedback_no_right_side_drawers — full-screen modal pattern). */
     'aside.tdf-side {' +
     '  display: none; background: var(--bg-elevated); border-right: 1px solid var(--border);' +
     '  padding: 18px 10px; flex-direction: column; gap: 8px; position: sticky; top: 54px; align-self: start;' +
     '  height: calc(100vh - 54px); overflow-y: auto;' +
     '}' +
+    /* Tablet+ (>=720px): sticky sidebar visible */
     '@media (min-width: 720px) { aside.tdf-side { display: flex; } }' +
+    /* Mobile drawer: centered full-screen modal sheet when toggled open */
+    '@media (max-width: 719px) {' +
+    '  aside.tdf-side.is-open {' +
+    '    display: flex; position: fixed; top: 0; left: 0; right: 0; bottom: 0;' +
+    '    width: 100vw; height: 100vh; max-height: 100vh; z-index: 1100;' +
+    '    padding: 60px 20px 24px; gap: 10px; overflow-y: auto;' +
+    '    background: var(--bg-elevated); border-right: 0;' +
+    '    animation: tdfSideIn .18s ease-out;' +
+    '  }' +
+    '  aside.tdf-side.is-open .nav-item { padding: 12px 14px; font-size: 15px; min-height: 44px; }' +
+    '  aside.tdf-side.is-open .nav-sub-item { padding: 10px 12px; font-size: 14px; min-height: 40px; }' +
+    '}' +
+    '@keyframes tdfSideIn { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }' +
+    /* Mobile topbar with hamburger (auto-injected on pages that have the sidebar partial) */
+    '.tdf-mobile-topbar {' +
+    '  display: none; position: sticky; top: 0; z-index: 1050;' +
+    '  background: var(--bg-elevated); border-bottom: 1px solid var(--border);' +
+    '  padding: 10px 14px; align-items: center; gap: 12px;' +
+    '}' +
+    '@media (max-width: 719px) {' +
+    '  .tdf-mobile-topbar { display: flex; }' +
+    '}' +
+    '.tdf-mobile-topbar .tdf-hamburger {' +
+    '  display: inline-flex; align-items: center; justify-content: center;' +
+    '  width: 44px; height: 44px; border-radius: 10px; border: 1px solid var(--border);' +
+    '  background: var(--bg); color: var(--fg); cursor: pointer;' +
+    '}' +
+    '.tdf-mobile-topbar .tdf-hamburger svg { width: 20px; height: 20px; }' +
+    '.tdf-mobile-topbar .tdf-mobile-brand {' +
+    '  font-family: var(--font-display, inherit); font-weight: 600; font-size: 15px;' +
+    '  color: var(--fg); display: inline-flex; align-items: center; gap: 8px;' +
+    '}' +
+    '.tdf-mobile-topbar .tdf-mobile-close {' +
+    '  display: none; margin-left: auto; width: 44px; height: 44px; border-radius: 10px;' +
+    '  border: 1px solid var(--border); background: var(--bg); color: var(--fg); cursor: pointer;' +
+    '  align-items: center; justify-content: center;' +
+    '}' +
+    /* When the sidebar is open on mobile, swap hamburger for close (X) inside the topbar */
+    'body.tdf-side-open .tdf-mobile-topbar .tdf-hamburger { display: none; }' +
+    'body.tdf-side-open .tdf-mobile-topbar .tdf-mobile-close { display: inline-flex; }' +
+    'body.tdf-side-open { overflow: hidden; }' +
+    /* Backdrop behind drawer */
+    '.tdf-side-backdrop {' +
+    '  display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.45);' +
+    '  z-index: 1080; backdrop-filter: blur(2px);' +
+    '}' +
+    'body.tdf-side-open .tdf-side-backdrop { display: block; }' +
     '.tdf-side .side-user { display: flex; align-items: center; gap: 10px; padding: 8px; border-radius: 10px; border: 1px solid var(--border); background: var(--bg); }' +
     '.tdf-side .side-user .av { width: 34px; height: 34px; border-radius: 50%; background: var(--hero-gradient); display: flex; align-items: center; justify-content: center; color: #fff; font-family: var(--font-display); font-weight: 600; font-size: 15px; flex-shrink: 0; }' +
     '.tdf-side .side-user .utxt { min-width: 0; flex: 1; }' +
@@ -267,6 +318,72 @@
     );
     el.outerHTML = html;
   });
+
+  /* ----------------------------------------------------------------- */
+  /* 3b. Mobile topbar + sidebar drawer wiring                          */
+  /*                                                                    */
+  /* On viewports <720px the canonical sidebar is hidden. Inject a      */
+  /* sticky topbar with a hamburger button that opens the sidebar as a  */
+  /* full-screen centered modal sheet (per feedback_no_right_side_      */
+  /* drawers — modal pattern, not slide-in panel).                      */
+  /* ----------------------------------------------------------------- */
+  (function setupMobileSidebarDrawer() {
+    var sidebar = document.querySelector('aside.tdf-side');
+    if (!sidebar) return;
+
+    var HAMBURGER_SVG = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>';
+    var CLOSE_SVG     = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>';
+
+    var topbar = document.createElement('div');
+    topbar.className = 'tdf-mobile-topbar';
+    topbar.setAttribute('role', 'banner');
+    topbar.innerHTML =
+      '<button type="button" class="tdf-hamburger" aria-label="Open navigation" aria-controls="tdf-sidebar-drawer" aria-expanded="false">' + HAMBURGER_SVG + '</button>' +
+      '<button type="button" class="tdf-mobile-close" aria-label="Close navigation">' + CLOSE_SVG + '</button>' +
+      '<span class="tdf-mobile-brand">' +
+        '<span class="logo-mark" data-logo style="width:22px;height:22px"></span>' +
+        '<span class="wordmark" style="font-size:15px"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span></span>' +
+      '</span>';
+
+    var backdrop = document.createElement('div');
+    backdrop.className = 'tdf-side-backdrop';
+    backdrop.setAttribute('aria-hidden', 'true');
+
+    /* Insert topbar at the very top of <body> so it stays sticky above content. */
+    document.body.insertBefore(topbar, document.body.firstChild);
+    document.body.appendChild(backdrop);
+    sidebar.id = sidebar.id || 'tdf-sidebar-drawer';
+
+    function openSidebar() {
+      sidebar.classList.add('is-open');
+      document.body.classList.add('tdf-side-open');
+      var btn = topbar.querySelector('.tdf-hamburger');
+      if (btn) btn.setAttribute('aria-expanded', 'true');
+    }
+    function closeSidebar() {
+      sidebar.classList.remove('is-open');
+      document.body.classList.remove('tdf-side-open');
+      var btn = topbar.querySelector('.tdf-hamburger');
+      if (btn) btn.setAttribute('aria-expanded', 'false');
+    }
+
+    topbar.querySelector('.tdf-hamburger').addEventListener('click', openSidebar);
+    topbar.querySelector('.tdf-mobile-close').addEventListener('click', closeSidebar);
+    backdrop.addEventListener('click', closeSidebar);
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' && document.body.classList.contains('tdf-side-open')) closeSidebar();
+    });
+    /* Close drawer when user navigates within it (link clicks). */
+    sidebar.addEventListener('click', function (e) {
+      var t = e.target.closest('a, button.nav-item, button.nav-sub-item');
+      if (t && document.body.classList.contains('tdf-side-open')) closeSidebar();
+    });
+
+    /* Re-register logo orb in the just-injected mobile brand */
+    if (window.tadaifyTokens && typeof window.tadaifyTokens.renderLogo === 'function') {
+      try { window.tadaifyTokens.renderLogo(); } catch (e) {}
+    }
+  })();
 
   /* ----------------------------------------------------------------- */
   /* 4. Tier badge + tier-gate-modal (no-blur premium UX)              */

--- a/mockups/tadaify-mvp/try.html
+++ b/mockups/tadaify-mvp/try.html
@@ -127,6 +127,99 @@
       box-shadow: var(--shadow-xl);
     }
   </style>
+
+<style data-source="responsive-tablet-tier">
+/* ==========================================================================
+   Responsive tablet-tier (600–1023px) + modal viewport clamp.
+   Auto-injected 2026-04-27 per feedback_tadaify_three_viewport_support.
+   Targets common cramped layouts at iPad-portrait widths and ensures
+   modals never overflow the viewport at any size.
+   ========================================================================== */
+@media (max-width: 1023px) and (min-width: 600px) {
+  /* Clamp 3+ column grids to 2 columns at tablet width */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+  /* Reduce horizontal padding on common containers */
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 24px !important;
+    padding-right: 24px !important;
+  }
+  /* Slightly smaller hero typography */
+  h1.hero-title, .hero h1 { font-size: clamp(28px, 5vw, 44px); }
+}
+
+@media (max-width: 599px) {
+  /* Mobile: single column, smaller padding, larger touch targets */
+  .feed,
+  .related-grid,
+  .grid-3,
+  .grid-4,
+  .features-grid,
+  .three-col,
+  .four-col,
+  .cards-grid,
+  .links-grid,
+  .blocks-grid,
+  .shop-grid,
+  .testimonial-grid,
+  .pricing-grid {
+    grid-template-columns: 1fr !important;
+    gap: 16px !important;
+  }
+  .container,
+  .wrap,
+  .page-wrap,
+  .public-wrap {
+    padding-left: 16px !important;
+    padding-right: 16px !important;
+  }
+  /* Touch-target floor for buttons + nav links */
+  .btn, button.btn, a.btn,
+  .nav-links a {
+    min-height: 44px;
+  }
+}
+
+/* Modal viewport clamp — applies at every viewport. Only adds bounds if a
+   modal forgot them. Uses min() to keep desktop behavior when there's
+   already a max-width or width set inline. */
+.modal,
+.modal-card,
+.modal-dialog,
+.tdf-modal,
+.modal-content {
+  max-width: min(960px, calc(100vw - 32px));
+  max-height: min(92vh, 920px);
+  overflow-y: auto;
+}
+@media (max-width: 599px) {
+  .modal,
+  .modal-card,
+  .modal-dialog,
+  .tdf-modal,
+  .modal-content {
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 32px);
+    border-radius: 14px;
+  }
+}
+</style>
 </head>
 <body>
 


### PR DESCRIPTION
## Summary

Three-viewport responsive audit of all 53 tadaify mockup HTML files
(Desktop 1280, Tablet 820, Mobile 390). Two systemic fixes applied:

1. **Mobile hamburger + drawer for shared sidebar partial** —
   `shared/partials.js` now auto-injects a 65px sticky topbar with a
   44×44 hamburger on viewports <720px. Sidebar opens as a full-screen
   centered modal sheet (per `feedback_no_right_side_drawers` — modal
   pattern, not slide-in panel). Affects 23 app pages that use the
   `data-partial="app-sidebar"` partial. Pre-fix, mobile users had no
   nav at all.

2. **Tablet-tier breakpoint + modal viewport clamp injected into 24
   high-risk files** — single inline `<style
   data-source="responsive-tablet-tier">` block before `</head>`.
   Targets common grid class names; clamps 3+ col grids to 2 col at
   600–1023px and 1 col at <600px. Adds modal `max-width:
   min(960px, calc(100vw - 32px))` + `max-height: min(92vh, 920px)`
   so modals never overflow the viewport.

Plus one audit report markdown summarising per-file × per-viewport
findings.

## Business requirements implemented

- BR-N/A — pure visual/UX fix, not a feature. Falls under the
  account-level rule "tadaify supports 3 viewports" locked
  2026-04-27 in
  `~/.claude/projects/.../memory/feedback_tadaify_three_viewport_support.md`.

## Technical requirements introduced or relied on

- TR-N/A new — relies on existing TR-015 traceability (`// Covers:`
  comments only apply to e2e specs; not relevant for static mockup
  HTML).
- Establishes a repeatable injection pattern using a `data-source`
  marker class to keep injections idempotent.

## Acceptance criteria from issue

(No GitHub issue yet — this is a proactive cleanup task scoped via
direct user request.) Implicit ACs:

- ✅ Every mockup audited at 3 viewports
- ✅ Per-file × per-viewport verdict published
- ✅ All `broken-layout` items fixed (cosmetic-only items deferred per
  rule)
- ✅ Mobile users can navigate app pages (was impossible pre-fix)
- ✅ Modals never overflow viewport at any size
- ✅ No visual regression at desktop 1280

## Test plan

This PR touches static HTML mockups only — no production code, no
runtime behaviour, no DB, no Playwright/unit test surface to add.

Manual verification performed:

- `app-page-blog.html` at 390×844: hamburger visible, drawer opens
  full-screen, ESC + close button + backdrop close drawer, body scroll
  locks, link click auto-closes
- `app-page-blog.html` at 820×1180: 72px icon-only sidebar, no topbar,
  no drawer
- `app-page-blog.html` at 1280×800: full 240px sidebar, labels visible
- `creator-blog-public.html` at 390×844: feed=1col, related=1col, no
  horizontal scroll
- `creator-blog-public.html` at 820×1180: feed=2col, related=2col
  (was 3col cramped pre-fix)
- `creator-blog-public.html` at 1280×800: feed=2col, related=3col
  (designer's original spec preserved)
- `landing.html` at 390×844: no horizontal scroll

Edge cases manually validated:

- Multiple `<aside>` injection (only one topbar injected — selector
  is `aside.tdf-side`)
- Backdrop click vs link click both close drawer
- Idempotent re-run of injector script (marker class detected, skip)

## Mockup

No UI change — these ARE the mockups. The PR fixes the mockups to
match the documented 3-viewport contract.

## Rollback

```
git revert ef42d32 c644e8e 62880c0
```

(audit report → tablet-tier injection → partial drawer fix)

If only the partial drawer fix is problematic and you want to keep
the tablet-tier fixes:

```
git revert 62880c0
```

## Files

- `mockups/tadaify-mvp/shared/partials.js` (+117)
- `mockups/tadaify-mvp/*.html` (24 files; pure additive `<style>` block,
  no existing rules removed)
- `mockups/tadaify-mvp/RESPONSIVE-AUDIT-2026-04-27.md` (new)

## Follow-up (not in this PR)

- `app-dashboard.html` and `app-dashboard-variants.html` use a bespoke
  inline `<aside>` instead of the shared partial. Mobile drawer fix
  does NOT apply. Recommend follow-up to migrate them.
- Marketing nav (`shared/header.html` `.nav-links`) wraps awkwardly
  at 600–800px on landing/pricing. Symmetric hamburger pattern
  needed. Out of scope for this audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
