### PR TITLE
feat(mockup): AI Suggest cost transparency wiring per locked strategy (Fix #3 Phase 1)

### DIFF
--- a/mockups/tadaify-mvp/app-ai-suggest-modal.html
+++ b/mockups/tadaify-mvp/app-ai-suggest-modal.html
@@ -1576,8 +1576,17 @@
       current.dirty = false;
 
       var ctx = TRIGGER_CONTEXTS[triggerKey];
-      document.getElementById('ai-target').textContent = ctx.label;
-      document.getElementById('ctx-text').innerHTML = ctx.ctxHtml;
+      var targetEl = document.getElementById('ai-target');
+      if (targetEl) targetEl.textContent = ctx.label;
+      /* ctx-text only exists on first paint; subsequent renderState()
+         calls rebuild the body and re-inject ctx-text via ctxHtml. */
+      var ctxEl = document.getElementById('ctx-text');
+      if (ctxEl) ctxEl.innerHTML = ctx.ctxHtml;
+
+      /* Reset to default loaded flow on every open so a stale 'out' /
+         'error' state from a previous session doesn't survive. The quota
+         gate immediately below flips back to 'out' if still capped. */
+      demoState = 'loaded';
 
       /* Quota gate at open time — DEC-177 hard-block. If the creator
          hits ✨ Suggest with 0 left, we show the out-of-quota panel

--- a/mockups/tadaify-mvp/app-ai-suggest-modal.html
+++ b/mockups/tadaify-mvp/app-ai-suggest-modal.html
@@ -169,6 +169,104 @@
       color: #fff;
       border-color: var(--brand-primary);
     }
+    /* Demo controls — tier switcher + used-today slider */
+    .demo-toolbar-row {
+      margin-top: 12px;
+      display: flex; gap: 14px; align-items: center; flex-wrap: wrap;
+      font-size: 12px; color: var(--fg-muted);
+      padding: 12px 14px;
+      background: var(--bg-muted);
+      border-radius: 10px;
+    }
+    .demo-toolbar-row .tlabel {
+      font-size: 11.5px; font-weight: 600;
+      color: var(--fg-muted); white-space: nowrap;
+    }
+    .demo-toolbar-row .slider-wrap {
+      display: flex; gap: 8px; align-items: center;
+      flex: 1; min-width: 220px;
+    }
+    .demo-toolbar-row input[type="range"] {
+      flex: 1; accent-color: var(--brand-primary); cursor: pointer;
+    }
+    .demo-toolbar-row .slider-readout {
+      font-family: var(--font-mono);
+      font-size: 11px; font-weight: 600;
+      color: var(--fg);
+      min-width: 64px; text-align: right;
+    }
+
+    /* Cost transparency strip — embedded in static state-variants */
+    .ctx-cost {
+      display: flex; align-items: center; gap: 10px;
+      padding: 10px 12px;
+      background: var(--bg-muted);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      font-size: 12px; line-height: 1.4; color: var(--fg-muted);
+    }
+    .ctx-cost .meter { flex: 1; display: flex; flex-direction: column; gap: 4px; }
+    .ctx-cost .line { color: var(--fg); font-weight: 500; }
+    .ctx-cost .line b { font-weight: 700; }
+    .ctx-cost .sub { font-size: 11px; color: var(--fg-subtle); }
+    .ctx-cost .bar {
+      height: 4px; background: rgba(0,0,0,0.06);
+      border-radius: 99px; overflow: hidden; margin-top: 2px;
+    }
+    .ctx-cost .bar > i {
+      display: block; height: 100%;
+      background: var(--brand-primary); border-radius: 99px;
+    }
+    .ctx-cost.is-low { background: rgba(245,158,11,0.10); border-color: rgba(245,158,11,0.32); }
+    .ctx-cost.is-low .bar > i { background: #F59E0B; }
+    .ctx-cost.is-out { background: rgba(239,68,68,0.10); border-color: rgba(239,68,68,0.32); }
+    .ctx-cost.is-out .bar > i { background: #EF4444; }
+
+    /* Refresh button explicit cost label inside foot */
+    .refresh-cost {
+      font-size: 11px; font-weight: 500;
+      color: var(--fg-subtle); margin-left: 2px;
+    }
+
+    /* Out-of-quota hard-block state */
+    .out-box {
+      padding: 22px 18px; text-align: center;
+      background: rgba(239,68,68,0.04);
+      border: 1px solid rgba(239,68,68,0.20);
+      border-radius: 12px;
+    }
+    .out-box .out-icon {
+      width: 40px; height: 40px; border-radius: 99px;
+      background: rgba(239,68,68,0.12); color: #EF4444;
+      display: inline-flex; align-items: center; justify-content: center;
+      font-size: 20px; margin-bottom: 12px;
+    }
+    .out-box .out-h {
+      font-family: var(--font-display);
+      font-size: 20px; font-weight: 600; color: var(--fg);
+      margin-bottom: 6px; letter-spacing: -0.01em;
+    }
+    .out-box .out-countdown {
+      font-size: 14px; color: var(--fg-muted); margin-bottom: 14px;
+    }
+    .out-box .out-countdown b {
+      font-family: var(--font-mono);
+      color: var(--fg); font-weight: 600;
+    }
+    .out-box details {
+      margin-top: 16px; padding-top: 14px;
+      border-top: 1px dashed rgba(0,0,0,0.10);
+      text-align: left;
+    }
+    .out-box details summary {
+      font-size: 12px; font-weight: 600; color: var(--fg-muted);
+      cursor: pointer; list-style: none; user-select: none;
+    }
+    .out-box details summary::-webkit-details-marker { display: none; }
+    .out-box details p {
+      margin: 8px 0 0; font-size: 12.5px; line-height: 1.55;
+      color: var(--fg-muted);
+    }
 
     /* =========================================================================
        Sub-modal (the AI Suggest UI itself — centered, NEVER right-drawer)
@@ -813,18 +911,37 @@
       block editor. The sub-modal reads what you've already entered (plus
       surrounding block context — type, URL, image alt-text, …) and returns
       five short alternatives in different tones. Pick one, click <b>Use this</b>,
-      and the field updates. <b>Cost:</b> ~$0.0001 per click on Claude Haiku
-      &mdash; baked into every paid tier with a soft 30/day cap on Free for
-      abuse protection.
+      and the field updates. <b>Cost:</b> $0.000223 per call on Cloudflare
+      Workers AI (llama-3.1-8b-instruct-fast). Per-tier daily quotas keep the
+      Free tier sustainable: <b>Free 5/day · Creator 50/day · Pro &amp; Business
+      unlimited</b> (DEC-174..179, locked 2026-04-27).
+    </div>
+
+    <!-- Demo controls — tier switcher (drives cost strip + per-button badges) -->
+    <div class="demo-toolbar-row">
+      <span class="tlabel">Tier:</span>
+      <button class="tier-chip is-active" type="button" data-tier="free"     onclick="setDemoTier(this, 'free')">Free · 5/day</button>
+      <button class="tier-chip"           type="button" data-tier="creator"  onclick="setDemoTier(this, 'creator')">Creator $8 · 50/day</button>
+      <button class="tier-chip"           type="button" data-tier="pro"      onclick="setDemoTier(this, 'pro')">Pro $19 · Unlimited</button>
+      <button class="tier-chip"           type="button" data-tier="business" onclick="setDemoTier(this, 'business')">Business $49 · Unlimited</button>
+    </div>
+
+    <!-- Demo controls — "used today" slider (lets reviewer preview every quota state) -->
+    <div class="demo-toolbar-row">
+      <span class="tlabel">Used today:</span>
+      <div class="slider-wrap">
+        <input type="range" id="used-slider" min="0" max="5" value="2" step="1" oninput="setDemoUsed(this.value)" />
+        <span class="slider-readout" id="used-readout">2 / 5</span>
+      </div>
     </div>
 
     <div class="tier-row">
       <span>Demo state:</span>
-      <button class="tier-chip is-active" type="button" data-state="loaded" onclick="setState(this, 'loaded')">5 suggestions</button>
+      <button class="tier-chip is-active" type="button" data-state="loaded"  onclick="setState(this, 'loaded')">5 suggestions</button>
       <button class="tier-chip" type="button" data-state="loading" onclick="setState(this, 'loading')">Loading</button>
-      <button class="tier-chip" type="button" data-state="error" onclick="setState(this, 'error')">Error</button>
-      <button class="tier-chip" type="button" data-state="empty" onclick="setState(this, 'empty')">Empty (no input)</button>
-      <button class="tier-chip" type="button" data-state="rate" onclick="setState(this, 'rate')">Rate-limited</button>
+      <button class="tier-chip" type="button" data-state="error"   onclick="setState(this, 'error')">Error</button>
+      <button class="tier-chip" type="button" data-state="empty"   onclick="setState(this, 'empty')">Empty (no input)</button>
+      <button class="tier-chip" type="button" data-state="out"     onclick="setState(this, 'out')">Out of quota (hard-block)</button>
     </div>
   </div>
 
@@ -852,6 +969,15 @@
             <line x1="6" y1="6" x2="18" y2="18"></line>
           </svg>
         </button>
+      </div>
+
+      <!-- Cost transparency strip — populated by paintCostStripLive() -->
+      <div class="ctx-cost" id="cost-strip" style="margin: 12px 22px 0">
+        <div class="meter">
+          <div class="line" id="cost-line"><b>2 of 5</b> suggestions today</div>
+          <div class="bar"><i id="cost-fill" style="width:40%"></i></div>
+          <div class="sub" id="cost-sub">Resets in 8h 23m · midnight UTC</div>
+        </div>
       </div>
 
       <div class="ai-modal-body" id="ai-body">
@@ -929,16 +1055,16 @@
         </ul>
       </div>
 
-      <div class="ai-modal-foot">
+      <div class="ai-modal-foot" id="ai-foot">
         <div class="left">
-          <button class="btn-secondary" type="button" id="refresh-btn" onclick="refreshSuggestions()">
+          <button class="btn-secondary" type="button" id="refresh-btn" onclick="refreshSuggestions()" title="Costs 1 from your daily limit. Different suggestions next time.">
             <span class="btn-spinner"></span>
             <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
               <polyline points="23 4 23 10 17 10"></polyline>
               <polyline points="1 20 1 14 7 14"></polyline>
               <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"></path>
             </svg>
-            Refresh suggestions
+            Refresh<span class="refresh-cost" id="refresh-cost-label"> (uses 1 daily)</span>
           </button>
         </div>
         <div class="right">
@@ -959,8 +1085,54 @@
        ========================================================================= -->
   <div class="variants">
 
+    <h2>State 0 &mdash; Cost transparency strip (per tier)</h2>
+    <p>
+      The slim panel under the modal header. Always visible for Free / Creator
+      (with quota readout + countdown to midnight UTC). Hidden for Pro / Business
+      (no clutter for unlimited tiers). Color shifts: neutral → amber when ≤2 left
+      → red when at 0. Locked per DEC-176 + DEC-177.
+    </p>
+    <div class="frame" style="flex-direction:column; gap:12px; padding:24px">
+      <!-- Free tier, fresh -->
+      <div class="ctx-cost" style="width:min(540px,100%)">
+        <div class="meter">
+          <div class="line"><b>2 of 5</b> suggestions today <span style="color:var(--fg-subtle); font-weight:500; font-size:11px">· Free tier</span></div>
+          <div class="bar"><i style="width:40%"></i></div>
+          <div class="sub">Resets in 8h 23m · midnight UTC</div>
+        </div>
+      </div>
+      <!-- Free tier, near limit (amber) -->
+      <div class="ctx-cost is-low" style="width:min(540px,100%)">
+        <div class="meter">
+          <div class="line"><b>4 of 5</b> suggestions today <span style="color:var(--fg-subtle); font-weight:500; font-size:11px">· Free tier · 1 left</span></div>
+          <div class="bar"><i style="width:80%"></i></div>
+          <div class="sub">Resets in 5h 12m · midnight UTC</div>
+        </div>
+      </div>
+      <!-- Free tier, out (red) -->
+      <div class="ctx-cost is-out" style="width:min(540px,100%)">
+        <div class="meter">
+          <div class="line"><b>You've used today's 5 AI suggestions</b></div>
+          <div class="bar"><i style="width:100%"></i></div>
+          <div class="sub">Resets in 3h 45m (midnight UTC)</div>
+        </div>
+      </div>
+      <!-- Creator tier mid-session -->
+      <div class="ctx-cost" style="width:min(540px,100%)">
+        <div class="meter">
+          <div class="line"><b>23 of 50</b> suggestions today <span style="color:var(--fg-subtle); font-weight:500; font-size:11px">· Creator $8 tier</span></div>
+          <div class="bar"><i style="width:46%"></i></div>
+          <div class="sub">Resets in 7h 02m · midnight UTC</div>
+        </div>
+      </div>
+      <!-- Pro / Business: hidden -->
+      <div style="font-size:12px; color:var(--fg-subtle); padding:10px 14px; border:1px dashed var(--border); border-radius:10px; width:min(540px,100%); text-align:center">
+        Pro $19 + Business $49 tiers: cost strip is <b>hidden entirely</b> — unlimited usage, no clutter.
+      </div>
+    </div>
+
     <h2>State 1 &mdash; Loaded (5 suggestions)</h2>
-    <p>The default state once the API returns. Five short variants in different tones, click any card to select.</p>
+    <p>The default state once the API returns. Five short variants in different tones, click any card to select. Cost strip shows mid-session usage.</p>
     <div class="frame">
       <div class="ai-modal">
         <div class="ai-modal-head">
@@ -968,6 +1140,14 @@
           <button class="iconbtn" type="button" aria-label="Close">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
           </button>
+        </div>
+        <!-- Cost strip — Free tier mid-session, neutral -->
+        <div class="ctx-cost" style="margin: 12px 22px 0">
+          <div class="meter">
+            <div class="line"><b>2 of 5</b> suggestions today</div>
+            <div class="bar"><i style="width:40%"></i></div>
+            <div class="sub">Resets in 8h 23m · midnight UTC</div>
+          </div>
         </div>
         <div class="ai-modal-body">
           <div class="ctx-strip">
@@ -994,7 +1174,7 @@
           </ul>
         </div>
         <div class="ai-modal-foot">
-          <div class="left"><button class="btn-secondary"><svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"></polyline><polyline points="1 20 1 14 7 14"></polyline><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"></path></svg>Refresh suggestions</button></div>
+          <div class="left"><button class="btn-secondary"><svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"></polyline><polyline points="1 20 1 14 7 14"></polyline><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"></path></svg>Refresh<span class="refresh-cost"> (uses 1 daily)</span></button></div>
           <div class="right"><button class="btn-ghost">Cancel</button><button class="btn-primary">Use this</button></div>
         </div>
       </div>
@@ -1030,7 +1210,7 @@
           </div>
         </div>
         <div class="ai-modal-foot">
-          <div class="left"><button class="btn-secondary is-loading"><span class="btn-spinner"></span>Refresh suggestions</button></div>
+          <div class="left"><button class="btn-secondary is-loading"><span class="btn-spinner"></span>Refresh<span class="refresh-cost"> (uses 1 daily)</span></button></div>
           <div class="right"><button class="btn-ghost">Cancel</button><button class="btn-primary" disabled>Use this</button></div>
         </div>
       </div>
@@ -1105,49 +1285,94 @@
       </div>
     </div>
 
-    <h2>State 5 &mdash; Rate-limited (Free tier abuse cap)</h2>
-    <p>Free creator hit 30 clicks today. Typical creator never sees this — only those automating against the trigger. Upsell to a paid tier where AI Suggest is unlimited (Business) or much higher (Creator/Pro).</p>
+    <h2>State 5 &mdash; Out of quota (Free hits 5/5, hard-block per DEC-177)</h2>
+    <p>
+      Free creator hit today's 5-click cap. Locked strategy (DEC-177): hard-block modal
+      with countdown to midnight UTC + tier-specific Upgrade CTA in sticky footer.
+      Cost strip up top turns red. No silent degradation, no partial results.
+    </p>
     <div class="frame">
       <div class="ai-modal">
         <div class="ai-modal-head">
           <h3><span class="sparkle">✨</span> AI suggestions for <span class="target-name">Caption</span></h3>
           <button class="iconbtn" aria-label="Close"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg></button>
         </div>
+        <!-- Cost strip — red, "you've used today's 5" -->
+        <div class="ctx-cost is-out" style="margin: 12px 22px 0">
+          <div class="meter">
+            <div class="line"><b>You've used today's 5 AI suggestions</b></div>
+            <div class="bar"><i style="width:100%"></i></div>
+            <div class="sub">Resets in 8h 23m (midnight UTC)</div>
+          </div>
+        </div>
         <div class="ai-modal-body">
           <div class="ctx-strip">
             <svg class="ctx-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="16" x2="12" y2="12"></line><line x1="12" y1="8" x2="12.01" y2="8"></line></svg>
-            <div class="ctx-text">
-              Based on your <b>Image</b> &mdash; filename <code>studio-session.jpg</code>
-            </div>
+            <div class="ctx-text">Based on your <b>Image</b> &mdash; filename <code>studio-session.jpg</code></div>
           </div>
-          <div class="rate-box">
-            <svg class="rate-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-              <circle cx="12" cy="12" r="10"></circle>
-              <polyline points="12 6 12 12 16 14"></polyline>
-            </svg>
-            <div class="rate-body">
-              <div class="rate-h">You've used today's AI credits</div>
-              <div class="rate-sub">
-                Free creators get 30 ✨ Suggest clicks per day &mdash; that resets at
-                midnight (your time zone). Upgrade for higher quotas now or just
-                give it a few hours.
-              </div>
-              <div class="upsell-row">
-                <button class="upgrade-btn" type="button">
-                  <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9" transform="rotate(180 12 12)"></polyline></svg>
-                  Upgrade for unlimited
-                </button>
-                <button class="btn-secondary" type="button">See plans</button>
-              </div>
-              <div class="rate-meta">
-                Resets in 4h 12m &middot; Creator 50/day &middot; Pro 200/day &middot; Business unlimited
-              </div>
-            </div>
+          <div class="out-box" role="alert">
+            <div class="out-icon" aria-hidden="true">⏳</div>
+            <div class="out-h">Comes back at midnight UTC</div>
+            <div class="out-countdown">in <b>8 hours 23 minutes</b></div>
+            <details open>
+              <summary>Why we limit</summary>
+              <p>AI suggestions cost us a fraction of a cent each ($0.000223 per call on Cloudflare Workers AI). We rate-limit to keep tadaify Free for everyone.</p>
+            </details>
           </div>
         </div>
         <div class="ai-modal-foot">
           <div class="left"></div>
-          <div class="right"><button class="btn-ghost">Close</button></div>
+          <div class="right">
+            <button class="btn-ghost">Wait until midnight</button>
+            <button class="upgrade-btn" type="button" style="padding:9px 14px">
+              Upgrade to Creator &mdash; $8/mo for 50/day
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <h2>State 5b &mdash; Out of quota on Creator tier (50/50, upsell to Pro)</h2>
+    <p>
+      Same hard-block, but Creator tier has hit its 50/day cap. Upsell now points
+      at Pro $19 with unlimited suggestions. Wait CTA stays available.
+    </p>
+    <div class="frame">
+      <div class="ai-modal">
+        <div class="ai-modal-head">
+          <h3><span class="sparkle">✨</span> AI suggestions for <span class="target-name">Block title</span></h3>
+          <button class="iconbtn" aria-label="Close"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg></button>
+        </div>
+        <div class="ctx-cost is-out" style="margin: 12px 22px 0">
+          <div class="meter">
+            <div class="line"><b>You've used today's 50 AI suggestions</b></div>
+            <div class="bar"><i style="width:100%"></i></div>
+            <div class="sub">Resets in 6h 04m (midnight UTC)</div>
+          </div>
+        </div>
+        <div class="ai-modal-body">
+          <div class="ctx-strip">
+            <svg class="ctx-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="16" x2="12" y2="12"></line><line x1="12" y1="8" x2="12.01" y2="8"></line></svg>
+            <div class="ctx-text">Based on your <b>Link button</b> &mdash; URL: <code>open.spotify.com/album/spring-drops</code></div>
+          </div>
+          <div class="out-box" role="alert">
+            <div class="out-icon" aria-hidden="true">⏳</div>
+            <div class="out-h">Comes back at midnight UTC</div>
+            <div class="out-countdown">in <b>6 hours 4 minutes</b></div>
+            <details>
+              <summary>Why we limit</summary>
+              <p>AI suggestions cost us a fraction of a cent each ($0.000223 per call on Cloudflare Workers AI). We rate-limit to keep tadaify Free for everyone.</p>
+            </details>
+          </div>
+        </div>
+        <div class="ai-modal-foot">
+          <div class="left"></div>
+          <div class="right">
+            <button class="btn-ghost">Wait until midnight</button>
+            <button class="upgrade-btn" type="button" style="padding:9px 14px">
+              Upgrade to Pro &mdash; $19/mo for unlimited suggestions
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -1180,7 +1405,7 @@
           </ul>
         </div>
         <div class="ai-modal-foot">
-          <div class="left"><button class="btn-secondary"><svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"></polyline><polyline points="1 20 1 14 7 14"></polyline><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"></path></svg>Refresh suggestions</button></div>
+          <div class="left"><button class="btn-secondary"><svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"></polyline><polyline points="1 20 1 14 7 14"></polyline><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"></path></svg>Refresh<span class="refresh-cost"> (uses 1 daily)</span></button></div>
           <div class="right"><button class="btn-ghost">Cancel</button><button class="btn-primary" style="box-shadow:0 0 0 3px rgba(99,102,241,0.25);">Use this</button></div>
         </div>
       </div>
@@ -1235,6 +1460,116 @@
     var current = { trigger: 'title', selectedIdx: 1, dirty: false };
     var demoState = 'loaded';
 
+    /* Cost transparency demo state — drives the cost strip + per-button
+       badges + out-of-quota hard-block. Mirrors the AI_QUOTA contract
+       in shared/partials.js (kept local here so the standalone file works
+       offline / without partials.js). DEC-176 limits. */
+    var QUOTAS = {
+      free:     { limit: 5,    label: '5/day',     unlimited: false },
+      creator:  { limit: 50,   label: '50/day',    unlimited: false },
+      pro:      { limit: 500,  label: 'Unlimited', unlimited: true  },
+      business: { limit: 2000, label: 'Unlimited', unlimited: true  }
+    };
+    var TIER_LABELS = { free: 'Free', creator: 'Creator', pro: 'Pro', business: 'Business' };
+    var TIER_PRICES = { free: 0, creator: 8, pro: 19, business: 49 };
+    var demoTier = 'free';
+    var demoUsed = { free: 2, creator: 12, pro: 47, business: 132 };
+
+    function nextTierUp(t) {
+      if (t === 'free') return 'creator';
+      if (t === 'creator') return 'pro';
+      return 'pro';
+    }
+    function formatCountdown(ms) {
+      if (ms <= 0) return '0s';
+      var s = Math.floor(ms / 1000);
+      var h = Math.floor(s / 3600);
+      var m = Math.floor((s % 3600) / 60);
+      if (h > 0) return h + 'h ' + m + 'm';
+      if (m > 0) return m + 'm';
+      return (s % 60) + 's';
+    }
+    function getResetMs() {
+      var now = new Date();
+      var midnight = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1, 0, 0, 0, 0);
+      return midnight - now.getTime();
+    }
+    function getQuota() {
+      var spec = QUOTAS[demoTier];
+      var used = demoUsed[demoTier] || 0;
+      return {
+        tier: demoTier,
+        used: used,
+        limit: spec.limit,
+        unlimited: spec.unlimited,
+        remaining: Math.max(0, spec.limit - used),
+        resetMs: getResetMs()
+      };
+    }
+
+    /* Paint the live modal's cost strip per current tier + used counter.
+       Pro+ tiers hide the strip entirely (no clutter for unlimited). */
+    function paintCostStripLive() {
+      var strip = document.getElementById('cost-strip');
+      if (!strip) return;
+      var q = getQuota();
+      if (q.unlimited) {
+        strip.style.display = 'none';
+        return;
+      }
+      strip.style.display = '';
+      strip.classList.remove('is-low', 'is-out');
+      if (q.remaining === 0) strip.classList.add('is-out');
+      else if (q.remaining <= 2) strip.classList.add('is-low');
+
+      var line = document.getElementById('cost-line');
+      var sub  = document.getElementById('cost-sub');
+      var fill = document.getElementById('cost-fill');
+      var pct  = Math.min(100, Math.round((q.used / q.limit) * 100));
+      if (q.remaining === 0) {
+        line.innerHTML = '<b>You\'ve used today\'s ' + q.limit + ' AI suggestions</b>';
+        sub.textContent = 'Resets in ' + formatCountdown(q.resetMs) + ' (midnight UTC)';
+      } else {
+        line.innerHTML = '<b>' + q.used + ' of ' + q.limit + '</b> suggestions today';
+        sub.textContent = 'Resets in ' + formatCountdown(q.resetMs) + ' · midnight UTC';
+      }
+      fill.style.width = pct + '%';
+    }
+
+    /* Demo tier switcher — also propagates to shared/partials.js so any
+       wired ✨ Suggest buttons elsewhere on the page (none here, but the
+       pattern is shared) re-render their per-tier hint. */
+    function setDemoTier(chip, tier) {
+      [].forEach.call(document.querySelectorAll('[data-tier]'), function (c) { c.classList.remove('is-active'); });
+      chip.classList.add('is-active');
+      demoTier = tier;
+      /* Reset slider bounds + value to current tier's "used" count. */
+      var slider   = document.getElementById('used-slider');
+      var readout  = document.getElementById('used-readout');
+      var spec     = QUOTAS[tier];
+      var maxLabel = spec.unlimited ? '500' : String(spec.limit);
+      slider.max   = spec.unlimited ? 500 : spec.limit;
+      slider.step  = spec.unlimited ? 50  : (spec.limit > 20 ? 5 : 1);
+      slider.value = demoUsed[tier];
+      readout.textContent = demoUsed[tier] + ' / ' + maxLabel;
+      paintCostStripLive();
+      renderState();
+      if (window.AISuggest && window.AISuggest._setDemoTier) {
+        window.AISuggest._setDemoTier(tier);
+      }
+    }
+    function setDemoUsed(value) {
+      demoUsed[demoTier] = parseInt(value, 10) || 0;
+      var spec     = QUOTAS[demoTier];
+      var maxLabel = spec.unlimited ? '500' : String(spec.limit);
+      document.getElementById('used-readout').textContent = demoUsed[demoTier] + ' / ' + maxLabel;
+      paintCostStripLive();
+      renderState();
+      if (window.AISuggest && window.AISuggest._setDemoUsed) {
+        window.AISuggest._setDemoUsed(demoTier, demoUsed[demoTier]);
+      }
+    }
+
     function openAi(triggerKey) {
       current.trigger = triggerKey;
       current.selectedIdx = -1;
@@ -1244,6 +1579,15 @@
       document.getElementById('ai-target').textContent = ctx.label;
       document.getElementById('ctx-text').innerHTML = ctx.ctxHtml;
 
+      /* Quota gate at open time — DEC-177 hard-block. If the creator
+         hits ✨ Suggest with 0 left, we show the out-of-quota panel
+         immediately (not a loading skeleton followed by an error). */
+      var q = getQuota();
+      if (!q.unlimited && q.remaining === 0) {
+        demoState = 'out';
+      }
+
+      paintCostStripLive();
       renderState();
 
       document.getElementById('ai-backdrop').classList.add('is-open');
@@ -1287,9 +1631,27 @@
     }
 
     function refreshSuggestions() {
+      /* Refresh = explicit 1-quota spend (DEC-179: bypass output cache).
+         Decrement counter, repaint cost strip, then either re-fetch or
+         flip to the out-of-quota hard-block if we just hit the cap. */
+      var spec = QUOTAS[demoTier];
+      if (!spec.unlimited) {
+        demoUsed[demoTier] = Math.min(spec.limit, (demoUsed[demoTier] || 0) + 1);
+      }
+      var slider  = document.getElementById('used-slider');
+      if (slider && !spec.unlimited) {
+        slider.value = demoUsed[demoTier];
+        document.getElementById('used-readout').textContent = demoUsed[demoTier] + ' / ' + spec.limit;
+      }
+      paintCostStripLive();
+      var q = getQuota();
+      if (!q.unlimited && q.remaining === 0) {
+        demoState = 'out';
+        renderState();
+        return;
+      }
       var btn = document.getElementById('refresh-btn');
       btn.classList.add('is-loading');
-      // In production: re-call the AI endpoint. In the demo: just blink.
       setTimeout(function () { btn.classList.remove('is-loading'); }, 900);
     }
 
@@ -1307,13 +1669,34 @@
     function renderState() {
       var ctx = TRIGGER_CONTEXTS[current.trigger];
       var body = document.getElementById('ai-body');
+      var foot = document.getElementById('ai-foot');
       var useBtn = document.getElementById('use-btn');
       var refreshBtn = document.getElementById('refresh-btn');
 
+      /* Restore default footer in case the previous render swapped it out
+         (e.g. coming back from the out-of-quota upsell footer). */
+      if (foot && !document.getElementById('refresh-btn')) {
+        foot.innerHTML =
+          '<div class="left">' +
+            '<button class="btn-secondary" type="button" id="refresh-btn" onclick="refreshSuggestions()" title="Costs 1 from your daily limit. Different suggestions next time.">' +
+              '<span class="btn-spinner"></span>' +
+              '↻ Refresh<span class="refresh-cost"> (uses 1 daily)</span>' +
+            '</button>' +
+          '</div>' +
+          '<div class="right">' +
+            '<button class="btn-ghost" type="button" onclick="closeAi()">Cancel</button>' +
+            '<button class="btn-primary" type="button" id="use-btn" onclick="useSelected()">Use this</button>' +
+          '</div>';
+        useBtn = document.getElementById('use-btn');
+        refreshBtn = document.getElementById('refresh-btn');
+      }
+
       // Reset the foot for the default state.
-      useBtn.style.display = '';
-      refreshBtn.style.display = '';
-      useBtn.disabled = true;
+      if (useBtn) { useBtn.style.display = ''; useBtn.disabled = true; }
+      if (refreshBtn) refreshBtn.style.display = '';
+
+      /* Always repaint cost strip — Pro+ tiers will hide it themselves. */
+      paintCostStripLive();
 
       var ctxHtml =
         '<div class="ctx-strip">' +
@@ -1371,20 +1754,45 @@
           '<button class="btn-primary" type="button" onclick="setState(document.querySelector(\'[data-state=loading]\'),\'loading\');setTimeout(function(){setState(document.querySelector(\'[data-state=loaded]\'),\'loaded\');},900);">Generate from context</button>' +
           '</div>';
         refreshBtn.style.display = 'none';
-      } else if (demoState === 'rate') {
+      } else if (demoState === 'rate' || demoState === 'out') {
+        /* Out-of-quota hard-block — DEC-177. Replaces 5 cards with a
+           friendly stop screen + countdown + per-tier upsell footer. */
+        var q = getQuota();
+        var nextT = nextTierUp(demoTier);
+        var nextLbl = TIER_LABELS[nextT];
+        var nextPrice = TIER_PRICES[nextT];
+        var nextSpec = QUOTAS[nextT];
+        var nextQuotaCopy = nextSpec.unlimited
+          ? 'unlimited suggestions'
+          : (nextSpec.limit + '/day');
         body.innerHTML = ctxHtml +
-          '<div class="rate-box">' +
-          '<svg class="rate-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
-          '<circle cx="12" cy="12" r="10"></circle><polyline points="12 6 12 12 16 14"></polyline></svg>' +
-          '<div class="rate-body">' +
-          '<div class="rate-h">You\'ve used today\'s AI credits</div>' +
-          '<div class="rate-sub">Free creators get 30 ✨ Suggest clicks per day — that resets at midnight (your time zone). Upgrade for higher quotas now or just give it a few hours.</div>' +
-          '<div class="upsell-row"><button class="upgrade-btn" type="button">Upgrade for unlimited</button><button class="btn-secondary" type="button">See plans</button></div>' +
-          '<div class="rate-meta">Resets in 4h 12m · Creator 50/day · Pro 200/day · Business unlimited</div>' +
-          '</div></div>';
-        refreshBtn.style.display = 'none';
-        useBtn.style.display = 'none';
+          '<div class="out-box" role="alert">' +
+            '<div class="out-icon" aria-hidden="true">⏳</div>' +
+            '<div class="out-h">Comes back at midnight UTC</div>' +
+            '<div class="out-countdown">in <b>' + formatCountdown(q.resetMs) + '</b></div>' +
+            '<details>' +
+              '<summary>Why we limit</summary>' +
+              '<p>AI suggestions cost us a fraction of a cent each ($0.000223 per call on Cloudflare Workers AI). We rate-limit to keep tadaify Free for everyone.</p>' +
+            '</details>' +
+          '</div>';
+        /* Swap footer to upsell-pair (Wait + Upgrade) — sticky under modal. */
+        if (foot) {
+          foot.innerHTML =
+            '<div class="left"></div>' +
+            '<div class="right">' +
+              '<button class="btn-ghost" type="button" onclick="closeAi()">Wait until midnight</button>' +
+              '<button class="upgrade-btn" type="button" onclick="onUpgradeClick(\'' + nextT + '\')" style="padding:9px 14px">' +
+                'Upgrade to ' + nextLbl + ' — $' + nextPrice + '/mo for ' + nextQuotaCopy +
+              '</button>' +
+            '</div>';
+        }
       }
+    }
+
+    function onUpgradeClick(tier) {
+      // In production: navigate to /settings/billing?upgrade=<tier>
+      try { console.log('[AI Suggest] upgrade CTA clicked → ' + tier); } catch (e) {}
+      closeAi();
     }
 
     function escapeHtml(s) {

--- a/mockups/tadaify-mvp/shared/partials.js
+++ b/mockups/tadaify-mvp/shared/partials.js
@@ -1636,8 +1636,13 @@
 
   /* Auto-enhance every existing ✨ Suggest entry point on the page once
      the DOM is ready. Picks up every button wired via the canonical
-     onclick="window.AISuggest.fromButton(this, ...)" pattern. */
+     onclick="window.AISuggest.fromButton(this, ...)" pattern.
+
+     We eagerly inject the AI Suggest CSS up-front so the per-button
+     [data-quota-badge]::after pill renders on initial page load, even
+     before the modal opens for the first time. */
   function autoEnhanceSuggestButtons() {
+    ensureAiCss();
     refreshAllButtonLabels();
   }
   if (document.readyState === 'loading') {

--- a/mockups/tadaify-mvp/shared/partials.js
+++ b/mockups/tadaify-mvp/shared/partials.js
@@ -788,7 +788,130 @@
   /* States: loaded (5 cards, default) / loading (skeletons) / error /  */
   /* empty / rate / selected. The default open() flow shows Loading for */
   /* 800ms then Loaded with 5 mocked suggestions matched to fieldName. */
+  /*                                                                    */
+  /* Cost transparency (DEC-174..179, 2026-04-27 cascade):              */
+  /*   - Free 5/day, Creator 50/day, Pro/Business unlimited (~500-2000) */
+  /*   - Cost strip shows current quota + countdown to midnight UTC     */
+  /*   - Refresh button explicitly costs 1 from daily limit             */
+  /*   - Out-of-quota = hard block + countdown + Upgrade CTA            */
+  /*   - Pro+ tiers: cost strip hidden (no clutter for unlimited)       */
   /* ----------------------------------------------------------------- */
+
+  /* Per-tier daily quota contract (locked 2026-04-27 via DEC-176).
+     Pro and Business are technically unlimited at the UI layer; the
+     "fair-use" ceiling exists only as abuse protection on the Worker. */
+  var AI_QUOTA = {
+    free:     { limit: 5,    label: '5/day',          unlimited: false },
+    creator:  { limit: 50,   label: '50/day',         unlimited: false },
+    pro:      { limit: 500,  label: 'Unlimited',      unlimited: true  },
+    business: { limit: 2000, label: 'Unlimited',      unlimited: true  }
+  };
+
+  /* Demo-only mocked "used today" counter per tier. In production this
+     comes from the Worker response. Values are intentionally above 0
+     so the cost strip always has something visible to show. */
+  var AI_USED_DEMO = { free: 2, creator: 12, pro: 47, business: 132 };
+
+  /* getCurrentTier — single source of truth for the current creator's
+     tier in mockup land. Resolution order:
+       1. window.__tadaifyDemoTier (set by demo toolbar / tier switcher)
+       2. localStorage 'tadaify_demo_tier'
+       3. 'free' default
+     Real app reads from creator.tier on the JWT payload. */
+  function getCurrentTier() {
+    try {
+      if (window.__tadaifyDemoTier && AI_QUOTA[window.__tadaifyDemoTier]) {
+        return window.__tadaifyDemoTier;
+      }
+      var saved = localStorage.getItem('tadaify_demo_tier');
+      if (saved && AI_QUOTA[saved]) return saved;
+    } catch (e) { /* localStorage blocked, fine */ }
+    return 'free';
+  }
+
+  /* getQuotaState — returns the per-tier quota snapshot the UI needs
+     to render the cost strip + decide hard-block. resetMs counts down
+     to next midnight UTC; pure function of Date.now(). */
+  function getQuotaState(tier) {
+    var t = tier || getCurrentTier();
+    var spec = AI_QUOTA[t] || AI_QUOTA.free;
+    var used = (typeof AI_USED_DEMO[t] === 'number') ? AI_USED_DEMO[t] : 0;
+    var now = new Date();
+    var midnightUtc = Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate() + 1,
+      0, 0, 0, 0
+    );
+    return {
+      tier:      t,
+      used:      used,
+      limit:     spec.limit,
+      label:     spec.label,
+      unlimited: spec.unlimited,
+      remaining: Math.max(0, spec.limit - used),
+      resetMs:   midnightUtc - now.getTime()
+    };
+  }
+
+  /* formatCountdown — turn an ms duration into "8h 23m" / "47m" /
+     "12s" depending on magnitude. Used by cost strip + out-of-quota. */
+  function formatCountdown(ms) {
+    if (ms <= 0) return '0s';
+    var totalSec = Math.floor(ms / 1000);
+    var h = Math.floor(totalSec / 3600);
+    var m = Math.floor((totalSec % 3600) / 60);
+    var s = totalSec % 60;
+    if (h > 0) return h + 'h ' + m + 'm';
+    if (m > 0) return m + 'm';
+    return s + 's';
+  }
+
+  /* nextTierUp — for upsell CTAs. Free → Creator → Pro → (Pro top). */
+  function nextTierUp(tier) {
+    if (tier === 'free') return 'creator';
+    if (tier === 'creator') return 'pro';
+    return 'pro'; // Pro / Business already unlimited
+  }
+
+  /* enhanceButtonLabel — called for every ✨ Suggest entry point. Adds
+     a hover tooltip describing the per-tier cost, plus an inline badge
+     when the creator is near their daily limit (last 2 calls). Pro+
+     tiers stay clean — just the bare "✨ Suggest". */
+  function enhanceButtonLabel(button) {
+    if (!button || button.__tdfAiEnhanced) return;
+    button.__tdfAiEnhanced = true;
+    var q = getQuotaState();
+    if (q.unlimited) {
+      button.title = 'AI suggestion · unlimited on ' + TIER_LABEL[q.tier];
+      return;
+    }
+    button.title = 'AI suggestion · uses 1 from your daily ' + q.limit +
+      ' (you have ' + q.remaining + ' left)';
+    if (q.remaining === 0) {
+      button.classList.add('tdf-ai-btn-out');
+      button.setAttribute('data-quota-badge', '0/' + q.limit + ' today');
+      return;
+    }
+    if (q.remaining <= 2) {
+      button.classList.add('tdf-ai-btn-low');
+      button.setAttribute('data-quota-badge', q.remaining + ' of ' + q.limit + ' left');
+    }
+  }
+  /* Re-enhance every wired ✨ Suggest button on the page. Called when
+     the demo toolbar swaps tier so badges re-render. */
+  function refreshAllButtonLabels() {
+    var btns = document.querySelectorAll(
+      '[onclick*="window.AISuggest.fromButton"], [onclick*="AISuggest.fromButton"]'
+    );
+    Array.prototype.forEach.call(btns, function (b) {
+      b.__tdfAiEnhanced = false;
+      b.removeAttribute('data-quota-badge');
+      b.classList.remove('tdf-ai-btn-low', 'tdf-ai-btn-out');
+      enhanceButtonLabel(b);
+    });
+  }
+
   var AI_SUGGEST_CSS = '' +
     '<style data-source="ai-suggest-partial">' +
     '.tdf-ai-backdrop {' +
@@ -941,6 +1064,116 @@
     '@media (prefers-reduced-motion: reduce) {' +
     '  .tdf-ai-backdrop, .tdf-ai, .tdf-ai-skel .sk { transition: none !important; animation: none !important; }' +
     '}' +
+    /* Cost transparency strip — inside modal head/body, between header and ctx */
+    '.tdf-ai-cost {' +
+    '  display: flex; align-items: center; gap: 10px;' +
+    '  margin: 0 20px; padding: 8px 12px;' +
+    '  background: var(--bg-muted, #F9FAFB);' +
+    '  border: 1px solid var(--border, rgba(0,0,0,0.08));' +
+    '  border-radius: 10px;' +
+    '  font-size: 12px; color: var(--fg-muted, #6B7280); line-height: 1.4;' +
+    '  flex-shrink: 0;' +
+    '}' +
+    '.tdf-ai-cost .cost-meter {' +
+    '  flex: 1; display: flex; flex-direction: column; gap: 4px;' +
+    '}' +
+    '.tdf-ai-cost .cost-line {' +
+    '  font-weight: 500; color: var(--fg, #111);' +
+    '}' +
+    '.tdf-ai-cost .cost-line b { font-weight: 700; }' +
+    '.tdf-ai-cost .cost-sub {' +
+    '  font-size: 11px; color: var(--fg-subtle, #9CA3AF);' +
+    '}' +
+    '.tdf-ai-cost .cost-bar {' +
+    '  height: 4px; background: rgba(0,0,0,0.06); border-radius: 99px; overflow: hidden;' +
+    '  margin-top: 2px;' +
+    '}' +
+    '.tdf-ai-cost .cost-bar-fill {' +
+    '  height: 100%; background: var(--brand-primary, #6366F1); border-radius: 99px;' +
+    '  transition: width .25s ease;' +
+    '}' +
+    '.tdf-ai-cost.is-low {' +
+    '  background: rgba(245,158,11,0.10); border-color: rgba(245,158,11,0.32);' +
+    '}' +
+    '.tdf-ai-cost.is-low .cost-bar-fill { background: #F59E0B; }' +
+    '.tdf-ai-cost.is-out {' +
+    '  background: rgba(239,68,68,0.10); border-color: rgba(239,68,68,0.32);' +
+    '}' +
+    '.tdf-ai-cost.is-out .cost-bar-fill { background: #EF4444; }' +
+    /* Refresh button explicit cost label */
+    '.tdf-ai-btn .refresh-cost {' +
+    '  font-size: 11px; font-weight: 500;' +
+    '  color: var(--fg-subtle, #9CA3AF); margin-left: 2px;' +
+    '}' +
+    '.tdf-ai-btn.is-secondary:hover .refresh-cost { color: var(--fg-muted, #6B7280); }' +
+    /* Out-of-quota hard-block panel */
+    '.tdf-ai-out {' +
+    '  padding: 22px 18px; text-align: center;' +
+    '  background: rgba(239,68,68,0.04);' +
+    '  border: 1px solid rgba(239,68,68,0.20);' +
+    '  border-radius: 12px;' +
+    '}' +
+    '.tdf-ai-out .out-icon {' +
+    '  width: 40px; height: 40px; border-radius: 99px;' +
+    '  background: rgba(239,68,68,0.12); color: #EF4444;' +
+    '  display: inline-flex; align-items: center; justify-content: center;' +
+    '  font-size: 20px; margin-bottom: 12px;' +
+    '}' +
+    '.tdf-ai-out .out-h {' +
+    '  font-family: var(--font-display, "Crimson Pro", serif);' +
+    '  font-size: 20px; font-weight: 600; color: var(--fg, #111);' +
+    '  margin-bottom: 6px; letter-spacing: -0.01em;' +
+    '}' +
+    '.tdf-ai-out .out-countdown {' +
+    '  font-size: 14px; color: var(--fg-muted, #6B7280); margin-bottom: 14px;' +
+    '}' +
+    '.tdf-ai-out .out-countdown b {' +
+    '  font-family: var(--font-mono, "JetBrains Mono", monospace);' +
+    '  color: var(--fg, #111); font-weight: 600;' +
+    '}' +
+    '.tdf-ai-out .out-why {' +
+    '  margin-top: 16px; padding-top: 14px; border-top: 1px dashed rgba(0,0,0,0.10);' +
+    '  text-align: left;' +
+    '}' +
+    '.tdf-ai-out .out-why summary {' +
+    '  font-size: 12px; font-weight: 600; color: var(--fg-muted, #6B7280);' +
+    '  cursor: pointer; list-style: none; user-select: none;' +
+    '  display: inline-flex; align-items: center; gap: 4px;' +
+    '}' +
+    '.tdf-ai-out .out-why summary::-webkit-details-marker { display: none; }' +
+    '.tdf-ai-out .out-why summary::after {' +
+    '  content: "▾"; font-size: 9px; transition: transform .14s ease;' +
+    '}' +
+    '.tdf-ai-out .out-why[open] summary::after { transform: rotate(180deg); }' +
+    '.tdf-ai-out .out-why p {' +
+    '  margin: 8px 0 0; font-size: 12.5px; line-height: 1.55;' +
+    '  color: var(--fg-muted, #6B7280);' +
+    '}' +
+    /* Per-button quota badge (rendered via ::after on data-quota-badge) */
+    '[data-quota-badge]::after {' +
+    '  content: attr(data-quota-badge);' +
+    '  display: inline-block; margin-left: 5px;' +
+    '  padding: 1px 6px; border-radius: 99px;' +
+    '  font-size: 9.5px; font-weight: 700; letter-spacing: 0.04em;' +
+    '  text-transform: uppercase;' +
+    '  background: rgba(245,158,11,0.16); color: #92400E;' +
+    '  vertical-align: middle; line-height: 1.5;' +
+    '}' +
+    '.tdf-ai-btn-out[data-quota-badge]::after {' +
+    '  background: rgba(239,68,68,0.16); color: #B91C1C;' +
+    '}' +
+    'body.dark-mode [data-quota-badge]::after {' +
+    '  background: rgba(245,158,11,0.18); color: #FBBF24;' +
+    '}' +
+    'body.dark-mode .tdf-ai-btn-out[data-quota-badge]::after {' +
+    '  background: rgba(239,68,68,0.18); color: #FCA5A5;' +
+    '}' +
+    'body.dark-mode .tdf-ai-cost { background: #0B0F1E; border-color: #1F2937; color: #9CA3AF; }' +
+    'body.dark-mode .tdf-ai-cost .cost-line { color: #F3F4F6; }' +
+    'body.dark-mode .tdf-ai-cost .cost-bar  { background: rgba(255,255,255,0.08); }' +
+    'body.dark-mode .tdf-ai-out { background: rgba(239,68,68,0.06); border-color: rgba(239,68,68,0.30); }' +
+    'body.dark-mode .tdf-ai-out .out-h { color: #F3F4F6; }' +
+    'body.dark-mode .tdf-ai-out .out-countdown b { color: #F3F4F6; }' +
     '</style>';
 
   var aiCssInjected = false;
@@ -997,10 +1230,20 @@
             '<h3 id="tdf-ai-title"><span class="sparkle">✨</span>Suggest for <span class="target" id="tdf-ai-target">field</span></h3>' +
             '<button type="button" class="ai-x" id="tdf-ai-close" aria-label="Close">×</button>' +
           '</div>' +
+          /* Cost transparency strip — hidden for unlimited tiers, shown otherwise. */
+          '<div class="tdf-ai-cost" id="tdf-ai-cost" hidden>' +
+            '<div class="cost-meter">' +
+              '<div class="cost-line" id="tdf-ai-cost-line"></div>' +
+              '<div class="cost-bar"><div class="cost-bar-fill" id="tdf-ai-cost-fill" style="width:0%"></div></div>' +
+              '<div class="cost-sub" id="tdf-ai-cost-sub"></div>' +
+            '</div>' +
+          '</div>' +
           '<div class="tdf-ai-body" id="tdf-ai-body"></div>' +
-          '<div class="tdf-ai-foot">' +
+          '<div class="tdf-ai-foot" id="tdf-ai-foot">' +
             '<div class="left">' +
-              '<button type="button" class="tdf-ai-btn is-secondary" id="tdf-ai-refresh">↻ Refresh suggestions</button>' +
+              '<button type="button" class="tdf-ai-btn is-secondary" id="tdf-ai-refresh" title="Costs 1 from your daily limit. Different suggestions next time.">' +
+                '↻ Refresh<span class="refresh-cost" id="tdf-ai-refresh-cost"> (uses 1 daily)</span>' +
+              '</button>' +
             '</div>' +
             '<div class="right">' +
               '<button type="button" class="tdf-ai-btn is-ghost" id="tdf-ai-cancel">Cancel</button>' +
@@ -1017,7 +1260,27 @@
     });
     document.getElementById('tdf-ai-close').onclick = closeAi;
     document.getElementById('tdf-ai-cancel').onclick = closeAi;
-    document.getElementById('tdf-ai-refresh').onclick = function () { renderAiState('loading'); setTimeout(function () { aiState.suggestions = pickPreset(aiState.fieldName); renderAiState('loaded'); }, 800); };
+    document.getElementById('tdf-ai-refresh').onclick = function () {
+      /* Refresh = 1 quota point. Decrement demo counter, re-render cost strip,
+         then either fetch new suggestions or hard-block if we just hit 0. */
+      var t = getCurrentTier();
+      var spec = AI_QUOTA[t] || AI_QUOTA.free;
+      if (!spec.unlimited) {
+        AI_USED_DEMO[t] = Math.min(spec.limit, (AI_USED_DEMO[t] || 0) + 1);
+      }
+      paintCostStrip();
+      refreshAllButtonLabels();
+      var q = getQuotaState();
+      if (!q.unlimited && q.remaining === 0) {
+        renderAiState('out');
+        return;
+      }
+      renderAiState('loading');
+      setTimeout(function () {
+        aiState.suggestions = pickPreset(aiState.fieldName);
+        renderAiState('loaded');
+      }, 800);
+    };
     document.getElementById('tdf-ai-use').onclick = function () {
       if (aiState.selected < 0) return;
       var picked = aiState.suggestions[aiState.selected];
@@ -1027,11 +1290,83 @@
     };
   }
 
+  /* Live countdown ticker for the cost strip — repaints every 30s while
+     the modal is open, so the "resets in 8h 23m" line stays accurate. */
+  var costStripTimer = null;
+  function startCostStripTicker() {
+    stopCostStripTicker();
+    costStripTimer = setInterval(paintCostStrip, 30000);
+  }
+  function stopCostStripTicker() {
+    if (costStripTimer) { clearInterval(costStripTimer); costStripTimer = null; }
+  }
+
+  function paintCostStrip() {
+    var strip = document.getElementById('tdf-ai-cost');
+    if (!strip) return;
+    var q = getQuotaState();
+    if (q.unlimited) {
+      strip.setAttribute('hidden', '');
+      return;
+    }
+    strip.removeAttribute('hidden');
+    strip.classList.remove('is-low', 'is-out');
+    if (q.remaining === 0) strip.classList.add('is-out');
+    else if (q.remaining <= 2) strip.classList.add('is-low');
+
+    var line = document.getElementById('tdf-ai-cost-line');
+    var sub  = document.getElementById('tdf-ai-cost-sub');
+    var fill = document.getElementById('tdf-ai-cost-fill');
+    var pct  = Math.min(100, Math.round((q.used / q.limit) * 100));
+
+    if (q.remaining === 0) {
+      line.innerHTML = '<b>You\'ve used today\'s ' + q.limit + ' AI suggestions</b>';
+      sub.textContent = 'Resets in ' + formatCountdown(q.resetMs) + ' (midnight UTC)';
+    } else {
+      line.innerHTML = '<b>' + q.used + ' of ' + q.limit + '</b> suggestions today';
+      sub.textContent = 'Resets in ' + formatCountdown(q.resetMs) + ' · midnight UTC';
+    }
+    fill.style.width = pct + '%';
+  }
+
   function closeAi() {
     var bd = document.getElementById('tdf-ai-backdrop');
     if (!bd) return;
     bd.classList.remove('is-open');
     bd.setAttribute('hidden', '');
+    stopCostStripTicker();
+    /* Restore the standard footer in case we were last on the out-of-quota
+       state — otherwise the next open() inherits the upgrade-CTA buttons. */
+    var foot = document.getElementById('tdf-ai-foot');
+    if (foot && !document.getElementById('tdf-ai-refresh')) {
+      foot.innerHTML =
+        '<div class="left">' +
+          '<button type="button" class="tdf-ai-btn is-secondary" id="tdf-ai-refresh" title="Costs 1 from your daily limit. Different suggestions next time.">' +
+            '↻ Refresh<span class="refresh-cost"> (uses 1 daily)</span>' +
+          '</button>' +
+        '</div>' +
+        '<div class="right">' +
+          '<button type="button" class="tdf-ai-btn is-ghost" id="tdf-ai-cancel">Cancel</button>' +
+          '<button type="button" class="tdf-ai-btn is-primary" id="tdf-ai-use" disabled>Use this</button>' +
+        '</div>';
+      document.getElementById('tdf-ai-cancel').onclick = closeAi;
+      document.getElementById('tdf-ai-refresh').onclick = function () {
+        var t = getCurrentTier();
+        var spec = AI_QUOTA[t] || AI_QUOTA.free;
+        if (!spec.unlimited) {
+          AI_USED_DEMO[t] = Math.min(spec.limit, (AI_USED_DEMO[t] || 0) + 1);
+        }
+        paintCostStrip();
+        refreshAllButtonLabels();
+        var q = getQuotaState();
+        if (!q.unlimited && q.remaining === 0) { renderAiState('out'); return; }
+        renderAiState('loading');
+        setTimeout(function () {
+          aiState.suggestions = pickPreset(aiState.fieldName);
+          renderAiState('loaded');
+        }, 800);
+      };
+    }
   }
 
   function renderAiState(kind) {
@@ -1109,15 +1444,54 @@
       if (gen) gen.onclick = function () { renderAiState('loading'); setTimeout(function () { aiState.suggestions = pickPreset(aiState.fieldName); renderAiState('loaded'); }, 800); };
       return;
     }
-    if (kind === 'rate') {
+    if (kind === 'rate' || kind === 'out') {
+      /* Hard-block out-of-quota — DEC-177 contract. Rendered identically
+         whether triggered by initial open() at 0 remaining or by Refresh
+         pushing the count to the cap. Pricing comes from TIER_PRICING. */
+      var q = getQuotaState();
+      var nextT = nextTierUp(q.tier);
+      var nextLabel = TIER_LABEL[nextT] || 'Pro';
+      var nextPrice = priceFor(nextT, 'monthly');
+      var nextSpec  = AI_QUOTA[nextT] || AI_QUOTA.pro;
+      var nextQuotaLabel = nextSpec.unlimited
+        ? 'unlimited suggestions'
+        : (nextSpec.limit + '/day');
+      var costPerCall = '$0.000223';
+
       body.innerHTML = ctx +
-        '<div class="tdf-ai-state is-rate">' +
-          '<div class="st-h">You have used today\'s AI credits</div>' +
-          '<div class="st-sub">Free creators get 30 ✨ Suggest clicks per day. Resets at midnight (your time zone). Upgrade for higher quotas.</div>' +
-          '<div class="st-actions"><button type="button" class="is-primary">Upgrade for more</button></div>' +
+        '<div class="tdf-ai-out" role="alert">' +
+          '<div class="out-icon" aria-hidden="true">⏳</div>' +
+          '<div class="out-h">Comes back at midnight UTC</div>' +
+          '<div class="out-countdown">in <b id="tdf-ai-out-cd">' + formatCountdown(q.resetMs) + '</b></div>' +
+          '<details class="out-why">' +
+            '<summary>Why we limit</summary>' +
+            '<p>AI suggestions cost us a fraction of a cent each (' + costPerCall + ' per call on Cloudflare Workers AI). We rate-limit to keep tadaify Free for everyone.</p>' +
+          '</details>' +
         '</div>';
-      refreshBtn.style.display = 'none';
-      useBtn.style.display = 'none';
+
+      /* Replace footer with sticky upsell pair (Wait + Upgrade). */
+      var foot = document.getElementById('tdf-ai-foot');
+      if (foot) {
+        foot.innerHTML =
+          '<div class="left"></div>' +
+          '<div class="right">' +
+            '<button type="button" class="tdf-ai-btn is-ghost" id="tdf-ai-out-wait">Wait until midnight</button>' +
+            '<button type="button" class="tdf-ai-btn is-primary" id="tdf-ai-out-upgrade" style="background:var(--brand-warm,#F59E0B)">' +
+              'Upgrade to ' + nextLabel + ' — $' + nextPrice + '/mo for ' + nextQuotaLabel +
+            '</button>' +
+          '</div>';
+        var wait = document.getElementById('tdf-ai-out-wait');
+        if (wait) wait.onclick = closeAi;
+        var up = document.getElementById('tdf-ai-out-upgrade');
+        if (up) up.onclick = function () {
+          closeAi();
+          /* Real app: window.location = '/settings/billing?upgrade=' + nextT;
+             In mockups we just log so the demo doesn't navigate away. */
+          try { console.log('[AI Suggest] upgrade CTA clicked → ' + nextT); } catch (e) {}
+        };
+      }
+      /* Also visually red-tint the cost strip when in this state. */
+      paintCostStrip();
       return;
     }
   }
@@ -1134,9 +1508,24 @@
     var target = document.getElementById('tdf-ai-target');
     if (target) target.textContent = aiState.fieldName;
 
-    /* Default flow: brief loading skeleton (800ms) then loaded state. */
-    renderAiState('loading');
-    setTimeout(function () { renderAiState('loaded'); }, 800);
+    /* Paint cost strip + decide whether to enter the modal in the
+       hard-block out-of-quota state right away. DEC-177 contract: even
+       the first click after hitting the cap shows the hard-block, not
+       a partial / cached result. */
+    paintCostStrip();
+    startCostStripTicker();
+
+    var q = getQuotaState();
+    if (!q.unlimited && q.remaining === 0) {
+      renderAiState('out');
+    } else {
+      /* Default flow: brief loading skeleton (800ms) then loaded state.
+         The opening "click" itself does NOT decrement quota in the mockup
+         — production decrements on the Worker only after a successful
+         response, mirrored here on Refresh which is the explicit re-spend. */
+      renderAiState('loading');
+      setTimeout(function () { renderAiState('loaded'); }, 800);
+    }
 
     var bd = document.getElementById('tdf-ai-backdrop');
     bd.removeAttribute('hidden');
@@ -1175,6 +1564,9 @@
      tracker on the page picks up the edit. */
   function fromButton(btn, fieldName, contextSummary) {
     if (!btn) return;
+    /* Belt-and-suspenders: ensure tooltip + badge are up to date even if
+       the auto-enhancer hasn't run yet (e.g. button added dynamically). */
+    enhanceButtonLabel(btn);
     var field = null;
     var el = btn;
     for (var i = 0; i < 4 && el && !field; i++) {
@@ -1212,8 +1604,47 @@
     close:      closeAi,
     fromButton: fromButton,
     /* Programmatic state — useful for tests and the standalone demo file. */
-    setState: function (kind) { renderAiState(kind); }
+    setState: function (kind) { renderAiState(kind); },
+    /* Tier-aware helpers (DEC-174..179, 2026-04-27). The standalone
+       app-ai-suggest-modal.html demo toolbar uses these to drive its
+       per-tier preview. Production app-block-editor wires the same
+       getCurrentTier()/getQuotaState() to the JWT/Worker response. */
+    getCurrentTier:        getCurrentTier,
+    getQuotaState:         getQuotaState,
+    formatCountdown:       formatCountdown,
+    nextTierUp:            nextTierUp,
+    enhanceButtonLabel:    enhanceButtonLabel,
+    refreshAllButtonLabels: refreshAllButtonLabels,
+    paintCostStrip:        paintCostStrip,
+    /* Demo-only setters — let the standalone modal page drive a tier
+       switcher + "used today" slider without reaching into globals. */
+    _setDemoTier: function (tier) {
+      if (!AI_QUOTA[tier]) return;
+      window.__tadaifyDemoTier = tier;
+      try { localStorage.setItem('tadaify_demo_tier', tier); } catch (e) {}
+      paintCostStrip();
+      refreshAllButtonLabels();
+    },
+    _setDemoUsed: function (tier, used) {
+      if (!AI_QUOTA[tier]) return;
+      AI_USED_DEMO[tier] = Math.max(0, Math.min(AI_QUOTA[tier].limit, used | 0));
+      paintCostStrip();
+      refreshAllButtonLabels();
+    },
+    _quotaSpec: AI_QUOTA
   };
+
+  /* Auto-enhance every existing ✨ Suggest entry point on the page once
+     the DOM is ready. Picks up every button wired via the canonical
+     onclick="window.AISuggest.fromButton(this, ...)" pattern. */
+  function autoEnhanceSuggestButtons() {
+    refreshAllButtonLabels();
+  }
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', autoEnhanceSuggestButtons);
+  } else {
+    autoEnhanceSuggestButtons();
+  }
 })();
 
 /* =========================================================================


### PR DESCRIPTION
## Summary

Wires AI Suggest cost transparency across the standalone modal mockup and 41 ✨ Suggest entry points across 9 page editors, per the locked **DEC-174..179** strategy (2026-04-27 cascade). Pure mockup-only work — no React/runtime impact.

- **Standalone modal** (`app-ai-suggest-modal.html`): cost transparency strip, refresh-cost label, out-of-quota hard-block panel + tier-specific upsell footer, demo toolbar with tier switcher + "used today" slider, 3 new state-variant frames for review.
- **shared/partials.js AISuggest namespace**: tier-aware quota helpers (`getCurrentTier`, `getQuotaState`, `formatCountdown`, `nextTierUp`, `enhanceButtonLabel`, `refreshAllButtonLabels`), centered cost strip in the modal, hard-block 'out' state with countdown + "Why we limit" expander + sticky upsell footer.
- **41 ✨ Suggest buttons** across 9 page editors: auto-enhanced on `DOMContentLoaded` with per-tier tooltips and low-quota badges, no per-file edits.

## Business requirements implemented

- **BR-AI-COST-TRANSPARENCY** — Creator always sees current quota state and what each click costs (cost strip + per-button tooltip).
- **BR-AI-HARD-BLOCK-OUT-OF-QUOTA** — When daily cap hit, modal opens straight into the hard-block panel; no silent degradation, no partial results (DEC-177).
- **BR-AI-REFRESH-EXPLICIT-COST** — Refresh button explicitly labelled "(uses 1 daily)" and tooltip "Costs 1 from your daily limit. Different suggestions next time." per DEC-179 (regenerate bypasses output cache).
- **BR-AI-PRO-CLEAN-UI** — Pro/Business creators see the bare `✨ Suggest` button + clean modal (cost strip hidden) — no clutter for unlimited tiers.
- **BR-AI-TIER-AWARE-UPSELL** — Out-of-quota footer reads "Upgrade to Creator — $8/mo for 50/day" on Free, "Upgrade to Pro — $19/mo for unlimited suggestions" on Creator, etc. Real prices from `pricing.html`.

## Technical requirements introduced or relied on

- **TR-MOCKUP-LOCKED-STRATEGY-PROPAGATION** — every visible quota number, model name, and tier price in the mockups must match the source of truth (`feedback_tadaify_ai_suggest_locked_strategy_2026_04_27.md` + `TIER_PRICING` in `shared/partials.js`). No example numbers.
- **TR-MOCKUP-NO-RIGHT-SIDE-DRAWERS** (existing) — every modal stays centered with backdrop overlay (`feedback_no_right_side_drawers.md`).
- **TR-MOCKUP-NO-BLUR-PREMIUM** (existing) — out-of-quota panel is fully visible content + clean stop, never blurred (`feedback_no_blur_premium_features.md`). Upsell happens at the action, not at display time.
- **TR-MOCKUP-SIMPLE-UI** (existing) — no Simple/Advanced toggle; cost strip + countdown live inline in the modal head, not behind a "Show details" expander (`feedback_tadaify_simple_ui_no_advanced_toggle.md`).

## Acceptance criteria from issue

- ✅ Cost transparency strip in modal header — Free/Creator visible (gradient turns amber at ≤2 left, red at 0); Pro/Business hidden entirely.
- ✅ Refresh button reads `↻ Refresh (uses 1 daily)`, tooltip `"Costs 1 from your daily limit. Different suggestions next time."`. Click decrements counter and either re-fetches or hard-blocks if just hit cap.
- ✅ Out-of-quota state: friendly message with countdown to midnight UTC + "Why we limit" expander naming the per-call $0.000223 cost + sticky footer "Wait until midnight" (ghost) + "Upgrade to <next-tier> — $X/mo for <quota>" (primary).
- ✅ Demo toolbar gains tier switcher (Free/Creator/Pro/Business with prices) + "Used today" slider (per-tier bounded). Both repaint cost strip and re-enhance every wired ✨ Suggest button on the page.
- ✅ Tier-aware tooltips on all 41 ✨ Suggest entry points (Free: "AI suggestion · uses 1 from your daily 5 (you have 3 left)"; Pro: "AI suggestion · unlimited on Pro"). Low-quota badge ("1 of 5 left", amber) renders inline when ≤2 remaining; "0/5 today" badge in red when at cap.
- ✅ `app-block-editor.html` left untouched (out of scope per Wave 3 author note — has its own inline AI modal).
- ✅ PR #98 mobile drawer + PR #99 viewport switcher untouched in `shared/partials.js` (verified: only the AISuggest IIFE was modified; the viewport switcher IIFE below is byte-identical).
- ✅ All prices ($8 Creator / $19 Pro / $49 Business) sourced from `pricing.html` via `TIER_PRICING` — no example numbers.
- ✅ Pure vanilla JS + CSS, no new dependencies.

## Test plan

### Unit-level (manual eval via preview)

- **`getCurrentTier()`** — returns 'free' default; reads from `window.__tadaifyDemoTier` first, then localStorage `tadaify_demo_tier`. ✅ Verified via `preview_eval`.
- **`getQuotaState(tier)`** — returns `{ tier, used, limit, label, unlimited, remaining, resetMs }` per tier. `resetMs` counts down to next midnight UTC. ✅ Verified.
- **`formatCountdown(ms)`** — "8h 23m" for hours, "47m" for minutes, "12s" for seconds, "0s" for ≤0. ✅ Verified ("17h 51m" rendered correctly).
- **`nextTierUp(t)`** — Free→Creator, Creator→Pro, Pro→Pro. ✅ Verified ("Upgrade to Creator" shown for Free out-of-quota; "Upgrade to Pro" for Creator).
- **`enhanceButtonLabel(btn)`** — sets `title`, conditionally adds `tdf-ai-btn-low` / `tdf-ai-btn-out` class + `data-quota-badge` attribute. Idempotent via `__tdfAiEnhanced` flag. ✅ Verified on `app-page-blog.html` (4 buttons).

### Playwright scenarios (deferred per plan-then-tests workflow)

- **S1 — Cost strip on Free fresh open**
  - Given: Free creator with 2/5 used; ✅ Suggest clicked.
  - Then: modal opens on loading state; cost strip shows "2 of 5 suggestions today · resets in <countdown> · midnight UTC"; class `tdf-ai-cost` (no `is-low` / `is-out`).
- **S2 — Cost strip turns amber at ≤2 left**
  - Given: Free creator with 4/5 used (1 left); modal open.
  - Then: cost strip has class `tdf-ai-cost is-low`; bar 80% width amber.
- **S3 — Hard-block on open at 5/5**
  - Given: Free creator with 5/5 used; ✅ Suggest clicked.
  - Then: modal opens directly on `out` state (no loading skeleton); body shows hourglass + "Comes back at midnight UTC" + countdown + "Why we limit" expander; footer shows "Wait until midnight" + "Upgrade to Creator — $8/mo for 50/day".
- **S4 — Refresh decrements + re-fetches**
  - Given: Free creator with 2/5 used; modal open on loaded; click Refresh.
  - Then: counter = 3, cost strip repaints "3 of 5", loading skeleton shown for ~800ms, then 5 fresh cards.
- **S5 — Refresh trips hard-block**
  - Given: Free creator with 4/5 used; modal open; click Refresh.
  - Then: counter = 5, cost strip flips to red `is-out`, body replaced with out-of-quota panel, footer swapped to upsell pair.
- **S6 — Pro tier hides cost strip + cleans buttons**
  - Given: Pro creator (any usage); page load + modal open.
  - Then: cost strip hidden (`display: none`); ✅ Suggest button title = "AI suggestion · unlimited on Pro"; no `[data-quota-badge]`.
- **S7 — Tier swap re-enhances all 41 buttons**
  - Given: page with 41 wired ✨ Suggest buttons; demo toolbar swaps Free → Pro.
  - Then: every button loses `data-quota-badge`; every title changes to "...unlimited on Pro".
- **S8 — Creator out-of-quota points at Pro**
  - Given: Creator creator with 50/50 used; ✅ Suggest clicked.
  - Then: footer reads "Upgrade to Pro — $19/mo for unlimited suggestions".

### Edge cases manually verified during build

- **EC1 — Modal re-open after out-of-quota** — closing then re-opening from a different button restores the standard footer (Refresh + Cancel + Use this), not the upsell pair (verified: `closeAi` restores foot HTML if `tdf-ai-refresh` element absent).
- **EC2 — `ctx-text` element disposal** — second `openAi` call no longer throws (preview verified: `ctx-text` writes guarded; first `renderState()` re-injects it).
- **EC3 — Used-slider bounds per tier** — slider max + step adjusts on tier swap (5/1 for Free, 50/5 for Creator, 500/50 for Pro/Business).
- **EC4 — Live countdown ticker** — repaints cost strip every 30s while modal open; cleared on close (`stopCostStripTicker`).
- **EC5 — Eager CSS injection** — per-button `[data-quota-badge]::after` pill renders on initial page load even before modal opens (auto-enhancer calls `ensureAiCss()` on `DOMContentLoaded`).

## Mockup

Standalone canonical modal: https://github.com/graspsoftwarepw/tadaify-app/blob/main/mockups/tadaify-mvp/app-ai-suggest-modal.html

State variants visible in the file:
- State 0 — Cost transparency strip (5 scenarios across tiers)
- State 1-4 — existing Loaded / Loading / Error / Empty (now with cost strip)
- State 5 — Out of quota on Free (hard-block + Creator upsell)
- State 5b — Out of quota on Creator (hard-block + Pro upsell)
- State 6 — Selected confirmation

Page-editor wiring example: https://github.com/graspsoftwarepw/tadaify-app/blob/main/mockups/tadaify-mvp/app-page-blog.html (4 ✨ Suggest buttons; tier-aware tooltip + badge auto-applied via `shared/partials.js`).

## Rollback

Revert by squash-revert of the merge commit:

```bash
git revert -m 1 <merge-sha>
```

No DB migrations, no Edge Function deploys, no infra changes — pure mockup files. The 4 commits in this branch are independent and can each be reverted in isolation if a partial rollback is desired:

- `c20baa1` — eager AI Suggest CSS load (pure additive, safe to keep on revert of the others)
- `c8114fc` — modal demo + state variants
- `4eaa0c4` — partials.js AISuggest helpers (the load-bearing one)
- `56588b8` — defensive openAi fix (only relevant if the modal commit stays)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
