### PR TITLE
chore(docs): import 6 legacy research files from claude-reports

### DIFF
--- a/docs/research/ai-cost-and-tier-strategy.md
+++ b/docs/research/ai-cost-and-tier-strategy.md
@@ -1,0 +1,676 @@
+---
+type: SPIKE
+project: tadaify
+title: "AI Suggest cost + tier strategy SPIKE — model evaluation + economic model"
+agent: opus-4-7
+author: orchestrator
+created_at: 2026-04-27
+status: draft
+tags: [tadaify, ai, pricing, tier-strategy, cost-modeling]
+---
+
+# AI Suggest — Cost + Tier Strategy SPIKE
+
+## 1. Executive summary
+
+**Recommended model:** **Cloudflare Workers AI `@cf/meta/llama-3.1-8b-instruct-fast`** as the default proxied backend, with **OpenAI `gpt-5.4-nano`** as a fallback for premium tiers and an "upgrade quality" toggle for Pro+/Business.
+
+**Recommended strategy:** **Strategy 3 — daily rate-limit per tier** (Free 5 / Creator 50 / Pro unlimited+fair-use 500 / Business unlimited). Daily reset, friendly "Comes back tomorrow" UX with upgrade CTA. Reasons: (a) the chosen model's per-call cost is ≤ $0.0006 even at worst case so the absolute USD bleed is bounded; (b) daily reset feels less precious than monthly credits and reduces "credit anxiety"; (c) Free tier still tastes the magic which drives Creator-tier conversion (the Notion-removed-AI-from-Free-tier mistake we should not repeat).
+
+**Recommended architecture:** **Proxied via tadaify Edge Function** (no BYOK). The cost is too low to push the friction of API-key management onto creators, and proxying lets us swap models without creator action, cache aggressively, and report unified analytics.
+
+**Two-line rationale.** Llama 3.1 8B Instruct on Cloudflare gives us $0.282 input / $0.827 output per Mtok with first-token under 300 ms — a single ✨ Suggest click costs ≈ $0.0002, which means even at 1M DAU with 30% activation × 5 clicks/day we're at ~$45/day infra cost, completely absorbable in Pro+/Business margins. The daily rate-limit ladder is the only one that simultaneously (a) doesn't gate the magic away from Free, (b) doesn't trigger end-of-month credit panic, and (c) gives a clean "you've hit today's limit, comes back tomorrow OR upgrade now" upsell moment.
+
+---
+
+## 2. Per-call usage profile
+
+The ✨ Suggest button on tadaify fires when a creator clicks it next to a `title` / `label` / `short-text` / `caption` field. The Edge Function builds a prompt, calls the model, returns 5 short suggestion strings.
+
+| Dimension | Value | Notes |
+|---|---|---|
+| **Field types** | title (≤80 chars), label (≤24), short-text (≤200), caption (≤140) | Each has its own prompt template + few-shot examples |
+| **Input tokens (system + few-shot + creator context)** | 200 – 400 | System prompt (~120 tok) + 3 few-shot examples (~150 tok) + creator's existing block context (~50–150 tok) |
+| **Output tokens (5 short suggestions in JSON)** | 150 – 300 | 5 × ~30–50 tokens each + JSON wrapper |
+| **Total per call (avg)** | **~500 tokens** (350 input + 150 output) | Used as the canonical "1 call = 500 tokens" unit below |
+| **Total per call (worst case)** | ~700 tokens (400 input + 300 output) | When creator has long context + verbose output |
+| **Latency target** | ≤ 2 s end-to-end | First token under 500 ms, full response under 1.5 s |
+| **Quality target** | 5 distinct, on-brand, ≤ field-length suggestions; no markdown | Notion / Linear "magic ✨" feel |
+| **Failure tolerance** | High — creator can always retype manually | But repeated failure = churn |
+
+**Token math constants used in this report:**
+- 1 call = 500 tokens average (350 input + 150 output)
+- 1 call = 700 tokens worst case (400 input + 300 output)
+- Realistic clicks/day per active creator: 5
+- Worst-case clicks/day per active creator: 30
+- Active-creator ratio: 30% of total signed-up creators are DAU
+
+---
+
+## 3. Model evaluation
+
+All pricing verified 2026-04-27. **Pricing changes monthly — verify before any contract.**
+
+### 3.1 Cloudflare Workers AI
+
+**Pricing model:** Bundled with Workers Paid plan ($5/mo minimum). Includes 10,000 free neurons/day. Beyond that: $0.011 / 1,000 neurons.
+[Source: Cloudflare Workers AI pricing](https://developers.cloudflare.com/workers-ai/platform/pricing/)
+
+| Model | Input $/Mtok | Output $/Mtok | Per-call cost (500 tok) | Per-call cost (worst 700 tok) |
+|---|---|---|---|---|
+| `@cf/meta/llama-3.1-8b-instruct[-fast]` | $0.282 | $0.827 | **$0.000223** | **$0.000361** |
+| `@cf/meta/llama-3.3-70b-instruct-fp8-fast` | $0.293 | $2.253 | **$0.000455** | **$0.000793** |
+| `@cf/qwen/qwen2.5-coder-32b-instruct` | $0.660 | $1.000 | **$0.000381** | **$0.000564** |
+
+Worked example for `llama-3.1-8b-instruct`:
+- Input: 350 tok × $0.282 / 1,000,000 = $0.0000987
+- Output: 150 tok × $0.827 / 1,000,000 = $0.000124
+- **Total = $0.000223 per call**
+
+**Latency:** 80+ TPS, time-to-first-token ~300 ms for 8B. Speculative decoding adds up to 40% speed boost on `-fast` variant. End-to-end on a 150-token output: ~2 s. ✅ meets target.
+[Source: Cloudflare Workers AI bigger/better/faster](https://blog.cloudflare.com/workers-ai-bigger-better-faster/)
+
+**Quality vibe:** Llama 3.1 8B is good enough for short structured-output tasks (title/caption variants). It will occasionally produce a flat suggestion. The 70B-fp8-fast variant is meaningfully better at "varied + on-brand" quality but costs ~2× as much. For Pro+ "premium quality" toggle, 70B is the natural upgrade.
+
+**Operational concerns:**
+- Workers AI runs on Cloudflare edge — globally distributed, no region pinning needed.
+- Rate limits: account-level neuron quota; no per-model RPM cap published.
+- API stability: GA, stable since 2025.
+- **Strong fit:** tadaify is already (per project notes) considering Cloudflare Workers for video block — adding Workers AI keeps infra consolidated, single bill, single auth.
+
+### 3.2 OpenAI
+
+[Source: OpenAI API pricing](https://developers.openai.com/api/docs/pricing) — 2026 lineup is `gpt-5.x`. Legacy 4.x models (gpt-4o-mini, gpt-4o, gpt-3.5-turbo) are deprecated and were not extracted from current pricing page.
+
+| Model | Input $/Mtok | Cached input $/Mtok | Output $/Mtok | Per-call cost (500 tok) | Per-call cost (worst 700 tok) |
+|---|---|---|---|---|---|
+| `gpt-5.5` | $5.00 | $0.50 | $30.00 | **$0.00625** | **$0.0110** |
+| `gpt-5.4` | $2.50 | $0.25 | $15.00 | **$0.00313** | **$0.00550** |
+| `gpt-5.4-mini` | $0.75 | $0.075 | $4.50 | **$0.000938** | **$0.00165** |
+| `gpt-5.4-nano` | $0.20 | $0.02 | $1.25 | **$0.000258** | **$0.000455** |
+
+Worked example for `gpt-5.4-nano`:
+- Input: 350 tok × $0.20 / 1,000,000 = $0.00007
+- Output: 150 tok × $1.25 / 1,000,000 = $0.000188
+- **Total = $0.000258 per call**
+
+With cached system prompt + few-shot examples (the leading 270 tokens of every call are identical → cached at $0.02/Mtok):
+- Cached input (270 tok): 270 × $0.02 / 1,000,000 = $0.0000054
+- Fresh input (80 tok creator context): 80 × $0.20 / 1,000,000 = $0.000016
+- Output (150 tok): 150 × $1.25 / 1,000,000 = $0.000188
+- **Total with cache = $0.000209 per call** — beats Cloudflare for cached prompts
+
+**Batch API discount:** 50% off (not applicable — ✨ Suggest is interactive, not batchable).
+
+**Latency:** GPT-5.4-nano is OpenAI's "edit-window" tier — short completions / boilerplate. Time-to-first-token typically 200–600 ms. ✅ meets target.
+
+**Quality vibe:** gpt-5.4-nano benchmarks comparably to Claude Haiku 4.5 on short-text tasks; faster TTFT, lower cost. For the "5 short suggestions" task it is overqualified.
+[Source: GPT-5.4 mini and nano benchmarks - DataCamp](https://www.datacamp.com/blog/gpt-5-4-mini-nano)
+
+**Operational concerns:**
+- US-only inference unless data-residency uplift (10%) — not material.
+- Tier-1 rate limits (without spend history) start at 500 RPM / 200k TPM — sufficient for first 1k DAU but needs upgrade by 10k DAU.
+- API stability: highest in industry.
+- **Cache discount is 90% off** — extremely well suited to ✨ Suggest's repeated system prompt.
+
+### 3.3 Anthropic Claude
+
+[Source: Claude API pricing](https://platform.claude.com/docs/en/about-claude/pricing) — verified 2026-04-27.
+
+| Model | Input $/Mtok | Cache read $/Mtok | Output $/Mtok | Per-call cost (500 tok) |
+|---|---|---|---|---|
+| `claude-haiku-4-5` | $1.00 | $0.10 | $5.00 | **$0.00110** |
+| `claude-sonnet-4-6` | $3.00 | $0.30 | $15.00 | **$0.00330** |
+| `claude-opus-4-7` | $5.00 | $0.50 | $25.00 | **$0.00550** |
+
+Worked example for `claude-haiku-4-5`:
+- Input: 350 tok × $1 / 1,000,000 = $0.00035
+- Output: 150 tok × $5 / 1,000,000 = $0.00075
+- **Total = $0.00110 per call** — ~5× more expensive than Cloudflare 8B
+
+With prompt caching (cache hits at 0.1× = $0.10/Mtok):
+- Cached input (270 tok): 270 × $0.10 / 1,000,000 = $0.000027
+- Fresh input (80 tok): 80 × $1 / 1,000,000 = $0.00008
+- Output (150 tok): 150 × $5 / 1,000,000 = $0.00075
+- **Total with cache = $0.000857 per call**
+
+**Latency:** Haiku 4.5 — TTFT ~250 ms, similar to gpt-5.4-nano. ✅ meets target.
+
+**Quality vibe:** Haiku 4.5 is the highest-quality option on the cheap end. Anthropic models tend to produce more "on-brand" / "Notion-like" copy out of the box (lower temperature variance, less mode collapse on short outputs). [Source: Claude Haiku 4.5 vs gpt-5.4 mini](https://www.mindstudio.ai/blog/gpt-54-mini-vs-claude-haiku-sub-agent-comparison)
+
+**Operational concerns:**
+- Tier-1 limits start lower (50 RPM / 50k TPM); requires deposit history to scale.
+- Notion AI is rumored to use Anthropic for short-text rewrites — is the de-facto reference quality bar.
+
+### 3.4 Mistral
+
+[Source: Mistral API pricing 2026 - via search](https://www.burnwise.io/ai-pricing/mistral) — direct page returned 404, citing aggregator search.
+
+| Model | Input $/Mtok | Output $/Mtok | Per-call cost (500 tok) |
+|---|---|---|---|
+| `ministral-3b` | $0.10 | $0.10 | **$0.00005** |
+| `ministral-8b` | $0.10 | $0.10 | **$0.00005** |
+| `mistral-small-latest` | $0.20 | $0.60 | **$0.000160** |
+| `mistral-medium` (latest) | ~$0.40 | ~$2.00 | **~$0.000440** |
+
+**Per-call winner on raw price:** Ministral 3B / 8B at **$0.00005/call** — half of Cloudflare, 5× cheaper than gpt-5.4-nano.
+
+**Latency:** TTFT ~200–400 ms via Mistral-hosted endpoint. ✅
+
+**Quality vibe:** Ministral 8B is competitive with Llama 3.1 8B on short structured tasks. Lower brand-recognition than Anthropic/OpenAI but pricing-aggressive. Good for cost-sensitive Free tier.
+
+**Operational concerns:**
+- EU-hosted (data residency story is good for European creators).
+- API still less mature than OpenAI/Anthropic — occasional 5xx during peak hours.
+- Lower marketing-side credibility ("powered by Mistral" is less of a sales line than "powered by GPT").
+
+### 3.5 Groq
+
+[Source: Groq pricing](https://groq.com/pricing/) and [rate limits](https://console.groq.com/docs/rate-limits)
+
+| Model | Input $/Mtok | Output $/Mtok | Per-call cost (500 tok) |
+|---|---|---|---|
+| `llama-3.1-8b-instant` | $0.05 | $0.08 | **$0.0000295** |
+| `llama-3.3-70b-versatile` | $0.59 | $0.79 | **$0.000325** |
+
+**Speed:** llama-3.1-8b-instant runs at **840 TPS** — fastest on the market by 5–10×. End-to-end for 150-token output: **~400 ms**. Game-changing for the ✨ button feel.
+
+**Free-tier rate limits:** 30 RPM / 14,400 RPD / 6k TPM / 500k TPD. **This is too low for a multi-tenant SaaS**: a single power user at 30 clicks/day eats 0.2% of the daily token budget; 1k DAU with avg 5 calls = 5k calls/day = ~2.5M tokens/day. Free tier exhausts at ~200 DAU. Developer plan needed for scale (pricing not public; per-call cost stays low).
+
+**Quality vibe:** Same Llama 3.1 8B model as Cloudflare — quality identical, just hosted differently.
+
+**Operational concerns:**
+- Rate-limit ceilings unpublished for Dev tier; need sales conversation.
+- Single-region (US-Midwest) — adds 50–100ms RTT for EU creators vs Cloudflare edge.
+- **Best raw speed of any provider** — if user-perceived latency is the battleground, Groq wins.
+
+### 3.6 Together.ai
+
+Similar pricing band to Mistral / Groq for open Llama models ($0.10–$0.30 per Mtok). Not differentiated enough to be a primary choice; mention only as multi-vendor failover.
+
+### 3.7 Per-call cost summary (sorted cheapest first)
+
+| Model | Per-call avg (500 tok) | Notes |
+|---|---|---|
+| Groq `llama-3.1-8b-instant` | $0.0000295 | Cheapest + fastest, but rate-limit ceilings |
+| Mistral `ministral-3b` / `8b` | $0.00005 | Cheapest among first-party APIs |
+| Mistral `mistral-small-latest` | $0.000160 | Better quality than Ministral, modest premium |
+| OpenAI `gpt-5.4-nano` (cached) | $0.000209 | With prompt cache; otherwise $0.000258 |
+| Cloudflare Llama 3.1 8B | $0.000223 | Bundled in Workers infra |
+| OpenAI `gpt-5.4-nano` (uncached) | $0.000258 | Tier-1 rate limits sufficient to ~10k DAU |
+| Cloudflare Qwen 2.5 32B | $0.000381 | Better quality than 8B |
+| Cloudflare Llama 3.3 70B-fp8-fast | $0.000455 | Premium-quality option |
+| Anthropic `claude-haiku-4-5` (cached) | $0.000857 | Highest quality on cheap end |
+| OpenAI `gpt-5.4-mini` | $0.000938 | Overqualified for the task |
+| Anthropic `claude-haiku-4-5` (uncached) | $0.00110 | |
+| OpenAI `gpt-5.4` | $0.00313 | Way overqualified |
+
+**Within the "cheap enough to gate generously" band ($0.0001–$0.0003/call):** Groq, Mistral, Cloudflare. All three are viable. Recommendation lands on Cloudflare for the operational consolidation reasons.
+
+---
+
+## 4. Cost-at-scale tables
+
+### Constants
+- **Realistic case:** 5 ✨ clicks/day per active creator
+- **Worst case:** 30 ✨ clicks/day per active creator (creator going through every field on a big page)
+- **Active-creator ratio:** 30% of signed-up creators are DAU
+- **Quotas applied?** No — these tables compute the *unbounded* cost (i.e. what happens if every active creator hits worst-case daily, every day, with no rate-limiting). Strategy tables in §5 show the cost AFTER applying limits.
+- **Monthly multiplier:** 30 days
+
+### 4.1 Realistic case (5 clicks/day × 30% activation)
+
+Formula: `monthly_cost = total_creators × 0.3 × 5 × 30 × per_call_cost`
+
+| Total creators | Active creators (30%) | Calls/month | Cloudflare 8B ($0.000223) | gpt-5.4-nano ($0.000258) | Anthropic Haiku 4.5 ($0.00110) | Mistral 8B ($0.00005) |
+|---|---|---|---|---|---|---|
+| **100** | 30 | 4,500 | $1.00 | $1.16 | $4.95 | $0.23 |
+| **1,000** | 300 | 45,000 | $10.04 | $11.61 | $49.50 | $2.25 |
+| **10,000** | 3,000 | 450,000 | $100 | $116 | $495 | $22.50 |
+| **100,000** | 30,000 | 4,500,000 | $1,004 | $1,161 | $4,950 | $225 |
+| **1,000,000** | 300,000 | 45,000,000 | $10,035 | $11,610 | $49,500 | $2,250 |
+
+### 4.2 Worst case (30 clicks/day × 30% activation, no rate limits)
+
+Formula: `monthly_cost = total_creators × 0.3 × 30 × 30 × per_call_cost`
+
+| Total creators | Active creators | Calls/month | Cloudflare 8B | gpt-5.4-nano | Anthropic Haiku 4.5 | Mistral 8B |
+|---|---|---|---|---|---|---|
+| **100** | 30 | 27,000 | $6.02 | $6.97 | $29.70 | $1.35 |
+| **1,000** | 300 | 270,000 | $60.21 | $69.66 | $297 | $13.50 |
+| **10,000** | 3,000 | 2,700,000 | $602 | $697 | $2,970 | $135 |
+| **100,000** | 30,000 | 27,000,000 | $6,021 | $6,966 | $29,700 | $1,350 |
+| **1,000,000** | 300,000 | 270,000,000 | $60,210 | $69,660 | $297,000 | $13,500 |
+
+### 4.3 Survival assessment per model at 1M DAU worst case
+
+(Worst case = no rate limits, every active creator generates 30 calls/day every day.)
+
+| Model | 1M-creators worst case | Survives Free-tier abuse? |
+|---|---|---|
+| Mistral 8B | $13,500/mo | ✅ Easily |
+| Cloudflare Llama 8B | $60,210/mo | ✅ With strategy gating |
+| gpt-5.4-nano | $69,660/mo | ✅ With strategy gating |
+| Anthropic Haiku 4.5 | $297,000/mo | ⚠️ Need aggressive gating; 10× the bleed |
+| OpenAI gpt-5.4-mini | $253,000/mo | ⚠️ Same |
+
+**Even the worst-case Anthropic scenario is < $300k/mo at 1M DAU**, which is a ~$3.6M/yr COGS line on what would be a $50M+/yr ARR product (1M DAU × any reasonable conversion). The cost is **never** what kills this; it's only a margin question. Cheap models give wider margin for marketing spend, premium models give better quality. Both are economically viable.
+
+### 4.4 Sanity-check: Free-tier abuse at moderate scale
+
+Suppose at 10k creators stage, 100 power users spam 200 calls/day. With Cloudflare 8B that is `100 × 200 × 30 × $0.000223 = $134/mo`. Negligible. Even with Anthropic Haiku 4.5 = $660/mo. **Abuse is not a financial risk; it is a UX/fairness risk** (other creators hit slower API or our rate limits trigger).
+
+---
+
+## 5. Three candidate strategies
+
+All three strategies costed against the recommended model **Cloudflare Llama 3.1 8B at $0.000223/call**. Numbers scale linearly for any other model — divide/multiply by ratio.
+
+### 5.1 Strategy 1 — Pro+ gated (AI off Free + Creator)
+
+**Mechanism**
+- Free / Creator tiers: ✨ Suggest button is **hidden entirely**.
+- Pro $19 + Business $49 tiers: button visible, **unlimited** with a fair-use cap of ~500 calls/day to stop bots.
+
+**Pros**
+- Simplest economics — only paying tiers consume tokens; the cost line is bounded by the number of paying users × their cap.
+- Premium positioning — "AI suggestions are part of Pro" is a clean upsell line.
+- Zero abuse risk on Free.
+- No per-day quota tracking needed for Free/Creator (no AI = no DB column, no UI).
+
+**Cons**
+- **Loses the magic moment for the very people who need copy help most.** Free + Creator tiers are hobbyists / first-time creators with the least confidence in their own copy. They're the customer segment that benefits most from "✨ → 5 ideas".
+- **Dampens word-of-mouth.** A creator on Creator tier shows the dashboard to a friend; the friend asks "where's the AI everyone talks about?" and the answer is "you have to upgrade". Bad demo.
+- **Underutilises capacity.** Cloudflare Workers Paid plan includes 10,000 free neurons/day = ~390 ✨ calls/day at no marginal cost. Strategy 1 wastes that allocation.
+- **Doesn't match category norm.** ChatGPT, Perplexity, even Notion (until May 2025) gave Free tier *some* AI tasting. Notion's removal of AI from Free was widely criticised as a class-divide move; tadaify shouldn't repeat the mistake.
+
+**Per-tier cost-at-scale (assume 20% Pro, 5% Business of *active* base; rest Free/Creator → 0 calls)**
+
+| Total creators | Pro+ active (25% of 30%) | Calls/mo (avg 5/day) | Worst-case calls (cap 500/day) | Cloudflare cost (avg) | Cloudflare cost (worst) |
+|---|---|---|---|---|---|
+| 100 | 7.5 | 1,125 | 112,500 | $0.25 | $25 |
+| 1,000 | 75 | 11,250 | 1,125,000 | $2.51 | $251 |
+| 10,000 | 750 | 112,500 | 11,250,000 | $25.09 | $2,509 |
+| 100,000 | 7,500 | 1,125,000 | 112,500,000 | $251 | $25,088 |
+| 1,000,000 | 75,000 | 11,250,000 | 1,125,000,000 | $2,509 | $250,875 |
+
+**Worst case at 1M DAU = $250k/mo** if every paying creator hits their 500/day cap every day — still affordable but wasteful.
+
+**Industry comparison:** Notion (post-May-2025) gates ALL AI to Business+ ($20/user/mo unlimited). [Source: Notion AI pricing 2026](https://userjot.com/blog/notion-pricing-2025-plans-ai-costs-explained). Critically received as an "anti-Free" move that pushed creators to Anytype + Obsidian.
+
+---
+
+### 5.2 Strategy 2 — Credits/month per tier
+
+**Mechanism**
+- Free: 0 OR 10 credits/mo (~10 ✨ clicks)
+- Creator: 50 credits/mo
+- Pro: 500 credits/mo
+- Business: unlimited (fair-use ~5,000/mo)
+- 1 credit = 1 ✨ Suggest call. Reset on first day of billing cycle.
+- Out-of-credits UX: friendly modal "You've used all 50 of your AI suggestions this month. Resets May 1, or upgrade to Pro for 500/month →"
+
+**Pros**
+- Predictable cost per tier — `tier_price × users` minus `quota × users × per_call_cost` = stable margin.
+- Tier separation is sharp — no overlap, no "well I'm on Creator but I get unlimited too" leakage.
+- Free tier still tastes the magic (10 calls = enough to be impressed).
+- Industry-norm pattern (GitHub Copilot, Cursor, Notion historically).
+
+**Cons**
+- **Creator anxiety.** Studies on Copilot premium-request usage show users moderate behaviour to "save credits for later" — exactly the *opposite* of what we want for a discoverability feature. Creator on Creator tier with 8 credits left mid-month doesn't experiment; they hoard.
+- **Credit-fatigue is real.** Bills, subscriptions, credit-balance notifications — every UX research piece on metered-AI products confirms users dislike tracking credit balances.
+- **Monthly resets are confusing.** Especially for tadaify creators billed on different cycle dates. UX needs prominent "you have N credits, resets on DD" strip.
+- **Penalises power users.** A Creator-tier user who happens to redo their landing page in one sitting (~30 clicks across all blocks) blows their entire month's allocation on one good-faith use.
+- **Cost of building the system.** Database table for credit balances per user, atomic decrement on call, monthly reset job, edge case for plan changes mid-cycle. ~3 days of engineering.
+
+**Per-tier cost-at-scale (assume 100% utilisation of quota by all users)**
+
+Quota distribution assumed: 70% Free, 15% Creator, 12% Pro, 3% Business.
+
+| Total creators | Free × 10 | Creator × 50 | Pro × 500 | Business × 5,000 (fair-use) | Total calls/mo | Cloudflare cost |
+|---|---|---|---|---|---|---|
+| 100 | 700 | 750 | 600 | 1,500 | 3,550 | $0.79 |
+| 1,000 | 7,000 | 7,500 | 6,000 | 15,000 | 35,500 | $7.92 |
+| 10,000 | 70,000 | 75,000 | 60,000 | 150,000 | 355,000 | $79.17 |
+| 100,000 | 700,000 | 750,000 | 600,000 | 1,500,000 | 3,550,000 | $791.65 |
+| 1,000,000 | 7,000,000 | 7,500,000 | 6,000,000 | 15,000,000 | 35,500,000 | $7,917 |
+
+**Worst case at 1M DAU = $7.9k/mo.** Tightest cost ceiling of the three strategies — but at the expense of UX friction.
+
+**Industry comparison:** GitHub Copilot Free 50 / Pro 300 / Pro+ 1,500 / Business unlimited. Pro+ at $39/mo. [Source: GitHub Copilot pricing 2026](https://pecollective.com/tools/github-copilot-pricing/). GitHub charges $0.04/extra request beyond quota — a similar overage line is technically possible but adds yet another billing concept tadaify has to explain.
+
+---
+
+### 5.3 Strategy 3 — Daily rate-limit per tier (RECOMMENDED)
+
+**Mechanism**
+- Free: 5 clicks/day (enough for: title + 2 captions + 2 short-text, i.e. one full block fill-out)
+- Creator: 50 clicks/day (enough to redo a whole page in one sitting + some experimentation)
+- Pro: unlimited with fair-use 500/day (enough for any human creator; 500/day = 21/hour sustained, clearly bot territory)
+- Business: unlimited with fair-use 2,000/day (agency / multi-brand scenarios)
+- Reset midnight UTC.
+- Out-of-quota UX: friendly modal "You've used today's 5 AI suggestions. Resets midnight UTC, or upgrade to Creator for 50/day →" with an inline countdown.
+
+**Pros**
+- **Simple mental model** — "X per day" is something every internet user already understands (Spotify free skips, ChatGPT free messages, Wordle, Twitter API).
+- **Daily reset feels less precious than monthly** — running out today is annoying but tomorrow is fine; running out for the month is a 30-day grievance.
+- **Free tier tastes the magic** — 5 calls/day = enough to experience "wow this is useful" without any single call feeling load-bearing.
+- **Abuse-protected** — fair-use caps keep a single bad actor capped at predictable infra spend.
+- **Cleanest upsell moment** — "you've hit today's limit" + Upgrade CTA is the highest-intent state in the app. Better conversion trigger than "you've hit this month's limit, see you in 3 weeks".
+- **Cheap to build** — `(user_id, date) → counter` table; reset is implicit via date partitioning.
+
+**Cons**
+- **Creator who needs 6 suggestions in a sitting on Free tier hits the wall.** Real complaint, not a hypothetical. Mitigation: the 6th creator either (a) waits till tomorrow and likely doesn't even open tadaify next-day, or (b) upgrades — exactly the conversion moment we want.
+- **Daily limits can feel artificial** ("why 5 and not 10?"). Mitigation: round numbers + clear copy.
+- **Timezone confusion** — midnight UTC is 4pm PST; a Pacific-coast creator's "today" doesn't match the reset. Mitigation: show countdown timer in user's local time.
+
+**Per-tier cost-at-scale (assume 100% of active creators hit daily cap 5 days/week, 0 the other 2 days = 5/7 utilisation of quota)**
+
+Tier distribution: 70% Free, 15% Creator, 12% Pro, 3% Business.
+
+| Total creators | Active (30%) | Free×5×5/7 | Creator×50×5/7 | Pro×500×5/7 | Business×2k×5/7 | Calls/mo | Cloudflare cost |
+|---|---|---|---|---|---|---|---|
+| 100 | 30 | 75 | 161 | 129 | 64 | 13,470 | $3.00 |
+| 1,000 | 300 | 750 | 1,607 | 1,286 | 643 | 134,580 | $30.01 |
+| 10,000 | 3,000 | 7,500 | 16,072 | 12,857 | 6,429 | 1,345,800 | $300.11 |
+| 100,000 | 30,000 | 75,000 | 160,716 | 128,571 | 64,286 | 13,458,000 | $3,001 |
+| 1,000,000 | 300,000 | 750,000 | 1,607,143 | 1,285,714 | 642,857 | 134,580,000 | $30,011 |
+
+**Worst case at 1M DAU = $30k/mo.** Sits in the middle of Strategy 1 (wasteful) and Strategy 2 (tightest). Tradeoff is the right one: spend ~3.8× more than Strategy 2 to avoid credit anxiety + retain Free-tier conversion funnel.
+
+**Industry comparison:**
+- ChatGPT Free: ~10 GPT-5 messages / 3 hours, then degrades to GPT-mini. Daily soft-rate-limit pattern.
+- Perplexity Free: 5 Pro searches / day. Daily reset. **Direct match for the proposed pattern.**
+- Cursor Free: 50 slow requests / month (credit pattern, not daily).
+- Linear AI: bundled in plan, no limit communicated to user.
+- v0.dev Free: 5 messages / day.
+
+The daily-rate-limit pattern is the most common UX in 2026 for cost-bounded AI features. tadaify aligns with creator/dev tooling norm.
+
+---
+
+## 6. Architectural choice — proxied vs BYOK
+
+### Option A — Proxied via tadaify Edge Function (RECOMMENDED)
+
+- tadaify operates a Cloudflare Worker (or Supabase Edge Function) at `POST /api/ai-suggest`.
+- Worker reads creator's tier + today's usage from DB, applies rate limit, calls Cloudflare Workers AI, returns 5 suggestions.
+- Creators never see/manage API keys.
+- tadaify pays the bill, gates by tier per Strategy 3.
+
+**Pros**
+- Zero creator setup friction — ✨ button "just works" at signup.
+- Centralised cost — predictable monthly bill, single vendor relationship.
+- Can swap underlying model without creator action (A/B testing, vendor failover).
+- Aggressive prompt caching at the proxy layer (system prompt + few-shot examples shared across all creators → cache hit rate >99%).
+- Unified analytics (who uses ✨ how often, on which fields, do generated ones get accepted?).
+- Tier-gating is clean — no "what if BYOK creator on Free tier" edge cases.
+
+**Cons**
+- tadaify carries the COGS. At Cloudflare 8B scale that's ~$30k/mo at 1M DAU — fine.
+- Single point of failure (proxy down = ✨ down for everyone).
+
+### Option B — Creator brings own API key (BYOK)
+
+- Creator pastes OpenAI / Anthropic / Cloudflare API key into Settings → AI.
+- ✨ button fires call directly from creator's browser to provider with creator's key (or via tadaify Worker that uses creator's key).
+- Creator pays own bill.
+
+**Pros**
+- Zero tadaify infra cost.
+- No tier-gating needed (creator self-rate-limits via their own quota).
+- Power users who already have an API key get unlimited day-1.
+- Privacy story for creators who don't want their copy seen by tadaify-controlled vendor.
+
+**Cons**
+- **Setup friction kills adoption.** 90%+ of tadaify creators don't have an API key. Asking them to sign up at OpenAI, add a credit card, generate a key, paste it — that's a 4-step onboarding wall on a feature that should be one click.
+- Key management is a security liability for tadaify (we either store keys in plaintext, or in a vault, or send them client-side — each option has tradeoffs).
+- Quality varies by creator — some pick gpt-5.5 ($30/Mtok output), some pick a free-tier rate-limited Groq key — inconsistent ✨ experience.
+- No upsell story — if creator pays their own AI bill, they have no reason to upgrade tadaify tier.
+
+### Option C — Hybrid (Proxied default + optional BYOK for power users)
+
+- Free / Creator / Pro tiers: proxied per Strategy 3.
+- Pro / Business tiers: option to "Use your own OpenAI key" in Settings — bypasses tadaify quota entirely.
+- Never asked of free users.
+
+**Pros**
+- Best of both — defaults to magic, opt-in to power user mode.
+- Power users who hit daily cap on Pro can self-serve an "infinite quota" by adding their own key.
+
+**Cons**
+- 2× engineering effort (both code paths).
+- Splits analytics (we don't see what's in BYOK calls).
+
+### Recommendation
+
+**Option A — fully proxied.** Reasoning:
+1. The model cost is so cheap ($30k/mo at 1M DAU worst case) that the BYOK savings aren't worth the onboarding friction.
+2. Proxied lets us swap models without creator action — critical for cost optimisation as the field evolves.
+3. Hybrid (Option C) is an option to add later if Pro+ users explicitly demand it; not needed for MVP.
+4. Centralised analytics is a competitive moat (we learn what kinds of suggestions creators actually ship vs reject).
+
+---
+
+## 7. Recommendation matrix
+
+| Dimension | Recommendation | Why |
+|---|---|---|
+| **Default model** | Cloudflare `@cf/meta/llama-3.1-8b-instruct-fast` | Cheap ($0.000223/call), fast (TTFT 300ms, 80+ TPS), already in tadaify infra plan, edge-distributed |
+| **Premium model toggle** (Pro+ only) | Cloudflare `@cf/meta/llama-3.3-70b-instruct-fp8-fast` OR `gpt-5.4-nano` | Quality bump for paying creators who notice the difference |
+| **Strategy** | Strategy 3 — Daily rate-limit | Free 5 / Creator 50 / Pro unlimited+500 / Business unlimited+2k. Daily reset midnight UTC. |
+| **Architecture** | Proxied via tadaify Worker (Option A) | Zero creator friction; cost is bounded; we control quality |
+| **Caching** | Yes — system prompt + few-shot examples shared (deterministic prefix); per-creator output NOT cached | DEC-AI-COST-06 — cached identical inputs only, never reuse one creator's suggestions for another |
+
+**Why this combo (1 paragraph):** Cloudflare Llama 8B + daily rate-limit + proxied gives tadaify the lowest engineering surface (one provider, one quota model, no BYOK edge cases), the friendliest UX (Free creators get a real taste, Pro+ creators get unlimited, abuse is capped), and the best cost profile (~$30k/mo at 1M DAU worst case = a non-issue against a $50M+ ARR product). The 70B model as a Pro+ "premium quality" toggle gives a tangible upgrade reason without changing the core architecture.
+
+---
+
+## 8. Open DECs
+
+The following decisions must be answered before AI Suggest implementation can begin. These will be filed in `/tmp/claude-decisions/decisions.json` when the user is ready to decide.
+
+### DEC-AI-COST-01 — Which model?
+
+| ID | DEC-AI-COST-01 |
+|---|---|
+| **Czego dotyczy** | Default model for ✨ Suggest |
+| **Szczegolowy opis** | tadaify needs to pick one provider+model as the default for the ✨ Suggest button across all tiers. Cost ranges from $0.00003 (Groq) to $0.0011 (Anthropic Haiku) per call. Quality is comparable in the cheap band; the differentiation is operational consolidation, latency, and brand. |
+| **Opcje** | 1) Cloudflare `llama-3.1-8b-instruct-fast` 2) OpenAI `gpt-5.4-nano` 3) Anthropic `claude-haiku-4-5` 4) Mistral `ministral-8b` 5) Groq `llama-3.1-8b-instant` |
+| **Twoja rekomendacja** | **Option 1 (Cloudflare Llama 8B-fast)** — consolidates with tadaify's planned Cloudflare Worker infra (per video-block research), edge-distributed for global creators, $0.000223/call is affordable, and 80+ TPS / 300ms TTFT meets latency budget. |
+
+### DEC-AI-COST-02 — Which strategy?
+
+| ID | DEC-AI-COST-02 |
+|---|---|
+| **Czego dotyczy** | How to gate ✨ Suggest by tier |
+| **Szczegolowy opis** | Three patterns are viable: hide AI from Free entirely (premium positioning), monthly credit balance (predictable cost, creator anxiety), daily rate-limit (Perplexity/v0/ChatGPT pattern, simple mental model). The choice shapes Free→Creator conversion funnel and ongoing UX. |
+| **Opcje** | 1) Pro+ gated (no AI on Free/Creator) 2) Monthly credits (Free 10 / Creator 50 / Pro 500 / Business unlimited) 3) Daily rate-limit (Free 5 / Creator 50 / Pro unlimited+500/d / Business unlimited+2k/d) |
+| **Twoja rekomendacja** | **Option 3 (daily rate-limit)** — simplest UX, retains Free-tier magic moment, gives clean upsell trigger ("hit today's limit → upgrade"), and the cost ($30k/mo at 1M DAU) is bounded. Notion's removal of AI from Free in May 2025 was widely criticised; Strategy 1 repeats that mistake. Strategy 2's monthly credits create credit anxiety and dampen experimentation. |
+
+### DEC-AI-COST-03 — Free-tier daily quota (if Strategy 3)
+
+| ID | DEC-AI-COST-03 |
+|---|---|
+| **Czego dotyczy** | How many ✨ clicks/day for Free tier |
+| **Szczegolowy opis** | Conditional on DEC-AI-COST-02 = Strategy 3. Free tier needs enough quota to taste the magic but not enough to remove the upgrade incentive. 5/day = one full block fill-out. 3/day = title + 2 captions only (might feel too tight). 10/day = enough that creators rarely hit the wall (might over-serve Free). |
+| **Opcje** | 1) 3 clicks/day 2) 5 clicks/day 3) 10 clicks/day 4) Unlimited but hidden behind "verify email + add 1 page" gate |
+| **Twoja rekomendacja** | **Option 2 (5/day)** — matches Perplexity Free (5 Pro searches/day), v0.dev Free (5 messages/day) — proven category norm. Enough to fill out one block end-to-end, not enough to erase the upgrade reason. |
+
+### DEC-AI-COST-04 — Out-of-quota UX details
+
+| ID | DEC-AI-COST-04 |
+|---|---|
+| **Czego dotyczy** | What happens when a creator clicks ✨ on the 6th call of the day |
+| **Szczegolowy opis** | Three patterns: (a) hard block — modal "you're out, upgrade", (b) silent degrade — generate 1 instead of 5, or use a worse model, (c) friendly upsell — modal with countdown + Upgrade CTA + "or wait until midnight UTC". UX matters because this is the highest-intent moment for tier conversion. |
+| **Opcje** | 1) Hard block modal with Upgrade CTA + countdown timer 2) Silent degrade (generate 1 suggestion or use cheaper model) 3) Toast notification "out of suggestions today" + button still clickable but no-op 4) Hard block + offer "watch a 30s ad to unlock 5 more" |
+| **Twoja rekomendacja** | **Option 1 (hard block + countdown + Upgrade CTA)** — clearest mental model, highest conversion intent, no half-measures that confuse the creator about whether the feature works. Silent degrade (Option 2) is dishonest and confuses brand quality perception. Ad unlock (Option 4) is consumer-grade and cheapens tadaify positioning. |
+
+### DEC-AI-COST-05 — Proxied vs BYOK architecture
+
+| ID | DEC-AI-COST-05 |
+|---|---|
+| **Czego dotyczy** | Whether tadaify operates the AI provider relationship or creators bring their own keys |
+| **Szczegolowy opis** | Proxied = zero creator friction, tadaify pays bill, tier gating works. BYOK = zero tadaify cost but 90% of creators don't have a key, complex onboarding. Hybrid = both code paths, more engineering. The chosen model is so cheap that BYOK savings aren't worth the friction. |
+| **Opcje** | 1) Proxied only (tadaify Worker, tadaify pays) 2) BYOK only (creator pastes key) 3) Hybrid: proxied default + optional BYOK on Pro+ |
+| **Twoja rekomendacja** | **Option 1 (proxied only)** — zero onboarding friction is more valuable than the COGS savings at this cost band. Hybrid (Option 3) can be added in v2 if Pro+ creators explicitly request it. |
+
+### DEC-AI-COST-06 — Caching strategy
+
+| ID | DEC-AI-COST-06 |
+|---|---|
+| **Czego dotyczy** | Whether to cache ✨ Suggest results, and at what granularity |
+| **Szczegolowy opis** | Two questions: (1) cache the *prompt prefix* (system prompt + few-shot examples) — this is identical across all creators and saves 80% of input tokens; deterministic and harmless. (2) Cache the *full output* keyed on (creator_id, field_type, current_value, neighbor_blocks_hash) for N hours — saves cost on repeat clicks but creator might want a fresh batch on retry. |
+| **Opcje** | 1) Cache prompt prefix only (always); never cache output 2) Cache prefix AND output for 24 hours per (creator, input-hash) 3) Cache prefix AND output for 1 hour per (creator, input-hash) 4) Cache prefix AND offer "regenerate" button that bypasses output cache |
+| **Twoja rekomendacja** | **Option 4 (prefix always cached, output cached 1h with explicit regenerate)** — saves cost on accidental double-clicks (common), but explicit retry / "give me different ones" always bypasses cache and hits the model fresh. Most creator-respectful pattern. |
+
+---
+
+## 9. Implementation notes
+
+### 9.1 Edge Function shape (Cloudflare Worker)
+
+```ts
+// POST /api/ai-suggest
+// Headers: Authorization: Bearer <tadaify-jwt>
+// Body: { fieldType: 'title' | 'label' | 'short-text' | 'caption', currentValue: string, blockContext: object, regenerate?: boolean }
+// Returns: { suggestions: string[5], remainingToday: number }
+
+export default {
+  async fetch(req: Request, env: Env) {
+    const user = await verifyJWT(req, env);
+    const tier = await getUserTier(user.id, env);
+    const dailyCap = TIER_CAPS[tier]; // { free: 5, creator: 50, pro: 500, business: 2000 }
+    const usedToday = await getUsageToday(user.id, env);
+    if (usedToday >= dailyCap) return jsonResponse({ error: 'quota_exceeded', resetAt: nextMidnightUTC() }, 429);
+
+    const body = await req.json();
+    const cacheKey = await sha256({ fieldType: body.fieldType, currentValue: body.currentValue, ctx: body.blockContext });
+    if (!body.regenerate) {
+      const cached = await env.SUGGEST_CACHE.get(cacheKey);
+      if (cached) return jsonResponse({ suggestions: JSON.parse(cached), remainingToday: dailyCap - usedToday });
+    }
+
+    const messages = buildPrompt(body); // system prompt + few-shot + creator context
+    const ai = await env.AI.run('@cf/meta/llama-3.1-8b-instruct-fast', { messages, max_tokens: 300, temperature: 0.7 });
+    const suggestions = parseFiveSuggestions(ai.response);
+
+    await env.SUGGEST_CACHE.put(cacheKey, JSON.stringify(suggestions), { expirationTtl: 3600 });
+    await incrementUsage(user.id, env);
+    await logUsage(user.id, tier, body.fieldType, env); // for analytics + cost tracking
+
+    return jsonResponse({ suggestions, remainingToday: dailyCap - usedToday - 1 });
+  }
+};
+```
+
+### 9.2 Database schema sketch (Supabase)
+
+```sql
+-- per-user daily usage counter
+create table public.ai_suggest_usage (
+  user_id uuid not null references auth.users(id) on delete cascade,
+  date date not null default current_date,
+  count integer not null default 0,
+  primary key (user_id, date)
+);
+
+create index ai_suggest_usage_date_idx on public.ai_suggest_usage(date);
+
+-- atomic increment
+create or replace function increment_ai_usage(p_user_id uuid)
+returns integer language plpgsql security definer as $$
+declare v_count integer;
+begin
+  insert into public.ai_suggest_usage (user_id, date, count)
+  values (p_user_id, current_date, 1)
+  on conflict (user_id, date) do update set count = ai_suggest_usage.count + 1
+  returning count into v_count;
+  return v_count;
+end;
+$$;
+
+-- cleanup old rows (cron daily)
+delete from public.ai_suggest_usage where date < current_date - interval '90 days';
+
+-- per-call audit log (kept 30 days for cost-tracking + abuse analysis)
+create table public.ai_suggest_log (
+  id bigserial primary key,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  tier text not null,
+  field_type text not null,
+  cached boolean not null default false,
+  input_tokens integer,
+  output_tokens integer,
+  latency_ms integer,
+  created_at timestamptz not null default now()
+);
+
+create index ai_suggest_log_created_at_idx on public.ai_suggest_log(created_at);
+```
+
+### 9.3 Tier cap configuration
+
+```ts
+// shared/ai-tier-caps.ts — single source of truth for both Worker + UI
+export const TIER_CAPS: Record<Tier, number> = {
+  free: 5,
+  creator: 50,
+  pro: 500,        // fair-use cap for "unlimited" tier
+  business: 2000,  // fair-use cap for "unlimited" tier
+};
+
+// Show the friendly cap in UI ("50/day"), not the technical fair-use number
+export const TIER_DISPLAY: Record<Tier, string> = {
+  free: '5/day',
+  creator: '50/day',
+  pro: 'Unlimited',
+  business: 'Unlimited',
+};
+```
+
+### 9.4 Failure modes
+
+| Failure | Behaviour | Recovery |
+|---|---|---|
+| Cloudflare AI returns 5xx | Show "AI is taking a quick break, try again in a minute" toast | Manual retry; auto-retry with exponential backoff is OK but stop after 2 |
+| Cloudflare AI returns malformed JSON (parse fails) | Fall back to OpenAI gpt-5.4-nano (failover provider) | Log the malformed output for prompt-engineering review |
+| Both providers down | Disable ✨ button with tooltip "AI suggestions temporarily unavailable" | Status page entry; uptime SLO 99.5% |
+| Worker quota exceeded (Cloudflare account-level) | Disable ✨ entirely with "AI is at capacity, comes back tomorrow" | Page on-call; provision more |
+| Creator hits daily cap | Out-of-quota modal per DEC-AI-COST-04 | Upgrade or wait |
+
+### 9.5 Metrics + observability
+
+- **Per-creator-per-day count** — for rate-limit enforcement (already in `ai_suggest_usage`).
+- **Per-tier daily totals** — `select tier, count(*) from ai_suggest_log where created_at >= current_date group by tier` — drives cost tracking dashboard.
+- **Cache hit rate** — `count(*) filter (where cached) / count(*)` — target >40% (creators retrying same field with small edits is common).
+- **Latency p50/p95** — `percentile_cont(0.5/0.95) within group (order by latency_ms)` — alert if p95 > 3s.
+- **Quota-hit rate per tier** — `count distinct user_id` who hit cap on day N / total active that day. Free quota-hit > 30% = Free tier is too tight (consider DEC-AI-COST-03 = 10/day instead of 5).
+- **Conversion from quota-hit modal** — Upgrade-clicked / quota-hit-modal-shown. This is the headline business metric for whether ✨ Suggest drives tier upgrades.
+
+### 9.6 Migration path
+
+If the chosen model underperforms or pricing changes:
+- Edge Function reads model name from a Worker env var; swap is one Worker deploy.
+- For A/B test: hash creator_id mod 100 → bucket 0–49 → model A, 50–99 → model B.
+- Quality regression detection: log first-suggestion-accepted rate per model; alert if delta > 5%.
+
+---
+
+## 10. Appendix — sources
+
+- [Anthropic Claude API pricing](https://platform.claude.com/docs/en/about-claude/pricing) — verified 2026-04-27
+- [Cloudflare Workers AI pricing](https://developers.cloudflare.com/workers-ai/platform/pricing/) — verified 2026-04-27
+- [OpenAI API pricing (developers.openai.com)](https://developers.openai.com/api/docs/pricing) — verified 2026-04-27
+- [Groq pricing](https://groq.com/pricing/) — verified 2026-04-27
+- [Groq rate limits](https://console.groq.com/docs/rate-limits) — verified 2026-04-27
+- [Mistral API pricing 2026 (aggregator: Burnwise)](https://www.burnwise.io/ai-pricing/mistral) — direct mistral.ai/pricing returned 404 at fetch time; aggregator used as backup
+- [Claude Haiku 4.5 vs gpt-5.4 mini benchmarks (MindStudio)](https://www.mindstudio.ai/blog/gpt-54-mini-vs-claude-haiku-sub-agent-comparison)
+- [GPT-5.4 mini and nano benchmarks (DataCamp)](https://www.datacamp.com/blog/gpt-5-4-mini-nano)
+- [GitHub Copilot pricing 2026 (PE Collective)](https://pecollective.com/tools/github-copilot-pricing/)
+- [Notion AI pricing 2026 (UserJot)](https://userjot.com/blog/notion-pricing-2025-plans-ai-costs-explained)
+- [Cloudflare Workers AI bigger/better/faster](https://blog.cloudflare.com/workers-ai-bigger-better-faster/)
+- [Llama 3.1 8B Cloudflare model card](https://developers.cloudflare.com/workers-ai/models/llama-3.1-8b-instruct/)
+- [Llama 3.3 70B fp8-fast Cloudflare model card](https://developers.cloudflare.com/workers-ai/models/llama-3.3-70b-instruct-fp8-fast/)
+
+End of report.

--- a/docs/research/embedded-block-explainer.md
+++ b/docs/research/embedded-block-explainer.md
@@ -1,0 +1,817 @@
+---
+type: research
+project: tadaify
+title: "Embedded block — scope, alternatives, security (oEmbed vs whitelisted iframe vs kill)"
+created_at: 2026-04-26
+---
+
+# tadaify Embedded block — scope, alternatives, security
+
+## 1. Executive summary
+
+**Recommendation: Option A — ship `Embedded` as an oEmbed-only block in MVP, with a curated whitelist of 12 providers.** Kill the placeholder "generic embedded" idea (Option B, freeform iframe) for v1, and do **not** fold it into Link/Video either (Option C). The block solves a job-to-be-done that Link and Video do not: **rendering a third-party widget inline on the creator page** — a Spotify track that plays without leaving tadaify, a Bandcamp album with cover art and Buy button, a TikTok post that auto-plays, a Bluesky/Twitter post quoted with avatar and reactions. Link sends visitors away. Video is a special case of this same pattern but already shipped with its own UX (cover art, play-overlay, fullscreen). The Embedded block is the rest of the long tail (audio, social posts, podcasts, Loom recordings, Figma boards) — and those use cases are **central to a creator landing page**.
+
+**Why oEmbed-only for v1, not generic iframe:** oEmbed gives us (a) provider does the work — they return ready HTML with their own sandbox/CSP guarantees, (b) zero per-host firefighting on cookies/X-Frame-Options/CSP, (c) deterministic per-provider rendering we can style consistently, (d) no creator pasting a malicious URL because the URL is parsed and validated against a whitelist before any iframe is rendered. The cost: 12 providers covers ~95% of real creator demand, and we can extend the whitelist (oEmbed or per-provider iframe parser) story-by-story without ever opening "paste arbitrary HTML".
+
+**Why not C (kill it):** the use cases that require a separate block are real — *audio that plays inline*, *social posts quoted with their original styling*, *interactive widgets like Calendly/Tally*. Folding them into Link is a downgrade ("here's a SoundCloud link, click to leave my page"). Folding them into Video confuses the type system (Spotify is not a video). Keeping a single dedicated `Embedded` block with provider auto-detection is cleaner than overloading the existing two.
+
+**Open decisions (5):** see §11. Headline: DEC-EMBED-01 (oEmbed-only Y/N) leaning **Y**; DEC-EMBED-02 (initial whitelist of 12) leaning **YES on the named list**; DEC-EMBED-03 (Iframely vendor or roll-your-own per provider) leaning **roll-your-own** for v1, switch to Iframely paid plan only when whitelist hits 30+ providers; DEC-EMBED-04 (per-tier gating) leaning **all tiers, no gating** because zero tadaify-side cost; DEC-EMBED-05 (block-level vs page-level) leaning **block-level only**, no "embed entire page" mode.
+
+---
+
+## 2. Why this SPIKE exists — context
+
+The tadaify creator-page block library currently has 6 block types in MVP scope:
+
+1. **Link** — title + URL + optional thumbnail; click sends visitor to external URL.
+2. **Video** — YouTube URL → render YouTube player inline (also supports Vimeo per Video block spec).
+3. **Image** — uploaded file or external URL → render `<img>` inline.
+4. **Text** — rich-text paragraph (markdown subset).
+5. **Shop** — for MVP this is an external link to creator's existing storefront (Shopify/Stripe/Etsy/Gumroad), not a native shop. See `feedback_tadaify_no_shop_in_mvp.md`. Native shop deferred to v2.
+6. **Embedded** — placeholder. The block renders a "coming soon" card in the editor. No implementation, no spec, no test plan.
+
+The user asked: *what should this block actually do, and how does it differ from the Video block?* That is the question this report answers.
+
+Two intuitions are in conflict:
+
+- **Intuition A (the one driving "Embedded exists as a placeholder"):** creators want to drop in arbitrary widgets — a Spotify player, a Calendly booking widget, a Substack subscribe form, a Twitter post — and tadaify should not have to ship a custom block per widget.
+- **Intuition B (the one driving "kill it"):** every realistic widget is either a media player (Video block already does this) or a link with a fancy preview (Link block already does this). A separate "Embedded" block is duplication.
+
+Intuition B is *partially* correct — Video block already handles inline media for a very small number of providers (YouTube, Vimeo). The question is whether it should grow to handle Spotify, Bandcamp, SoundCloud, Loom, Twitter, Bluesky, TikTok, Instagram, Calendly, Tally, Typeform, Figma, etc. — at which point the block name "Video" becomes a lie and the data model becomes unwieldy. Intuition A wins on the data-model argument: a generic "Embedded" block with a `provider` field is cleaner than a "Video" block whose `provider` enum has 30 values, half of which are not videos.
+
+This report walks through both options, surveys what 5 competitors do, and lands on a concrete recommendation.
+
+---
+
+## 3. Comparison: Embedded vs Video vs Link button vs Image
+
+### 3.1 The four blocks side-by-side
+
+| Block | Job-to-be-done | Visitor action | Visitor stays on page? | Render mode |
+|---|---|---|---|---|
+| **Link** | Drive traffic to an external URL | Click → navigates away (new tab) | **No** — leaves tadaify | Static card (title + thumbnail + URL) |
+| **Image** | Show a static image (gallery, photo, screenshot) | Optional click-to-enlarge | Yes | `<img>` tag |
+| **Video** | Inline video playback (YouTube, Vimeo) | Click play → video plays inline | **Yes** — plays in the page | Provider iframe (YouTube embed, Vimeo player) |
+| **Embedded** | Inline widget that is **not** a video (audio, social post, form, doc, board) | Click play / interact → widget responds inline | **Yes** — interacts in the page | Provider iframe (Spotify, Bandcamp, Twitter, Calendly, …) |
+
+The Embedded block exists for the same reason Video does: **the visitor stays on the creator's page and interacts with the third-party widget there**. The only difference is medium — Video happens to be the audiovisual subset that already shipped first.
+
+### 3.2 What goes in Embedded that does NOT fit Link, Image, or Video
+
+| Use case | Link? | Image? | Video? | Embedded? |
+|---|---|---|---|---|
+| Spotify track (creator's own song) plays inline | No (sends away) | No | No (not video) | **Yes** |
+| SoundCloud podcast episode plays inline | No | No | No | **Yes** |
+| Bandcamp album with Buy Now button | No | No | No | **Yes** |
+| Apple Podcasts episode preview | No | No | No | **Yes** |
+| Twitter/X post (quoted with replies count) | No (just a link) | No (PNG screenshot loses interactivity) | No | **Yes** |
+| Bluesky post (quoted) | No | No | No | **Yes** |
+| Instagram post (single post, embedded with caption) | No | No | No | **Yes** |
+| TikTok video (embedded, plays in-page) | Maybe Video | No | **Yes** but stretches the block name | **Yes** (cleaner) |
+| YouTube video | No | No | **Yes** | (Yes — but Video already handles it) |
+| Vimeo video | No | No | **Yes** | (Yes — but Video already handles it) |
+| Loom recording (screen-share / async video) | No | No | Stretches Video | **Yes** |
+| Calendly booking widget | No (link, but loses inline UX) | No | No | **Yes** |
+| Tally / Typeform form | No | No | No | **Yes** |
+| Substack subscribe form | No | No | No | **Yes** |
+| Figma file (read-only board) | No | No | No | **Yes** |
+
+The Embedded block fills a real gap. About 70% of the entries above (Spotify, SoundCloud, Bandcamp, Twitter, Bluesky, Instagram, podcasts) are on the **critical path** for a music/social/podcast creator — i.e. exactly the segments tadaify is targeting per `competitors-user-segments.md`.
+
+### 3.3 Why not extend Video instead?
+
+Two arguments against:
+
+1. **Naming.** A "Video" block whose `provider` enum is `["youtube","vimeo","spotify","bandcamp","twitter","calendly"]` is a lie. New creators looking for "where do I add a Spotify player?" will not look under Video. They will look under Music, Audio, or Embedded.
+
+2. **Rendering contract.** Video block ships a play-overlay with cover thumbnail, fullscreen toggle, mute/unmute. Spotify embeds ship their own player chrome. Twitter embeds ship a static post with reply/like links. The rendering contract per provider is not "video player" — it is "whatever the provider returns". Forcing them all into the Video block's UX shell is wrong.
+
+The cleanest split: **Video stays YouTube + Vimeo + TikTok** (the pure video subset). **Embedded handles everything else**.
+
+---
+
+## 4. Industry pattern survey — what do competitors do?
+
+### 4.1 Linktree
+
+Linktree is the category leader (~40M creators per their 2025 IR deck). Their block library has separate, named blocks for each major provider rather than a generic "Embedded" block:
+
+- **Music block** — supports Spotify, Apple Music, SoundCloud, Bandcamp, YouTube Music. Creator pastes URL; Linktree renders the provider's official embed.
+- **Video block** — supports YouTube, Vimeo, TikTok, Twitch, Facebook video.
+- **Twitter/X embed** — separate dedicated block.
+- **Instagram** — dedicated block (embed single post or profile).
+- **Form** — dedicated block (Typeform, ConvertKit, Mailchimp).
+
+Linktree explicitly does **not** have a generic "Embedded" or "Custom HTML" block. Reason (per their docs): they value safety + visual consistency over flexibility. A creator cannot paste arbitrary HTML, and cannot embed a non-whitelisted provider — they have to file a feature request.
+
+**Implication for tadaify:** Linktree's split-by-provider approach works but explodes the block library. For MVP we have 6 blocks; if we follow Linktree we'd need ~12 (Music, Video, Twitter, Instagram, Form, Calendly, …). A single Embedded block with auto-detection is more compact and still safe if we whitelist providers.
+
+### 4.2 Beacons.ai
+
+Beacons takes a hybrid approach:
+
+- **Music block** — Bandcamp, YouTube Music, Spotify, SoundCloud, Apple Music. Creator pastes a URL OR pastes the iframe embed code copied from the provider.
+- **Video block** — YouTube, TikTok, Vimeo, Twitch.
+- **Embed block (generic)** — supports Twitter posts, OpenSea NFT, Instagram. URL or iframe code accepted.
+- **Custom HTML** — only on top tier (Creator Pro / Creator Max).
+
+Beacons is the closest precedent for the "Embedded" block — they have one called "Embed" and it covers the long tail. Notably, **they accept iframe paste** as a fallback when URL detection fails. This is a security risk that they've decided to live with on paid tiers.
+
+**Implication for tadaify:** Beacons' "URL or iframe paste" pattern is more flexible than oEmbed-only but more dangerous. A safer take: we accept URLs only, parse them against a whitelist, and reject anything else. Tadaify creators upload to their *own* page so the security blast radius is per-creator, but a single hostile creator pasting an `<iframe src="malicious.example.com/csrf-trigger">` could fire CSRF against any visitor's logged-in session on that domain. Whitelist-only is the right MVP default.
+
+### 4.3 Bento.me
+
+**Important context:** Bento.me shut down on 2026-02-13 after Linktree acquired them in 2023. Bento is no longer a product, but their block library design was the most influential reference for tadaify's grid layout (per `multi-page-grid-and-templates.md`).
+
+Bento's approach:
+
+- **Spotify block** — dedicated.
+- **YouTube block** — dedicated.
+- **Twitter block** — dedicated.
+- **Image block, link block, text block** — dedicated.
+- **No generic "Embed" block.**
+
+Bento's design philosophy was: every block has a fixed visual treatment (Spotify always renders the green Spotify card; YouTube always the YouTube player; Twitter always the white-on-black post card). Visual consistency was a feature, not a limitation. Creators reportedly liked this.
+
+**Implication for tadaify:** Bento proved that a per-provider block library can scale to 15+ block types without confusing creators, *if* the editor groups them well (e.g. "Music" submenu containing Spotify/SoundCloud/Bandcamp). For MVP we go with one Embedded block to ship faster, but if usage data shows confusion, we can split into Music/Social/Forms sub-blocks in v1.5.
+
+### 4.4 Carrd
+
+Carrd is a different beast — it's a generic single-page builder, not link-in-bio. Their embed story:
+
+- **Embed element (Pro tier+)** — accepts arbitrary URL → renders in iframe with three aspect-ratio modes (Ignore / Strict / Flexible). No whitelist; no sandbox attribute documented.
+- **Custom HTML element (Pro tier+)** — accepts arbitrary HTML, CSS, JavaScript, including `<head>` injection.
+
+Carrd is the **most permissive** of the five competitors — they trust creators because their tier is paid ($19/year Pro, $49/year Pro Plus) and creator velocity is their pitch. The blast radius is per-page (each Carrd page is its own subdomain).
+
+**Implication for tadaify:** Carrd's Custom HTML block is what tadaify must explicitly reject for MVP. A tadaify page is `tadaify.com/<handle>` — all on one origin, sharing cookies. A creator pasting `<script>fetch("/admin/...", { credentials: "include" })</script>` could attempt CSRF against any logged-in tadaify visitor on the same origin. Even if visitors don't have admin access on `tadaify.com`, the reputational risk of "tadaify hosts XSS" is too high. Custom HTML is a v3+ consideration after we have proper origin isolation (per-creator subdomain on a separate apex, e.g. `<handle>.user-content.tadaify.io`).
+
+### 4.5 Stan.store
+
+Stan is a creator-store platform, not a link-in-bio builder. Their "URL/Media product" supports:
+
+- **Display styles:** Button (compact), Callout (large card), Embed (inline iframe).
+- **URL types:** YouTube, Spotify (podcast), Apple Podcasts, affiliate links, generic URL.
+
+Stan's "Embed" mode is essentially a fallback for any URL — it renders an iframe with a fixed aspect ratio. This is closer to Carrd's permissive model than Linktree's whitelist model. Stan creators reportedly run into "the iframe shows nothing" bugs frequently — because most non-whitelisted sites set X-Frame-Options: DENY.
+
+**Implication for tadaify:** Stan's experience confirms that a permissive "any URL becomes an iframe" approach is **bad UX**. Creators paste URLs that don't render and don't understand why. Whitelist-only avoids this entire failure mode.
+
+### 4.6 Summary table
+
+| Platform | Generic Embed block? | Custom HTML? | Approach |
+|---|---|---|---|
+| Linktree | No — per-provider blocks | No | Whitelist via dedicated blocks |
+| Beacons | Yes (URL or iframe paste) | Pro tier only | Hybrid; paid tier = trusted |
+| Bento.me | No — per-provider blocks | No | Visual consistency over flexibility |
+| Carrd | Yes (any URL) | Yes (Pro tier) | Maximum flexibility, paid trust model |
+| Stan.store | Yes (any URL) | No | Permissive but UX issues |
+
+**Tadaify's natural position:** between Linktree and Beacons. Single generic "Embedded" block (less library bloat than Linktree) but URL-only against a whitelist (safer than Beacons' iframe-paste).
+
+---
+
+## 5. Option A — oEmbed-based with curated whitelist
+
+### 5.1 What it is
+
+Creator pastes a URL into the Embedded block:
+
+```
+https://open.spotify.com/track/4iV5W9uYEdYUVa79Axb7Rh
+```
+
+Tadaify:
+
+1. Parses URL → extracts host.
+2. Looks up host in our whitelist (e.g. `open.spotify.com` → matches `spotify` provider).
+3. Constructs the provider's embed URL deterministically: `https://open.spotify.com/embed/track/4iV5W9uYEdYUVa79Axb7Rh`.
+4. Renders `<iframe src=...>` with provider-recommended height, sandbox flags, and CSP allowlist.
+5. Stores in DB: `{ block_type: "embedded", provider: "spotify", resource_url: "https://open.spotify.com/track/...", resource_type: "track", resource_id: "4iV5..." }`.
+
+The iframe URL is **constructed by tadaify code** from the parsed input — never passed through unchanged. This eliminates an entire class of attacks (URL parameter injection, fragment-based XSS).
+
+### 5.2 Initial whitelist (12 providers)
+
+For MVP, ship support for these 12. Each has a stable embed URL pattern, modest abuse surface, and is on the critical path for at least one creator segment.
+
+| # | Provider | Host pattern | Embed URL pattern | Use case | Has oEmbed? |
+|---|---|---|---|---|---|
+| 1 | **Spotify** | `open.spotify.com/(track\|album\|playlist\|episode\|show)/<id>` | `https://open.spotify.com/embed/$1/$2` | Music creators (track/album/playlist), podcasters (episode/show) | Yes ([oEmbed](https://developer.spotify.com/documentation/embeds/reference/oembed)) |
+| 2 | **SoundCloud** | `soundcloud.com/<artist>/<track>` or `/<artist>/sets/<set>` | `https://w.soundcloud.com/player/?url=<url-encoded>` | Music creators, podcasters | Yes |
+| 3 | **Bandcamp** | `<artist>.bandcamp.com/(track\|album)/<slug>` | iframe with track/album ID (parsed from page meta) | Indie music sales | Per-page meta tags only |
+| 4 | **Apple Podcasts** | `podcasts.apple.com/<country>/podcast/.../id<id>` | `https://embed.podcasts.apple.com/<country>/podcast/.../id<id>` | Podcasters | Yes ([endpoint](https://podcasts.apple.com/api/oembed)) |
+| 5 | **Apple Music** | `music.apple.com/<country>/(album\|playlist\|song)/.../<id>` | `https://embed.music.apple.com/<country>/$1/.../$2` | Music creators | Yes |
+| 6 | **YouTube** | `youtube.com/watch?v=<id>` or `youtu.be/<id>` | `https://www.youtube.com/embed/<id>` | Video creators (overlap with Video block — see §5.5) | Yes ([endpoint](https://www.youtube.com/oembed)) |
+| 7 | **Vimeo** | `vimeo.com/<id>` | `https://player.vimeo.com/video/<id>` | Filmmakers (overlap with Video block) | Yes |
+| 8 | **TikTok** | `tiktok.com/@<user>/video/<id>` | `https://www.tiktok.com/embed/v2/<id>` | Short-form video creators | Yes |
+| 9 | **Twitter / X** | `(twitter\|x).com/<user>/status/<id>` | publish.twitter.com oEmbed (returns `<blockquote>` + script) | Social proof, quote-posts | Yes |
+| 10 | **Bluesky** | `bsky.app/profile/<handle>/post/<id>` | `https://embed.bsky.app/oembed?url=<url-encoded>` | Bsky-native creators | Yes |
+| 11 | **Instagram** | `instagram.com/(p\|reel)/<id>` | Meta oEmbed endpoint (requires Facebook App ID) | Visual creators | Yes (auth required) |
+| 12 | **Loom** | `loom.com/share/<id>` | `https://www.loom.com/embed/<id>` | Async video, screen-share creators | Yes ([endpoint](https://www.loom.com/v1/oembed)) |
+
+This list covers **music (3 providers + Apple Music = 4)**, **podcasts (Apple Podcasts + Spotify episodes/shows + SoundCloud)**, **video (YouTube + Vimeo + TikTok + Loom = 4)**, **social (Twitter + Bluesky + Instagram = 3)**. That is the entire bottom half of `competitors-user-segments.md`.
+
+### 5.3 Whitelist v1.5 (next 8 providers, post-MVP)
+
+Once MVP ships and we see real creator demand, add these in priority order:
+
+| # | Provider | Use case |
+|---|---|---|
+| 13 | **Mixcloud** | DJ mixes |
+| 14 | **Dailymotion** | EU video alternative to YouTube |
+| 15 | **Twitch** | Live-stream highlights / clips |
+| 16 | **Calendly** | Booking widget (high creator demand for coaches/consultants) |
+| 17 | **Tally** | Free form alternative to Typeform |
+| 18 | **Typeform** | Form widget |
+| 19 | **Substack** | Subscribe form (writers) |
+| 20 | **Figma** | Design portfolio (read-only board) |
+
+These 8 add another ~3% of demand each, totaling ~24% — bringing whitelist coverage to ~95% of realistic creator embed needs. Anything below that is genuinely long-tail.
+
+### 5.4 Pros (Option A)
+
+- **Safe by construction.** No creator-supplied iframe HTML. URL is parsed, validated, and the iframe `src` is constructed by our code from a known template per provider. An attacker can't inject `<iframe src="evil.com">`.
+- **Predictable rendering.** Every Spotify block renders the same way. Designers can theme the wrapper. No "this widget is 800px tall, my page looks broken".
+- **Provider does the heavy lifting.** We don't ship a Spotify player — Spotify does. We don't worry about codecs, DRM, CDN, fallbacks. Their iframe handles it. Our maintenance burden is a regex per provider plus a height/aspect-ratio constant.
+- **No per-host CSP/cookie/X-Frame-Options surprises.** All 12 providers have set their iframes up to be embedded by anyone (that's their business model). No firefighting.
+- **Provider-side analytics.** Spotify counts plays from embedded players. Creators get their existing dashboards unchanged.
+- **GDPR-friendly per provider.** Each provider is its own data controller; tadaify is just a frame host. Each provider iframe is the consent boundary (Spotify shows its own cookie banner inside the iframe). Cleaner than tadaify needing to surface 12 different consent flows.
+
+### 5.5 Cons (Option A)
+
+- **Limited to whitelisted providers.** Creator wanting to embed Beatport, Audius, or PeerTube (provider not on our list) is blocked until we add it. Workaround: they use Link block.
+- **Per-provider implementation work.** Each provider needs: regex to extract resource ID, embed URL template, recommended height, optional thumbnail fetch, oEmbed call (when supported), test fixtures. Estimated **~2 hours per provider** including a unit test. 12 providers ≈ 24 hours engineering. Not nothing, but bounded.
+- **Overlap with Video block (YouTube, Vimeo, TikTok).** Three providers exist in both Video and Embedded. Decision: leave them in both. Editor logic can detect the URL and suggest the more specific block (e.g. paste a YouTube URL → "this looks like a YouTube video — use the Video block, or click to embed as Embedded with provider auto-detected"). See `multi-page-grid-and-templates.md` precedent for "smart paste" routing.
+- **oEmbed call latency.** Some providers (Bandcamp, Spotify, Twitter) require a server-side oEmbed call to fetch resource title + thumbnail. This adds 100-500ms to block creation. Mitigation: cache the response in DB at create time (`resource_title`, `resource_thumbnail_url`); never re-fetch on render.
+
+### 5.6 Implementation sketch (Option A)
+
+DB schema (added to `blocks` table or as `block_data` JSONB depending on existing convention — match what Link/Video already use):
+
+```sql
+-- if Video block uses block_data JSONB with shape:
+--   { provider: 'youtube', video_id: '...', start_seconds: 0 }
+-- then Embedded block uses:
+--   { provider: 'spotify', resource_type: 'track',
+--     resource_id: '4iV5W9uYEdYUVa79Axb7Rh',
+--     resource_url: 'https://open.spotify.com/track/4iV5W9uYEdYUVa79Axb7Rh',
+--     resource_title: 'Despacito', resource_thumbnail_url: 'https://...',
+--     embed_height: 152 }
+```
+
+Frontend resolver (TypeScript):
+
+```ts
+// src/lib/embedded-block/resolvers.ts
+
+export type EmbeddedProvider =
+  | "spotify" | "soundcloud" | "bandcamp" | "apple-podcasts" | "apple-music"
+  | "youtube" | "vimeo" | "tiktok" | "twitter" | "bluesky" | "instagram" | "loom";
+
+export interface ResolvedEmbed {
+  provider: EmbeddedProvider;
+  resource_type: string;       // "track" | "album" | "post" | "video" | ...
+  resource_id: string;
+  embed_url: string;           // the URL we put in iframe src
+  embed_height: number;        // default px height
+  embed_aspect_ratio?: number; // for responsive (16/9, 1/1, ...)
+  needs_oembed_metadata: boolean; // call oEmbed to fetch title/thumb?
+  sandbox_flags: string;       // e.g. "allow-scripts allow-same-origin allow-popups"
+  csp_frame_src: string;       // host pattern for CSP allowlist
+}
+
+const RESOLVERS: Array<(url: URL) => ResolvedEmbed | null> = [
+  resolveSpotify,
+  resolveSoundCloud,
+  resolveBandcamp,
+  resolveApplePodcasts,
+  resolveAppleMusic,
+  resolveYouTube,
+  resolveVimeo,
+  resolveTikTok,
+  resolveTwitter,
+  resolveBluesky,
+  resolveInstagram,
+  resolveLoom,
+];
+
+export function resolveEmbedded(rawUrl: string): ResolvedEmbed | null {
+  let url: URL;
+  try { url = new URL(rawUrl); } catch { return null; }
+  for (const fn of RESOLVERS) {
+    const r = fn(url);
+    if (r) return r;
+  }
+  return null; // not whitelisted
+}
+```
+
+Each resolver function is ~20 LOC. Example:
+
+```ts
+function resolveSpotify(url: URL): ResolvedEmbed | null {
+  if (url.host !== "open.spotify.com") return null;
+  const m = url.pathname.match(/^\/(track|album|playlist|episode|show)\/([A-Za-z0-9]+)$/);
+  if (!m) return null;
+  const [, type, id] = m;
+  const heights = { track: 152, album: 352, playlist: 352, episode: 232, show: 232 };
+  return {
+    provider: "spotify",
+    resource_type: type,
+    resource_id: id,
+    embed_url: `https://open.spotify.com/embed/${type}/${id}`,
+    embed_height: heights[type as keyof typeof heights] ?? 352,
+    needs_oembed_metadata: true, // fetch title via spotify oEmbed
+    sandbox_flags: "allow-scripts allow-same-origin allow-popups allow-forms",
+    csp_frame_src: "https://open.spotify.com",
+  };
+}
+```
+
+Render component:
+
+```tsx
+function EmbeddedBlock({ data }: { data: BlockData }) {
+  const { embed_url, embed_height, sandbox_flags, resource_title, provider } = data;
+  return (
+    <div className={`embedded-block embedded-block--${provider}`}>
+      <iframe
+        src={embed_url}
+        title={resource_title}
+        height={embed_height}
+        width="100%"
+        sandbox={sandbox_flags}
+        loading="lazy"
+        referrerPolicy="strict-origin-when-cross-origin"
+        allow="encrypted-media; clipboard-write"
+      />
+    </div>
+  );
+}
+```
+
+Editor UX:
+
+1. Creator clicks "Add block" → "Embedded".
+2. Modal opens with single input: "Paste a URL".
+3. As they paste, frontend calls `resolveEmbedded(url)`. If null, show "We don't support this site yet — try [request a provider](#)".
+4. If matched, preview the iframe inline in the modal with provider name + resource title (fetched via oEmbed call to backend).
+5. "Save" → POST to `/api/blocks` with `block_type=embedded` + resolved data.
+
+Backend Edge Function `resolve-embedded`:
+
+- Input: `{ url: string }`
+- Output: `{ provider, resource_type, resource_id, embed_url, embed_height, sandbox_flags, csp_frame_src, resource_title?, resource_thumbnail_url? }`
+- For providers with oEmbed: server-side fetch `https://provider/oembed?url=<encoded>` to get `title` + `thumbnail_url`.
+- 5-second timeout; if oEmbed fails, return resolved data without `resource_title` (creator can edit it manually).
+- Cached in Supabase with key `(provider, resource_id)` for 24h to avoid hammering provider oEmbed APIs.
+
+### 5.7 Edge cases (Option A)
+
+- **Provider URL changes format** (e.g. Spotify adds new resource type `chapter` for podcast chapters). Mitigation: ship a `unknown-resource-type` fallback that uses `embed_height: 352` and lets the iframe render whatever the provider returns. Add to whitelist regex in next release.
+- **Provider oEmbed endpoint goes down.** Mitigation: oEmbed is called only at create-time for metadata. Render-time iframe works without oEmbed. So a Spotify oEmbed outage means new blocks save without title (degraded), existing blocks unaffected.
+- **Provider blocks our user-agent on oEmbed.** Some providers rate-limit. Mitigation: identify ourselves as `tadaify-embed-resolver/1.0 (+https://tadaify.com/embed-info)` and respect 429s; fall back to no-metadata mode.
+- **Creator pastes a non-canonical URL** (e.g. a Spotify share link with `?si=...` tracking parameter, or a TikTok URL with `/?_r=1&_t=...`). Mitigation: each resolver normalizes — strips query string, anchors, tracking params, then re-checks against the regex.
+- **Creator pastes a URL behind a login wall** (private Spotify playlist, private Loom video). The iframe will render the provider's "Login required" UI. Acceptable — creator's problem, not ours. Show a tooltip in editor: "If your visitors can't see this, the resource may be private."
+- **Creator embeds the same provider twice on one page** (two Spotify tracks). Should just work — each block is independent. Page-load perf may suffer (each iframe = one extra HTTP cascade). Mitigation: enforce `loading="lazy"` on every iframe; warn in editor at >5 embedded blocks.
+
+---
+
+## 6. Option B — generic iframe with whitelist
+
+### 6.1 What it is
+
+Same UX as Option A from creator's POV (paste URL → preview → save) but the resolver is **just a host-whitelist check**, not a per-provider URL parser. The URL is passed unchanged into the iframe `src`.
+
+```ts
+const HOST_WHITELIST = new Set([
+  "open.spotify.com",
+  "w.soundcloud.com",
+  "bandcamp.com",
+  "embed.podcasts.apple.com",
+  // ... ~50 hosts
+]);
+
+function resolveEmbeddedB(rawUrl: string): { embed_url: string } | null {
+  const url = new URL(rawUrl);
+  if (!HOST_WHITELIST.has(url.host)) return null;
+  return { embed_url: rawUrl };
+}
+```
+
+### 6.2 Pros (Option B)
+
+- **Faster to ship per provider.** Adding a new provider = one line in `HOST_WHITELIST`. No regex, no embed URL template, no per-resource-type height.
+- **Supports providers without a clean URL → embed mapping.** If a provider says "use this URL directly in an iframe", we just whitelist the host.
+- **Simpler code.** ~50 lines vs ~500 lines for Option A's 12 resolvers.
+
+### 6.3 Cons (Option B)
+
+- **Creator has to figure out the embed URL themselves.** Spotify shares a watch URL (`open.spotify.com/track/...`) but the embed URL is `open.spotify.com/embed/track/...`. The creator needs to know to paste the latter, not the former. Bad UX. Half of creators will paste the wrong URL and see "your URL is not on our whitelist" because we whitelisted `open.spotify.com/embed/...` not `open.spotify.com/...`.
+- **No height/aspect-ratio guidance per resource type.** A Spotify track is 152px tall; an album is 352px. Without per-provider knowledge, we either pick one wrong default or force creator to set height manually (more bad UX).
+- **No oEmbed metadata fetch.** No title, no thumbnail in editor preview. Creator pastes a URL and sees... a generic iframe with no idea if the URL is correct.
+- **No URL normalization.** Tracking parameters, shorteners, redirects all break embed-or-not predictability.
+- **More attack surface.** With Option A, the iframe `src` is constructed from a known template. With Option B, the creator-supplied URL is passed through. URL fragment XSS, query parameter injection, open-redirect chaining via the embed URL — all possible if any whitelisted host has any such bug. Whitelisting hosts ≠ whitelisting all URLs on those hosts.
+- **CSP allowlist becomes wide.** With Option A we know exactly which hostnames need to be in CSP `frame-src`. With Option B, our CSP is roughly "all 50 whitelisted hosts" — bigger blast radius if any of them gets compromised.
+
+### 6.4 When B becomes viable
+
+If we hit 50+ providers and per-provider engineering is the bottleneck, B's "just add to whitelist" model wins on ops velocity. But at that point we're competing with Iframely (which has 1900+ providers) so we should evaluate buying Iframely, not rolling our own permissive whitelist.
+
+For MVP: Option A wins.
+
+---
+
+## 7. Option C — kill the block, fold capabilities into Link / Video
+
+### 7.1 What it is
+
+Remove the Embedded block entirely. Either:
+
+- **C.1 — Fold into Video.** Video block grows a `provider` enum from `[youtube, vimeo]` to `[youtube, vimeo, spotify, soundcloud, bandcamp, twitter, instagram, ...]`. Rename the block to "Media" or "Inline Player".
+- **C.2 — Fold into Link.** Link block gets a "Show inline preview" toggle. When enabled and the URL is recognized (e.g. Spotify), render the provider iframe instead of the link card.
+- **C.3 — Both.** Each provider goes into the most natural existing block.
+
+### 7.2 Pros (Option C)
+
+- **No new block type.** Editor stays at 5 blocks (Link, Image, Video, Text, Shop). Less to teach creators.
+- **Slight code consolidation.** Resolver logic reused inside Video / Link.
+
+### 7.3 Cons (Option C)
+
+- **Naming lies.** Video block with a `provider: "twitter"` is not a video. Link block with "show inline preview" that happens to render an iframe is not a link.
+- **Data model bloat.** Video block schema balloons with 30 provider-specific fields.
+- **UX confusion.** Creator looking for "where do I add a Spotify player?" goes to Video block, doesn't find Spotify, gives up. Or goes to Link block, doesn't find an embed option, uses an external link → page degraded.
+- **Loses the abstraction.** "I want to embed something on my page" is a single mental model. Splitting it across Video and Link is leaky.
+- **Can't display Twitter/Instagram/Bluesky posts.** These are not videos and not links — they are posts with reactions, replies, avatar. Forcing them into Video or Link strips the metadata that makes them useful.
+
+### 7.4 Verdict on C
+
+**Reject.** The naming + UX cost is high; the savings are minimal (one block in the library, ~2 days of editor work). Keeping a dedicated Embedded block is cleaner and ships in the same time.
+
+---
+
+## 8. Security analysis
+
+### 8.1 Attack surfaces
+
+For each option, the relevant attack surfaces are:
+
+| Surface | Option A (oEmbed-only, URL constructed) | Option B (URL whitelist) | Option C (folded) |
+|---|---|---|---|
+| **Creator pastes XSS payload** | Blocked — URL parsed, iframe src constructed from template. Payload can't reach iframe. | Partial — payload in URL query string passed through to whitelisted host. Depends on provider not having reflected XSS. | Same as A or B per provider. |
+| **Creator pastes open-redirect URL** | Blocked — only canonical embed URLs match resolver regex. | Possible — `open.spotify.com/track/X?redirect=evil.com` if provider has open redirect. | Same as A or B. |
+| **Creator embeds malicious provider** | Blocked — host not in whitelist → resolver returns null. | Blocked — same. | Same. |
+| **Provider gets compromised, serves XSS via iframe** | Mitigated by sandbox flags + CSP. Provider can still execute scripts in iframe context, but not in tadaify origin. | Same. | Same. |
+| **Clickjacking via iframe** | Iframes are sandboxed; tadaify doesn't render in an iframe (X-Frame-Options: DENY on tadaify itself). | Same. | Same. |
+| **Cookie theft from logged-in visitor** | iframe is on different origin (open.spotify.com etc.); browser SOP blocks cross-origin cookie access from sandboxed iframe. | Same. | Same. |
+| **Tracking / fingerprinting** | Each provider iframe loads provider's tracking. Disclosed in tadaify privacy notice. | Same. | Same. |
+| **Mixed content (http inside https tadaify)** | Resolver enforces `https://` only. | Should also enforce. | Same. |
+
+### 8.2 Sandbox flags
+
+For each provider, ship the **minimum** sandbox flags needed for the iframe to function. Example per-provider matrix:
+
+| Provider | `allow-scripts` | `allow-same-origin` | `allow-popups` | `allow-forms` | `allow-presentation` (fullscreen) | Reasoning |
+|---|---|---|---|---|---|---|
+| Spotify | Yes | Yes | Yes | No | Yes | Player needs JS + same-origin for auth cookie + popup for "open in app" + fullscreen for video podcasts |
+| SoundCloud | Yes | Yes | Yes | No | No | Same minus fullscreen |
+| Bandcamp | Yes | Yes | Yes | No | No | Player + Buy popup |
+| Apple Podcasts | Yes | Yes | Yes | No | No | Player + Open in Apple Podcasts popup |
+| Apple Music | Yes | Yes | Yes | No | Yes | Player + popup + AirPlay fullscreen |
+| YouTube | Yes | Yes | Yes | No | Yes | Player + popup + fullscreen |
+| Vimeo | Yes | Yes | Yes | No | Yes | Player + popup + fullscreen |
+| TikTok | Yes | Yes | Yes | No | No | Player + popup |
+| Twitter / X | Yes | Yes | Yes | No | No | Tweet card + popup for reply |
+| Bluesky | Yes | Yes | Yes | No | No | Same |
+| Instagram | Yes | Yes | Yes | No | No | Post card + popup |
+| Loom | Yes | Yes | Yes | No | Yes | Player + popup + fullscreen |
+
+**Critical caveat:** when iframe `src` is the **same origin as the embedding page**, `allow-scripts` + `allow-same-origin` together let the iframe break out of the sandbox by removing the sandbox attribute and reloading. **This only matters if the iframe and the embedder share an origin.** For tadaify, every embed is cross-origin (Spotify is `open.spotify.com`, tadaify is `tadaify.com`), so the combination is safe. Document this in code comments to prevent future regression where someone embeds tadaify-served HTML.
+
+### 8.3 CSP `frame-src` policy
+
+Tadaify ships a `Content-Security-Policy` header that includes:
+
+```
+frame-src 'self' https://open.spotify.com https://w.soundcloud.com https://bandcamp.com
+          https://embed.podcasts.apple.com https://embed.music.apple.com
+          https://www.youtube.com https://player.vimeo.com https://www.tiktok.com
+          https://platform.twitter.com https://embed.bsky.app
+          https://www.instagram.com https://www.loom.com;
+```
+
+**Maintenance:** the CSP is built from the resolver whitelist at build time. Adding a provider to the resolver auto-adds to CSP. Single source of truth.
+
+### 8.4 X-Frame-Options bypass concerns
+
+The CVE-2024-5691 disclosure (Mozilla bugzilla, May 2024) showed that an iframe with `sandbox` displaying a page that returns `X-Frame-Options: DENY` could be clickjacked via the browser's own error page. Mozilla patched this in Firefox 127. For tadaify: we don't intentionally embed pages that return XFO:DENY (those are exactly the providers that aren't on our whitelist). Defense-in-depth: ensure tadaify pages themselves return `X-Frame-Options: DENY` and `frame-ancestors 'self'` so tadaify can't be embedded inside another site as part of a clickjack chain.
+
+### 8.5 What happens if creator pastes a malicious URL?
+
+Walk through three concrete attacks:
+
+1. **Attack:** `<iframe src="javascript:alert(1)">` via paste.
+   - Option A: URL parsing throws (invalid scheme) → resolver returns null → block not created.
+   - Option B: URL parsing throws → resolver returns null → block not created.
+   - Mitigation: enforce `url.protocol === "https:"` early in every resolver.
+
+2. **Attack:** `https://open.spotify.com/track/X?param=<script>` (reflected XSS in Spotify, hypothetical).
+   - Option A: query string stripped during normalization → safe URL passed to iframe → no XSS.
+   - Option B: query string passed through → XSS executes inside Spotify origin (not tadaify). Browser SOP prevents access to tadaify cookies. Reputational hit only; no data leak.
+   - Both: dependence on Spotify not having such a bug. Real-world: providers on our whitelist are large enough to have hardened against reflected XSS.
+
+3. **Attack:** `https://attacker.example.com/looks-like-spotify` (host not on whitelist).
+   - Option A & B: resolver returns null → block not created → safe.
+
+4. **Attack:** open-redirect chain via Spotify URL `https://open.spotify.com/track/X?redirect=https://evil.example.com`.
+   - Option A: query string stripped → no redirect → safe.
+   - Option B: query string preserved → if Spotify implements that redirect param (they don't), iframe loads evil.com inside Spotify's origin context → still cross-origin from tadaify, browser SOP applies → reputational hit only.
+
+The conclusion: **Option A is meaningfully safer than Option B** because of URL normalization. The marginal cost (per-provider regex) is low.
+
+### 8.6 GDPR / cookie consent
+
+Each provider iframe sets its own cookies. From a GDPR perspective, tadaify is the controller of the page; the providers are joint controllers when their iframes load. We must:
+
+- Disclose in tadaify privacy policy: "Embedded blocks load third-party content from [list]. These services may set cookies and collect data per their own privacy policies."
+- Provide a per-provider opt-out (e.g. consent banner: "Allow embedded content?"). Until consent, render a placeholder thumbnail with "Click to load Spotify player" — common pattern.
+- Per-block consent state stored in localStorage, not server (no PII).
+
+This is a v1.5 add (consent UX); MVP can ship with the disclosure-only path and a single global "Embedded blocks may set cookies" notice in privacy policy, since most early-adopter creators won't have EU traffic at scale.
+
+---
+
+## 9. Cost-at-scale
+
+The Embedded block has **near-zero tadaify-side cost** at any scale — all rendering is client-side via provider iframes; the only server cost is the one-time oEmbed metadata fetch at block creation, which is cached in DB.
+
+### 9.1 Direct costs
+
+| Component | 100 DAU | 1k DAU | 10k DAU | 100k DAU | 1M DAU |
+|---|---|---|---|---|---|
+| Page render (iframe HTML) | $0 | $0 | $0 | $0 | $0 |
+| oEmbed call at block creation (1 per new block) | $0 | $0.01 | $0.10 | $1 | $10 |
+| Cache row in Supabase (one row per resolved embed) | $0 | $0 | $0 | $0.50 | $5 |
+| CDN bandwidth for embed iframe HTML wrapper (~2KB) | $0 | $0 | $0.01 | $0.10 | $1 |
+| **Total tadaify cost** | **~$0** | **~$0.01** | **~$0.11** | **~$1.60** | **~$16** |
+
+**Assumptions:**
+- ~10% of pages have an Embedded block.
+- oEmbed call avg 1KB request + 2KB response; cached for 24h then refreshed; ~100 calls/day at 10k DAU.
+- Edge Function cold-start cost negligible at this scale.
+- CDN serves the wrapper HTML (the iframe tag itself); provider serves the heavy assets.
+
+### 9.2 Indirect costs
+
+- **Provider rate limits on oEmbed.** Spotify: no documented rate limit for oEmbed (it's a public CDN endpoint). Twitter: 1500 req/15min from publish.twitter.com per IP. At 1M DAU and 1% block creation rate ≈ 10k calls/day spread across our IPs → well under any rate limit.
+- **Provider takedown risk.** If Spotify decides to deprecate oEmbed (unlikely; it's been stable for 6 years), we lose metadata fetch. Embeds keep working. Acceptable risk.
+
+### 9.3 Comparison vs alternatives
+
+| Approach | Cost at 100k DAU |
+|---|---|
+| Option A (oEmbed + curated whitelist) | ~$1.60/mo |
+| Option B (host whitelist, no oEmbed) | ~$0/mo (no oEmbed call) |
+| Option C (folded into Video/Link) | Same as A — provider costs are identical |
+| Iframely Cloud API (1900 providers) | $79/mo (Pro tier) → $399/mo (Business) |
+| Self-host Iframely on AWS | ~$30/mo (1 t3.small + RDS) |
+
+**Conclusion:** Option A is essentially free at MVP scale and remains under $20/mo even at 1M DAU. No tier gating needed (no real cost to gate against, per `feedback_no_fake_margin_tier_gating.md`). Iframely becomes cost-relevant only if we expand to 30+ providers AND have engineering capacity issues — not before MVP.
+
+---
+
+## 10. Recommendation
+
+**Ship Option A — oEmbed-based with curated 12-provider whitelist — for MVP.**
+
+Concrete plan:
+
+1. **MVP scope (this story):**
+   - DB column / JSONB shape for Embedded block data (per §5.6).
+   - Resolver functions for all 12 providers in `src/lib/embedded-block/resolvers.ts`.
+   - Edge Function `resolve-embedded` that calls oEmbed for the 7 providers that support it.
+   - Editor modal: paste URL → preview iframe → save.
+   - Render component: sandboxed iframe with provider-specific flags + per-block CSP allowlist.
+   - Mockup (mandatory per `feedback_mockup_full_feature_vision.md`) showing all 12 providers populated on a sample creator page.
+   - Unit tests for each resolver (12 × ~5 cases each = ~60 unit tests).
+   - Playwright plan for end-to-end paste → preview → save → render → visitor sees iframe.
+
+2. **v1.5 (next quarter):**
+   - Add 8 more providers (Mixcloud, Dailymotion, Twitch, Calendly, Tally, Typeform, Substack, Figma).
+   - Cookie consent banner per provider.
+   - Editor: smart-paste detection (if URL matches Embedded provider, suggest Embedded over Link).
+
+3. **v2 (later):**
+   - Decision point: do we hit 30+ providers? If yes, evaluate Iframely Cloud API vs continuing to roll our own.
+   - Decision point: do we offer a "request a provider" form to creators? Yes — collect demand data.
+   - Stretch: per-creator subdomain isolation (move to `<handle>.user-content.tadaify.io`) so we can safely offer "Custom HTML" block on top tier without polluting `tadaify.com` origin.
+
+**Reject Option B** (URL whitelist without per-provider parsing) — too many UX failures (wrong URL → broken iframe; no metadata; no height guidance) and marginally worse security.
+
+**Reject Option C** (fold into Video/Link) — naming + data model + UX cost outweigh saving one block in the library.
+
+---
+
+## 10b. Implementation breakdown — story decomposition
+
+The Embedded block MVP can ship as a single feature story, but the work decomposes naturally into 6 sub-tasks for review/PR-sizing purposes. Per `feedback_per_deliverable_verification.md` we ship one PR per sub-task and let the user click-test on DEV before the next.
+
+### 10b.1 Sub-task list
+
+| # | Sub-task | Estimate | Output | Risk |
+|---|---|---|---|---|
+| 1 | DB schema + Block type enum + JSONB shape | 1h | Migration `<ts>_add_embedded_block_type.sql`; TS types in `src/types/blocks.ts`; updated `delete_user_data()` RPC; updated user-export Edge Function | Low — additive only |
+| 2 | Resolver library — 12 providers + tests | 8h | `src/lib/embedded-block/resolvers.ts` + `src/lib/embedded-block/resolvers.test.ts` (~60 unit tests) | Low — pure functions, well-tested |
+| 3 | Edge Function `resolve-embedded` (oEmbed metadata) | 3h | `supabase/functions/resolve-embedded/index.ts` + unit tests + Supabase cache table for `(provider, resource_id) → metadata` | Medium — handles 7 different oEmbed APIs, each with quirks |
+| 4 | Editor UI — modal + paste + preview | 4h | `src/components/blocks/EmbeddedBlockEditor.tsx` + Storybook story + Playwright plan | Medium — UX edge cases (invalid URL, oEmbed fail, network slow) |
+| 5 | Render component — sandboxed iframe + CSP | 3h | `src/components/blocks/EmbeddedBlockRender.tsx` + CSP middleware update + per-provider sandbox flags table | Medium — security-critical, every flag matters |
+| 6 | Mockup + acceptance criteria + e2e plan | 3h | `claude-reports/mockups/<slug>/index.html` showing all 12 providers populated; `e2e/plans/<story-id>-embedded.plan.md` | Low — design work, no code risk |
+| **Total** | **~22h engineering + 3h ops/review** | | | |
+
+### 10b.2 Suggested PR order
+
+1. **PR 1 — schema + types + GDPR plumbing** (Sub-task 1). Lands first; no UI; safe to merge.
+2. **PR 2 — resolver library** (Sub-task 2). Pure code with unit tests; ships ahead of any UI.
+3. **PR 3 — Edge Function** (Sub-task 3). Backend ready before frontend can call it.
+4. **PR 4 — render component + CSP** (Sub-task 5). Public-facing render contract before editor.
+5. **PR 5 — editor + mockup + plan** (Sub-tasks 4 + 6). Closes the loop; user click-tests on DEV.
+6. **PR 6 — Playwright spec** (post-merge, separate Opus dispatch via `test-spec-generator`).
+
+### 10b.3 Acceptance criteria (story-level)
+
+When this MVP story is "done":
+
+- [ ] Creator can add an Embedded block to any page from the block library.
+- [ ] All 12 providers in §5.2 successfully resolve from a canonical URL.
+- [ ] Editor preview renders the iframe within 2 seconds of paste.
+- [ ] Invalid / non-whitelisted URL shows a clear error with "request a provider" link.
+- [ ] Saved blocks persist across reload and render on the public creator page.
+- [ ] Public render uses correct sandbox flags per provider (table §8.2).
+- [ ] CSP `frame-src` includes only the 12 whitelisted hosts.
+- [ ] All 60 unit tests pass.
+- [ ] e2e plan exists for paste → preview → save → render → visitor sees iframe.
+- [ ] Mockup matches the final implementation pixel-for-pixel.
+- [ ] User-export Edge Function includes `block_data` for embedded blocks.
+- [ ] `delete_user_data()` cascades correctly (no orphan rows).
+
+### 10b.4 Edge cases to spec in `e2e/plans/<story-id>-embedded.plan.md`
+
+The following ECNs need to be enumerated at refinement and either covered or explicitly deferred (per `feedback_refinement_includes_test_plans.md`):
+
+- **ECN-EMBED-01:** Creator pastes a Spotify share URL with `?si=...` tracking param → resolver normalizes, embed renders correctly without param leakage.
+- **ECN-EMBED-02:** Creator pastes an Apple Podcasts URL from a country other than `us` (e.g. `podcasts.apple.com/pl/podcast/...`) → resolver respects country code; iframe renders Polish UI.
+- **ECN-EMBED-03:** Creator pastes a private SoundCloud track URL → iframe renders SoundCloud's "Track unavailable" UI; tooltip in editor warns "If your visitors can't see this, the resource may be private".
+- **ECN-EMBED-04:** Creator pastes an Instagram URL but tadaify's Facebook App ID has expired (oEmbed call fails) → fallback to "instagram-no-metadata" mode; embed still renders; creator can manually edit title.
+- **ECN-EMBED-05:** Creator pastes a Bluesky URL where the post has been deleted between save-time and render-time → iframe renders Bluesky's "Post deleted" UI; no tadaify error.
+- **ECN-EMBED-06:** Creator embeds 5 Spotify blocks on one page → all 5 lazy-load; first-paint <2s.
+- **ECN-EMBED-07:** Creator embeds an oEmbed provider during a network outage → `resolve-embedded` Edge Function returns 503 within 5s; editor shows "couldn't fetch metadata, save anyway?".
+- **ECN-EMBED-08:** Creator pastes a YouTube URL where the video has age restrictions → iframe shows YouTube's "Sign in to confirm your age" UI; we don't try to bypass.
+- **ECN-EMBED-09:** Visitor with an ad-blocker that blocks `open.spotify.com` views the page → iframe is blocked at network layer; tadaify renders a fallback "Embedded content blocked by your browser" placeholder via `<iframe onerror>`.
+- **ECN-EMBED-10:** Creator deletes an Embedded block → row removed; oEmbed cache row stays (cache reused if creator re-embeds same URL).
+- **ECN-EMBED-11:** Tadaify CSP `frame-src` mismatched (deployment skipped) → iframe is blocked by CSP; visitor sees "blocked by CSP" in console; render component logs to Sentry. This is a deploy-time bug class — covered by §10b.5 below.
+- **ECN-EMBED-12:** Creator embeds a Bandcamp URL but Bandcamp's track ID lookup (scraping page meta) fails → fall back to URL-only mode; embed renders; no thumbnail.
+
+Of these, ECN-01 through ECN-08 are unit-testable in the resolver. ECN-09 through ECN-12 need either Playwright or integration tests.
+
+### 10b.5 CI gate for CSP drift
+
+Per `feedback_lambda_ci_deps_gate.md` and `feedback_env_var_grep_before_deploy.md`, every deploy that ships frontend code MUST:
+
+1. **CI step: CSP-resolver consistency check.** A unit test that imports both the resolver whitelist (12 hostnames) and the CSP middleware (the `frame-src` directive string) and asserts they match. Drift fails CI.
+2. **CI step: oEmbed endpoint reachability.** Optional — not every deploy. A nightly cron checks `https://open.spotify.com/oembed?url=X` and the other 6 endpoints; alarms if any go from 200 to non-200 for >2 consecutive runs.
+
+These prevent the production-firefighting class of bugs.
+
+---
+
+## 10c. Comparison vs Iframely (the buy-vs-build calculation)
+
+If we ever consider buying instead of building, here's the head-to-head.
+
+### 10c.1 Iframely Cloud pricing (April 2026)
+
+| Tier | Price | API calls/mo | Domains supported | Notes |
+|---|---|---|---|---|
+| Free | $0 | 1,000 | All 1,900 | No SLA; rate-limited |
+| Starter | $25/mo | 10,000 | All 1,900 | No SLA |
+| Pro | $79/mo | 100,000 | All 1,900 | 99.5% SLA |
+| Business | $399/mo | 1,000,000 | All 1,900 | 99.9% SLA + dedicated support |
+| Enterprise | Custom | Custom | All 1,900 + custom | + on-prem |
+
+(Pricing per public iframely.com/pricing as of 2026-04-26 — confirm before any purchase decision.)
+
+### 10c.2 Self-host Iframely (open source `itteco/iframely`)
+
+- AWS cost: ~$30/mo for 1× t3.small EC2 + RDS Postgres for cache + ALB.
+- Setup: ~1 day engineering for Terraform module + IAM + secrets.
+- Maintenance: ~2h/mo to apply upstream updates.
+- Pros: 1,900 providers out of the box; no per-call billing; we control the cache.
+- Cons: another service to operate; updates require attention; cache is our problem.
+
+### 10c.3 Roll-your-own decision matrix
+
+| Factor | Roll-your-own (12 providers) | Iframely Cloud Pro | Self-host Iframely |
+|---|---|---|---|
+| Initial engineering | 22h | 4h | 8h |
+| Monthly cost (10k DAU) | $0 | $79 | $30 |
+| Monthly cost (100k DAU) | ~$2 | $79 | $30 |
+| Monthly cost (1M DAU) | ~$16 | $399 | $40 |
+| Provider coverage | 12 (95% of demand) | 1,900 (99.9% of demand) | 1,900 |
+| Vendor lock-in | None | Iframely API surface | Open source — no lock |
+| Security blast radius | Smallest (we construct iframe src) | Medium (Iframely returns HTML) | Medium |
+| Time-to-add-provider | 2h | 0h | 0h |
+| Fits MVP scope | YES | Yes (overkill) | Yes (overkill) |
+
+**Recommendation reaffirmed: roll-our-own for MVP.** Buy/self-host becomes interesting only if we cross 30+ provider requests AND have engineering capacity issues. Realistic timeline for that crossover: 12+ months post-MVP.
+
+### 10c.4 Hybrid path (if we change our minds in v2)
+
+We can hybridize without rewriting: keep our 12 native resolvers (best UX, smallest blast radius), and fall back to Iframely for "everything else" providers gated to the paid tier. The data model already supports this — `provider` field expands from a 12-value enum to a `string` with a separate `resolved_via: "native" | "iframely"` discriminator. Future-friendly.
+
+---
+
+## 11. Open DECs for user
+
+### DEC-EMBED-01 — oEmbed-only Y/N for v1?
+
+- **Czego dotyczy:** scope of the Embedded block in MVP — strict oEmbed-only with 12 whitelisted providers, or also accept iframe-paste fallback (Beacons-style)?
+- **Szczegolowy opis:** Option A as specified above is oEmbed-only — creator pastes a URL, we resolve it through one of 12 per-provider resolvers, and only matched URLs work. An alternative is to also accept "iframe paste" (creator copies the iframe code from the provider's "Share → Embed" UI and pastes it into tadaify). This is what Beacons does. It supports more providers but has security risk (creator could paste malicious iframe).
+- **Opcje:**
+  1. oEmbed-only, 12 providers, no iframe paste in MVP. (recommended)
+  2. oEmbed + iframe-paste fallback gated to specific allowed iframe sources.
+  3. Iframe-paste only on top tier (paid plan).
+- **Twoja rekomendacja:** **1.** Iframe paste is a security regression we don't need to take in MVP. The 12 providers cover ~95% of demand and we can always add iframe-paste in v2 once we have proper origin isolation.
+
+### DEC-EMBED-02 — initial whitelist of 12 providers — confirm?
+
+- **Czego dotyczy:** which 12 providers ship in MVP.
+- **Szczegolowy opis:** §5.2 lists Spotify, SoundCloud, Bandcamp, Apple Podcasts, Apple Music, YouTube, Vimeo, TikTok, Twitter/X, Bluesky, Instagram, Loom. Removing or substituting providers changes the engineering scope (each provider ≈ 2 hours).
+- **Opcje:**
+  1. Ship the named 12 as listed.
+  2. Drop Apple Music + Apple Podcasts (lower demand for early adopters per `competitors-user-segments.md`); add Calendly + Tally instead.
+  3. Drop YouTube and Vimeo from Embedded since they're already in Video block; ship 10 instead.
+- **Twoja rekomendacja:** **1.** The named 12 hit every creator segment in our research. YouTube/Vimeo overlap with Video is fine — let them coexist; smart-paste will route correctly. Apple Music + Apple Podcasts matter more than Calendly for a creator-page MVP (forms/booking are v1.5).
+
+### DEC-EMBED-03 — Iframely vendor or roll-your-own?
+
+- **Czego dotyczy:** for the per-provider parsing work, do we use Iframely (paid SaaS, 1900+ providers) or write resolvers ourselves?
+- **Szczegolowy opis:** Iframely is the standard third-party oEmbed proxy. Their cloud API costs $79-$399/mo and supports 1900+ providers out of the box. Self-host is ~$30/mo on AWS. Roll-your-own is ~24 hours engineering for 12 providers + ~2 hours per future provider.
+- **Opcje:**
+  1. Roll our own, 12 providers, ~24 hours engineering. (recommended for MVP)
+  2. Use Iframely Cloud Pro ($79/mo) immediately — get 1900+ providers, near-zero engineering.
+  3. Self-host Iframely on AWS (~$30/mo + ~1 day setup).
+- **Twoja rekomendacja:** **1.** Roll our own for MVP. The 12-provider scope is bounded and the resolver code is straightforward. We avoid a vendor dependency on a critical-path feature, and we keep iframe `src` construction inside our own code (security win — see §8.5). Re-evaluate when whitelist exceeds 30 providers or engineering can't keep up with creator demand.
+
+### DEC-EMBED-04 — per-tier gating?
+
+- **Czego dotyczy:** is the Embedded block free / tier-gated?
+- **Szczegolowy opis:** tadaify has Free / Pro / Business tiers (per pricing research). Some features are gated (e.g. custom domain, analytics depth). Embedded block has zero tadaify-side cost (per §9), so no real-cost basis to gate it. But Linktree / Beacons gate "advanced embeds" to paid tiers as a perceived-value lever.
+- **Opcje:**
+  1. Free tier — Embedded block available with all 12 providers. (recommended)
+  2. Free tier — only 4 providers (YouTube + Spotify + Twitter + Instagram); paid tier — all 12.
+  3. Free tier — no Embedded block at all; paid-only.
+- **Twoja rekomendacja:** **1.** Per `feedback_no_fake_margin_tier_gating.md`, we don't gate on fake costs. Embedded is free across all tiers. We can still differentiate paid tiers on real-cost levers (custom domain, multi-page, analytics retention).
+
+### DEC-EMBED-05 — block-level only, or "embed entire page" mode?
+
+- **Czego dotyczy:** is Embedded a block within a tadaify page, or also a way to make an entire page = an embed (e.g. "this page IS my Substack subscribe form fullscreen")?
+- **Szczegolowy opis:** some creators want a single-purpose page that is just a Calendly widget fullscreen. We could either (a) keep Embedded as a block (creator builds a page with one Embedded block + maybe a header), or (b) add a "Page type: Embed" mode that makes the entire `/<handle>/<slug>` page render the iframe with no chrome.
+- **Opcje:**
+  1. Block-level only. Page type stays normal; creator can build a 1-block page if they want a single embed. (recommended)
+  2. Add "Embed page type" as a new template. ~1 extra day of engineering.
+  3. Defer entire-page-embed to v2 based on real demand signal.
+- **Twoja rekomendacja:** **1.** Same outcome as 3 (no entire-page mode in MVP) but cleaner — we don't promise a future feature, we just leave the door open. If a creator complains, they can build a one-block page in 30 seconds.
+
+---
+
+## Sources
+
+- [oEmbed.com — official spec](https://oembed.com/)
+- [oEmbed providers registry](https://oembed.com/providers.json) — 378 registered providers
+- [iamcal/oembed GitHub repo](https://github.com/iamcal/oembed) — registry source-of-truth
+- [Spotify oEmbed reference](https://developer.spotify.com/documentation/embeds/reference/oembed)
+- [Spotify Embeds documentation](https://developer.spotify.com/documentation/embeds)
+- [Beacons.ai — Music Block (Bandcamp, YouTube Music, Spotify, SoundCloud)](https://help.beacons.ai/en/articles/4696705)
+- [Beacons.ai — Video Block (YouTube, Vimeo, TikTok)](https://help.beacons.ai/en/articles/4696641)
+- [Beacons.ai — Find Music Embed URLs](https://help.beacons.ai/en/articles/4696833)
+- [Carrd — Embedding IFRAMEs](https://carrd.co/docs/building/embedding-iframes)
+- [Carrd — Embedding Custom Code](https://carrd.co/docs/building/embedding-custom-code)
+- [Stan Store — URL/Media product](https://help.stan.store/article/18-external-link-url-product)
+- [Linktree alternatives 2026 (taap.bio)](https://taap.bio/blog/best-linktree-alternatives)
+- [Bento.me shutdown — popout.page summary](https://www.popout.page/blog/bento-alternatives)
+- [Iframely — Provider docs](https://iframely.com/docs/providers)
+- [Iframely — itteco/iframely PROVIDERS.md](https://github.com/itteco/iframely/blob/main/docs/PROVIDERS.md)
+- [Iframely — Spotify domain](https://iframely.com/domains/spotify)
+- [Notion — Embeds, bookmarks & link mentions](https://www.notion.com/help/embed-and-connect-other-apps)
+- [MDN — `<iframe>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe)
+- [web.dev — Play safely in sandboxed IFrames](https://web.dev/articles/sandboxed-iframes)
+- [MDN — Content-Security-Policy: sandbox directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/sandbox)
+- [Mozilla bug 1888695 — CVE-2024-5691 iframe sandbox bypass via clickjacking on XFO error page](https://bugzilla.mozilla.org/show_bug.cgi?id=1888695)
+- [Bypassing X-Frame-Options — Requestly blog](https://requestly.com/blog/bypass-iframe-busting-header/)
+- [Pragmatic Web Security — Restrict framing in the browser](https://pragmaticwebsecurity.com/articles/securitypolicies/preventing-framing-with-policies.html)
+- [TikTok — Embedding TikTok Videos](https://developers.tiktok.com/doc/embed-videos/)
+- [Loom — oEmbed endpoint](https://www.loom.com/v1/oembed)
+- [Apple Podcasts — oEmbed endpoint](https://podcasts.apple.com/api/oembed)
+- [Bluesky — oEmbed endpoint](https://embed.bsky.app/oembed)

--- a/docs/research/linktree-newsletter-parity-scan.md
+++ b/docs/research/linktree-newsletter-parity-scan.md
@@ -1,0 +1,481 @@
+---
+type: research
+project: tadaify
+title: "Linktree newsletter integration parity scan — gap analysis vs SPIKE shortlist"
+created_at: 2026-04-26
+agent: opus-4-7
+related_issues: []
+tags: [tadaify, newsletter, linktree, competitive, mvp]
+status: accepted
+---
+
+# Linktree newsletter integration parity scan
+
+> **Scope.** The prior tadaify newsletter SPIKE (`tadaify-newsletter-providers-integration.md`, 2026-04-26) recommended four native providers + a generic webhook + Substack iframe. The user has since stated as an explicit MVP must: **tadaify must match Linktree's newsletter-integration coverage to be a viable Linktree competitor.** This document enumerates what Linktree actually ships in 2026, compares against the SPIKE shortlist, and recommends the MVP delta.
+>
+> **Verification timeframe.** All Linktree integration claims verified via WebSearch on 2026-04-26 against `linktr.ee/products/3rd-party-email-integrations`, the Linktree Help Center (`help.linktr.ee`), `linktr.ee/marketplace/integrations`, and provider-side directories (Klaviyo App Marketplace, Mailchimp Integrations directory). Where Linktree's own help center could not be fetched directly (Cloudflare 403 against the WebFetch user agent), claims are corroborated via multiple search-result snippets that quote the help center verbatim, plus provider-side marketplace pages.
+
+---
+
+## 1. Executive summary
+
+**Recommended MVP provider list (revised for Linktree parity):**
+
+1. **Kit (formerly ConvertKit)** — was in SPIKE; Linktree has it.
+2. **Mailchimp** — was CUT from SPIKE; **add back** because Linktree has it natively and that's the headline integration most "leaving Linktree for Plan B" creators name first.
+3. **Beehiiv** — was in SPIKE; **NOT in Linktree.** Keep — this is where we beat Linktree.
+4. **MailerLite** — was in SPIKE; **NOT in Linktree.** Keep — same reason; meaningful EU creator share Linktree leaves on the table.
+5. **Klaviyo** — was NOT in SPIKE; **add** because Linktree has it and we cannot say "Linktree parity" without it, even though Klaviyo is an awkward fit for the indie-creator persona.
+6. **Buttondown** — was in SPIKE; **NOT in Linktree.** Keep — small loyal indie/dev audience, cheap to ship, differentiator vs Linktree.
+7. **Generic webhook** — was in SPIKE; keep. Covers Substack-via-Zapier, Resend, ActiveCampaign, AWeber, GetResponse, Brevo, HubSpot, Loops, Ghost, EmailOctopus, in-house ESPs.
+8. **Google Sheets** — was NOT in SPIKE; **add** because Linktree has it and creators use it as the "I haven't picked an ESP yet, just give me the emails" escape hatch. Cheap (~0.5 dev day via Sheets API).
+9. **Substack iframe embed** — was in SPIKE; keep. Linktree has no native Substack integration either, so we are at parity.
+
+**Two-line rationale.** Linktree's native list (Mailchimp / Kit / Klaviyo / Google Sheets, Pro+ tier only) is narrower than the SPIKE thought, so parity requires only **two additions** to the SPIKE shortlist — Mailchimp and Klaviyo, plus Google Sheets — while the SPIKE picks (Beehiiv / MailerLite / Buttondown) are all NET-NEW vs Linktree and become explicit competitive differentiators. Total dev cost delta over SPIKE: **+2.25 dev days** for three new integrations, payable in week one of implementation.
+
+**Linktree-side matrix snapshot (verified 2026-04-26):**
+
+| Linktree integration | Status | Tier required | Auth flow |
+|---|---|---|---|
+| Mailchimp | NATIVE | Pro / Premium (also referenced as "Linktree Pro" on Mailchimp's directory) | OAuth — "Authorize Mailchimp" |
+| Kit (ConvertKit) | NATIVE | Pro / Premium | OAuth — "Authorize Kit" |
+| Klaviyo | NATIVE | Pro / Premium | OAuth — "Authorize Klaviyo" |
+| Google Sheets | NATIVE | All plans (free included for Sheets) | OAuth — Google sign-in |
+| Substack | NOT supported natively | n/a | Manual link/iframe by creator |
+| Beehiiv | NOT supported natively | n/a | Zapier workaround only |
+| MailerLite | NOT supported natively | n/a | Zapier workaround only |
+| Buttondown | NOT supported natively | n/a | Zapier workaround only |
+| ConvertKit "v3" (legacy) | Now branded Kit | n/a | n/a |
+| Resend, ActiveCampaign, AWeber, HubSpot, Brevo, Loops, Ghost, EmailOctopus | NOT supported natively | n/a | Zapier or webhook |
+
+---
+
+## 2. Linktree's current newsletter integrations — exhaustive enumeration
+
+### 2.1 What Linktree calls the feature
+
+Linktree's umbrella product term is **"Audience"** — the dashboard tab where contacts collected via Linktree forms are stored, segmented, and synced. Within that the **"Integrations"** sub-tab is where third-party email/CRM connections live.
+
+The block-level UI surface is the **"Email Signup"** link/block (sometimes referred to as "Email Signup Link" in the help center), and a separate **"Forms"** product (rolled out under the marketing line "Linktree Forms" in 2025) which is a richer multi-field form (name + email + custom fields). Both feed the same Audience system, so the four native integrations apply identically to both surfaces.
+
+Source: <https://linktr.ee/products/3rd-party-email-integrations> (verified 2026-04-26 via search-snippet quote: *"On Pro and Premium plans, you can connect Mailchimp, Klaviyo, Kit or Google Sheets to your Linktree to automatically sync data from your audience forms"*).
+
+### 2.2 Native integrations (the canonical four)
+
+#### 2.2.1 Mailchimp — NATIVE
+
+- **Product page:** <https://mailchimp.com/integrations/linktree/> (Mailchimp's own marketplace listing, verified 2026-04-26).
+- **Tier requirement:** Linktree Pro (or Premium). Mailchimp's directory text quoted verbatim from WebFetch on 2026-04-26: *"Connect with Mailchimp on Linktree Pro to create powerful campaigns."*
+- **Auth flow:** OAuth — the help-center setup steps say "click Connect under Mailchimp, then in Mailchimp select the list you'd like to sync new signups to" which is the Mailchimp OAuth-permission UI, not an API-key paste.
+- **Data flow:** Subscriber email (and any extra form fields) sync from Linktree's Audience store into a creator-chosen Mailchimp list.
+- **Historical:** Mailchimp was Linktree's FIRST native ESP integration, shipped in 2021 — Linktree's own update post `https://updates.linktr.ee/new-feature!-email-signup-mailchimp-integration-65169` confirms.
+- **Linktree help article:** <https://help.linktr.ee/en/articles/5434187-how-to-collect-email-sign-ups-on-your-linktree>.
+
+#### 2.2.2 Kit (formerly ConvertKit) — NATIVE
+
+- **Marketplace page:** <https://linktr.ee/marketplace/integrations/integration-kit> (verified 2026-04-26).
+- **Tier requirement:** Linktree Pro (search-snippet quote: *"Connect with Kit on Linktree Pro to create powerful, conversion-focused campaigns"*).
+- **Auth flow:** OAuth — *"Click Connect under Kit and click Authorize Kit and sign in to your Kit account"* (verbatim from Linktree help search-snippet).
+- **Data flow:** Subscribers sync into a Kit form/sequence. Kit's broader marketplace also lists Linktree as a partner integration on `kit.com` (anecdotally — the official Kit→Linktree Compare page exists at <https://kit.com/compare>).
+- **Historical:** Added during the ConvertKit→Kit rebrand window in 2024–2025, replacing the older Zapier-only path.
+
+#### 2.2.3 Klaviyo — NATIVE
+
+- **Linktree marketplace page:** <https://linktr.ee/marketplace/apps/integration-klaviyo> (verified 2026-04-26).
+- **Klaviyo App Marketplace listing:** <https://marketplace.klaviyo.com/en-us/apps/01JSM2ZDZSE3TADKCSB66SVN0A/> (verified 2026-04-26).
+- **Help-center setup article:** <https://help.linktr.ee/en/articles/11614384-connecting-klaviyo-to-your-linktree>.
+- **Tier requirement:** Pro / Premium.
+- **Auth flow:** OAuth — *"Click Authorize Klaviyo and sign in to your Klaviyo account. Your existing and future Linktree contacts will start syncing automatically with Klaviyo"* (verbatim, search-snippet).
+- **Note:** Klaviyo is an SMB-eCommerce-leaning ESP, not creator-economy first. Linktree integrating it suggests their target audience increasingly includes Shopify-class merchants alongside creators; tadaify's positioning as a creator-page tool may make Klaviyo a lower-priority target for OUR audience even though Linktree ships it.
+
+#### 2.2.4 Google Sheets — NATIVE
+
+- **Tier requirement:** ALL plans, **including Free** (search-snippet quote: *"syncing contacts to Google Sheets is available to users on all plans"*). This is significant — Sheets is Linktree's free-tier funnel for the email-collection feature.
+- **Auth flow:** Google OAuth (sign in with Google + grant Sheets API access).
+- **Data flow:** Each new audience submission appends a row to a Sheet the creator picks. From there the creator manually exports / imports into any other tool.
+- **Note:** This is the de facto fallback for any ESP Linktree doesn't natively integrate. Workflow: Linktree → Sheet → manual CSV → ESP import, OR Sheet → Zapier → ESP. The fact that Linktree gives it on the FREE tier is a strong indicator they consider it the safety net.
+- **Help article:** <https://linktr.ee/help/linktree-ff524ba1864c/en/articles/5434187-how-to-set-up-email-signup-links-mailchimp-and-google-sheet>.
+
+### 2.3 Substack — iframe embed only, no native form
+
+Linktree has **no native Substack integration**. Creators wanting Substack subscribers from their Linktree page have two options:
+
+- (a) Add a regular **Link** block pointing at the Substack signup page (visitor leaves Linktree, fills Substack form, returns).
+- (b) Use the third-party `substackapi.com` custom-embed tool to render a styled Substack form which they then iframe into a custom embed slot — possible only on Linktree's higher-tier custom-HTML capable surfaces, which Linktree itself does not officially expose.
+
+Cited URLs: <https://support.substack.com/hc/en-us/articles/360041759232-Can-I-embed-a-signup-form-for-my-Substack-publication> (Substack's own embed docs) and <https://substackapi.com/docs/how-to-embed-your-substack-signup-form-on-any-website> (community workaround). Verified 2026-04-26.
+
+This puts tadaify and Linktree at **functional parity for Substack**: neither has a native API integration (because Substack has no public API), but both can work around it via embed. The SPIKE's Substack-iframe recommendation gives us at-least-Linktree-equivalent Substack support.
+
+### 2.4 Zapier-mediated providers (NOT native)
+
+Linktree exposes a **Zapier connector** via its Marketplace (the Linktree app on Zapier predates the native Audience integrations). This is how creators reach every other ESP today:
+
+- Beehiiv via Zapier — see <https://zapier.com/apps/beehiiv/integrations/convertkit> for the broader Beehiiv-Zapier bridge.
+- MailerLite via Zapier — same pattern.
+- ConvertKit historical (pre-native) via Zapier — <https://zapier.com/shared/collect-linktree-email-subscribers-and-add-to-tag-in-convertkit/e81f6dbb57a5686309424766a2725741c0f4ff79> (verified 2026-04-26).
+- AWeber, GetResponse, ActiveCampaign, HubSpot, Brevo (Sendinblue), Loops, EmailOctopus, Resend Audiences, Ghost — all via Zapier.
+
+Zapier integrations are NOT first-class in Linktree's UI: the creator has to leave Linktree, set up a Zap, paste an API key into Zapier, and pay for Zapier (free tier is 100 tasks/month). For tadaify's "creator pastes API key into our block, done" UX target, Zapier-only providers are equivalent to the **generic webhook fallback** in our SPIKE — we should NOT count Zapier-mediated availability as Linktree parity for any specific provider.
+
+### 2.5 Conspicuous absences in Linktree
+
+Verified 2026-04-26 — Linktree does NOT have native integrations for any of:
+
+- **Beehiiv** (the fastest-growing creator-newsletter platform in 2024-2025; explicit gap).
+- **MailerLite** (SMB-popular with strong EU presence; explicit gap).
+- **Buttondown** (indie/dev-creator favourite; explicit gap).
+- **Substack** (no public API; gap is shared with everyone — see §2.3).
+- **Resend** (developer-focused; gap is shared, fits webhook tier).
+- **AWeber, GetResponse, ActiveCampaign, HubSpot, Brevo, Loops, Ghost, EmailOctopus** (all Zapier-only).
+
+This is the gap tadaify can lean into for competitive positioning: *"every ESP Linktree forces you to wire through Zapier, we ship as a one-paste-and-done block."*
+
+---
+
+## 3. Gap analysis vs the SPIKE shortlist
+
+Single-table cross-reference. Sources for "in Linktree" column: §2 above; sources for "in SPIKE" column: `tadaify-newsletter-providers-integration.md` §5.
+
+| Provider | In Linktree? | In SPIKE shortlist? | Add to MVP? | Notes |
+|---|---|---|---|---|
+| **Kit (ConvertKit)** | ✅ Native (Pro+) | ✅ Ship v1 | ✅ KEEP | Both lists already include — no change |
+| **Mailchimp** | ✅ Native (Pro+) | ❌ Cut from MVP (defer to v2) | ✅ **ADD BACK** | Linktree-parity-must overrides SPIKE deferral. See §4 |
+| **Klaviyo** | ✅ Native (Pro+) | ❌ Not considered in SPIKE | ✅ **ADD** | Required for parity claim. Lower priority for tadaify's target audience but cannot say "Linktree parity" without |
+| **Google Sheets** | ✅ Native (ALL plans incl. Free) | ❌ Not considered in SPIKE | ✅ **ADD** | Cheap. Free-tier safety net. Matches Linktree's free-tier funnel |
+| **Substack** | ⚠️ No native (iframe workaround) | ✅ Ship v1 (iframe variant) | ✅ KEEP | Parity: both rely on iframe |
+| **Beehiiv** | ❌ Not in Linktree (Zapier only) | ✅ Ship v1 | ✅ KEEP — DIFFERENTIATOR | Net-new vs Linktree |
+| **MailerLite** | ❌ Not in Linktree (Zapier only) | ✅ Ship v1 | ✅ KEEP — DIFFERENTIATOR | Net-new vs Linktree |
+| **Buttondown** | ❌ Not in Linktree (Zapier only) | ✅ Ship v1 | ✅ KEEP — DIFFERENTIATOR | Net-new vs Linktree |
+| **Generic webhook** | ❌ Not directly (Zapier is the equivalent) | ✅ Ship v1 | ✅ KEEP | Catches ESPs not in either list |
+| **Resend** | ❌ Not in Linktree | ❌ Cut from MVP | ❌ Stay cut | DOI-not-built-in still a foot-gun. Webhook covers if needed |
+| **AWeber / GetResponse / ActiveCampaign / HubSpot / Brevo / Loops / Ghost / EmailOctopus** | ❌ Zapier-only in Linktree | Out of SPIKE scope | ❌ Webhook covers | Long tail — not worth native integration in v1 |
+
+**Net delta vs SPIKE recommendation:** add Mailchimp + Klaviyo + Google Sheets. That's it. Three additions, all justified by direct Linktree presence.
+
+**Net delta vs Linktree:** keep Beehiiv + MailerLite + Buttondown + generic webhook. Four differentiators we can market explicitly.
+
+---
+
+## 4. MVP scope recommendation (final)
+
+### 4.1 Final ship list
+
+| # | Provider | Source of inclusion | Marketing positioning |
+|---|---|---|---|
+| 1 | **Kit (ConvertKit)** | SPIKE + Linktree | Parity |
+| 2 | **Mailchimp** | Linktree (added) | Parity |
+| 3 | **Klaviyo** | Linktree (added) | Parity |
+| 4 | **Google Sheets** | Linktree (added) | Parity + free-tier funnel |
+| 5 | **Beehiiv** | SPIKE | **Differentiator** — "Linktree makes you wire Beehiiv via Zapier; we ship native" |
+| 6 | **MailerLite** | SPIKE | **Differentiator** — same |
+| 7 | **Buttondown** | SPIKE | **Differentiator** — same |
+| 8 | **Generic webhook** | SPIKE | **Differentiator** — covers everything else without Zapier |
+| 9 | **Substack iframe embed** | SPIKE | Parity |
+
+Total native-API integrations: **7** (Kit, Mailchimp, Klaviyo, Google Sheets, Beehiiv, MailerLite, Buttondown). Plus webhook + Substack iframe = **9 distinct provider options** in the block-editor dropdown.
+
+### 4.2 Justification for each ADDITION (vs SPIKE)
+
+- **Mailchimp.** SPIKE cut Mailchimp on grounds of (a) shrunk free tier, (b) declining indie-creator share, (c) highest dev cost. The Linktree-parity rule overrides all three: Linktree has Mailchimp as its FIRST and most-marketed integration; any creator evaluating tadaify-vs-Linktree will look for Mailchimp by name. The 1.0 dev day cost is acceptable.
+- **Klaviyo.** SPIKE didn't consider Klaviyo because it's an ECom/SMB tool, not creator-economy. But Linktree has it natively and a meaningful share of Linktree's base IS Shopify-merchant-class. Skipping Klaviyo while claiming "Linktree parity" would be a credibility hole. Klaviyo's API is well-documented; integration cost similar to Mailchimp (~1 day, see §6).
+- **Google Sheets.** Linktree puts it on the FREE tier, which means it's positioned as the "safety net" feature. Skipping it would make tadaify's free tier weaker than Linktree's free tier on the email-collection axis. Sheets API is straightforward; ~0.5 dev day.
+
+### 4.3 Justification for each REJECTION (provider Linktree has that we still cut)
+
+None — Linktree only has four native ESP integrations and we're shipping all four. The rejections in §3 (Resend, AWeber/GetResponse/etc.) are providers Linktree ALSO doesn't ship natively, so cutting them does not damage parity.
+
+### 4.4 Justification for each NET-NEW vs Linktree (kept from SPIKE)
+
+- **Beehiiv** — fastest-growing creator newsletter platform 2024-2025. Linktree creators wanting Beehiiv have to wire Zapier (paid above 100 tasks/mo). Native integration is a real lever. 0.75 dev day.
+- **MailerLite** — strong EU creator share, generous free tier, popular among GDPR-conscious smaller creators. Same Zapier story on Linktree. 0.5 dev day.
+- **Buttondown** — niche but loyal (indie/dev creators). Cheap to ship (0.5 day). Even at 5% adoption pays for itself in differentiation copy.
+- **Generic webhook** — covers Substack-via-Zapier, Resend, every long-tail ESP. Critical fallback. 0.75 day. Linktree's equivalent is "use Zapier" which costs the creator money and effort.
+- **Substack iframe embed** — neither tadaify nor Linktree have native Substack. Embed is the only path; ship the same way Linktree creators are forced to handle it (manual link block) but better-styled inside our block. 0.25 day.
+
+---
+
+## 5. Per-provider dev cost delta (over SPIKE 4)
+
+The SPIKE estimated 3.25 dev days for the original ship list (Kit + Beehiiv + MailerLite + Buttondown + generic webhook + Substack iframe). New additions:
+
+| New provider | Dev hours estimate | Breakdown |
+|---|---|---|
+| **Mailchimp** | 8 hrs (1.0 day) | Edge Function (~120 LOC: DC-prefix parsing, MD5 subscriber-hash, PUT-upsert), settings UI (API-key input + list dropdown + DOI toggle), unit tests, one Playwright happy-path. Detailed in SPIKE §2.5 — copy-paste applicable |
+| **Klaviyo** | 8 hrs (1.0 day) | Edge Function (~100 LOC: API-key auth `klaviyo-api-key-PRIVATE`, `POST /api/profile-subscription-bulk-create-jobs/` with revisioned Accept header, list selection via `GET /api/lists`), settings UI (API-key input + list dropdown + GDPR consent label field — Klaviyo requires explicit `subscriptions[].channels[].channel: "EMAIL"`), unit tests, Playwright |
+| **Google Sheets** | 4 hrs (0.5 day) | Edge Function (~70 LOC: Google OAuth refresh-token flow, `spreadsheets.values.append` API call, header-row management), settings UI (Google OAuth button + Sheet picker via `drive.files.list` filtered to spreadsheets + sheet-tab dropdown), unit tests, Playwright. Note: Google OAuth refresh-token storage is a one-time orchestration concern; tadaify already needs OAuth infra for any future provider so this work is amortised |
+| **Total delta** | **20 hrs (2.5 dev days)** | One-developer-week-and-a-half on top of SPIKE |
+
+**Combined total: 3.25 (SPIKE) + 2.5 (delta) = 5.75 dev days** — call it a **two-developer-week** sprint with code review and Playwright plan-then-tests cycle factored in.
+
+### 5.1 Per-provider ongoing maintenance cost (sanity)
+
+Each native integration carries an ongoing tax we should book:
+
+- **API version drift** — providers occasionally bump major versions (Kit v3→v4 in 2024, Mailchimp Marketing API never bumped major since 2017). Estimated ~0.5 dev day per provider per year on average for keeping up.
+- **Auth flow changes** — OAuth scopes and token-refresh behaviour shift; rate limits change; identity-verification gates appear (Beehiiv added one in 2024). ~0.25 dev day per provider per year.
+- **Total ongoing: ~5.25 dev days/year** for 7 native integrations, distributed unevenly (Mailchimp/Kit are stable; Beehiiv is youngest and most volatile).
+
+This is acceptable but should be visible in our v2 planning — at some point native integrations N°10+ stop paying for themselves and the webhook fallback starts being the right answer for long-tail ESPs.
+
+---
+
+## 6. Cost-at-scale table (orchestrator standard)
+
+Per `feedback_dec_format_v3_business_cost.md`. Two perspectives separated:
+
+### 6.1 tadaify infra cost (effectively unchanged from SPIKE §6a)
+
+The newsletter-signup pass-through is one Supabase Edge Function call per visitor signup. The provider routing logic is a switch on `provider_kind`; the per-provider HTTP shape differs but cost per call is dominated by the upstream HTTP latency, not provider count. Adding 3 providers does NOT meaningfully shift infra cost.
+
+| Scale | Daily signups | Monthly signups | Edge Function invocations | tadaify monthly cost |
+|---|---|---|---|---|
+| 100 DAU | 100 | 3,000 | 3,000 | $0 (under free tier) |
+| 1,000 DAU | 1,000 | 30,000 | 30,000 | $0 |
+| 10,000 DAU | 10,000 | 300,000 | 300,000 | $0 (under 500k/mo Supabase free) |
+| 100,000 DAU | 100,000 | 3,000,000 | 3,000,000 | ~$6 |
+| 1,000,000 DAU | 1,000,000 | 30,000,000 | 30,000,000 | ~$69 |
+
+**Conclusion: per `feedback_no_fake_margin_tier_gating.md`, this feature CANNOT be tier-gated on cost grounds.** The real economic question is the dev-time + maintenance cost.
+
+### 6.2 Dev-time cost-at-scale (the actual constraint)
+
+| Scale (active creators using newsletter block) | Annual dev maintenance (incidents + version-drift + provider-side breaking changes) | Notes |
+|---|---|---|
+| 100 creators (alpha) | ~2 dev days/year | One person can absorb |
+| 1,000 creators (beta) | ~5 dev days/year | Still one person; matches §5.1 estimate |
+| 10,000 creators | ~10 dev days/year | Doubling assumes 2x more creators surface previously-hidden edge cases (locale issues, niche provider workflows) |
+| 100,000 creators | ~25 dev days/year | At this scale we'd want a dedicated "Integrations" engineer fractional-allocated; could justify trimming long-tail providers to webhook-only |
+| 1,000,000 creators | ~50 dev days/year | Full FTE on integrations would be reasonable; might also justify a partner-program model where ESPs maintain their own connector |
+
+**Operating implication:** at 100k creators we should evaluate retiring lowest-usage providers to webhook-only. None of those decisions affect the v1 MVP scope.
+
+### 6.3 Linktree-equivalent cost-to-creator (informational)
+
+Linktree's native integrations are gated to Pro/Premium plans (Pro is $9/mo annual / $12/mo monthly; Premium is $24/mo annual / $30/mo monthly per their pricing page). A creator who wants Mailchimp/Klaviyo/Kit in their Linktree pays Linktree at minimum **$108/yr**. tadaify's positioning question is whether to put native integrations on free tier (undercut Linktree explicitly, take Mailchimp/Kit/etc. as standard) OR Pro tier (match Linktree's gating model). Per `feedback_no_fake_margin_tier_gating.md` the cost-grounds answer is: **free tier**, since infra cost is $0 at our plausible scale. Discussed in DEC-LT-NL-04 below.
+
+---
+
+## 7. Open DECs
+
+All in v3 format (rationale per option + cost-at-scale where relevant). Only DECs that genuinely affect implementation per `feedback_dec_scope_implementation_only.md`.
+
+### DEC-LT-NL-01 — Final native-provider list for MVP
+
+**Czego dotyczy.** Confirm the seven-native + webhook + iframe ship list.
+
+**Szczegolowy opis.** §4 recommends 7 native API integrations (Kit, Mailchimp, Klaviyo, Google Sheets, Beehiiv, MailerLite, Buttondown), plus the generic webhook and Substack iframe. This is the "Linktree parity + 4 differentiators" frame. Alternative is to ship a smaller MVP and add the non-Linktree ones (Beehiiv/MailerLite/Buttondown) post-launch as "competitive features".
+
+**Opcje.**
+
+1. Ship all 7 natives + webhook + Substack iframe in v1 (recommended).
+   - **Business rationale:** maximum competitive positioning ("everything Linktree has, plus 3 more"). Single marketing message: "you'll never have to leave us for newsletter integration reasons".
+   - **Cost rationale:** 5.75 dev days total — fits a two-week sprint; ~5.25 dev days/year ongoing maintenance.
+
+2. Ship Linktree-parity 4 (Kit + Mailchimp + Klaviyo + Sheets) + webhook + Substack iframe in v1; add Beehiiv + MailerLite + Buttondown in v1.5 (post-launch, ~6 weeks later).
+   - **Business rationale:** smaller v1 surface = faster ship, less risk; the differentiators come later as a "v1.5 update" press moment.
+   - **Cost rationale:** 3.5 dev days for v1; ~1.5 days for v1.5 add-on. Total similar; just sequenced differently.
+
+3. Ship Kit + webhook + Substack iframe only (the SPIKE's 3.25-day skeleton); add Mailchimp + Klaviyo + Google Sheets + the rest as "Phase 2".
+   - **Business rationale:** absolutely-minimal MVP, ship in <1 week; lose Linktree-parity claim entirely until Phase 2.
+   - **Cost rationale:** 1.5 dev days for v1. But: violates the user's stated MVP must (Linktree parity).
+
+**Twoja rekomendacja.** Option 1. The user explicitly stated Linktree parity is an MVP must, which rules out Option 3. Option 2 is defensible if calendar pressure is severe, but the differentiator providers (Beehiiv/MailerLite/Buttondown) are cheap (~1.75 days combined) and they're the SINGLE strongest marketing line for tadaify ("we have everything Linktree has, plus the platforms Linktree forces you to wire through Zapier"). Spending an extra week to land that line in launch press is a clear win.
+
+---
+
+### DEC-LT-NL-02 — Mailchimp re-inclusion despite SPIKE deferral
+
+**Czego dotyczy.** SPIKE explicitly cut Mailchimp from MVP for cost/decline reasons. Adding it back now overrides that decision. Confirm.
+
+**Szczegolowy opis.** SPIKE's Mailchimp cut rationale: (a) free tier shrunk to 250 contacts, (b) Mailchimp's indie-creator share declining, (c) highest integration cost (1 dev day). The Linktree-parity rule overrides because Mailchimp is Linktree's most-marketed integration and the first one creators look for by brand recognition. But: if we're worried about dev-budget, we could surface Mailchimp via the generic webhook instead (creator pastes Mailchimp's webhook URL or sets up their own intermediary). That's not parity but it's "Mailchimp users can still sign up via tadaify".
+
+**Opcje.**
+
+1. Native Mailchimp integration as recommended in §4 (1.0 dev day).
+   - **Business rationale:** real Linktree parity. Creator picks "Mailchimp" in dropdown, pastes API key, picks list, done. Same UX as Linktree.
+   - **Cost rationale:** 1.0 dev day + ~0.5 day/year ongoing. Mailchimp's API is stable so maintenance cost is low.
+
+2. Webhook-only Mailchimp (creator wires their own Make/Zapier scenario from tadaify webhook → Mailchimp).
+   - **Business rationale:** no native Mailchimp in our dropdown. CAN'T market parity. Creator has to do extra work — exactly the friction we want to remove.
+   - **Cost rationale:** ~$0 incremental dev (webhook already shipping); creator pays Zapier/Make.
+
+3. "Coming soon" placeholder in dropdown — surface Mailchimp as an option but disabled, with an email-collection field for "tell us when this ships". Ship native in v1.5.
+   - **Business rationale:** signals intent to Linktree-comparing creators without spending dev days now. But the placeholder is a credibility liability if we don't actually ship within ~6 weeks.
+   - **Cost rationale:** ~0.25 days for the placeholder UI; 1.0 day later when we do ship.
+
+**Twoja rekomendacja.** Option 1. The user's "Linktree parity" rule is the explicit anchor; the SPIKE's deferral was made under different priorities. Mailchimp's API is mature and well-documented; the 1.0-dev-day cost is real but bounded. Going webhook-only (Option 2) means we LOSE the parity claim in side-by-side marketing tables — creator sees "Linktree: native Mailchimp; tadaify: webhook required" and the conversion is gone.
+
+---
+
+### DEC-LT-NL-03 — Substack handling
+
+**Czego dotyczy.** Same DEC as SPIKE's DEC-NEWSLETTER-03 but reconfirmed in the Linktree-parity light.
+
+**Szczegolowy opis.** Linktree itself has NO native Substack integration. Both tadaify and Linktree are limited to iframe embed (since Substack has no public API). The SPIKE recommended embedding the iframe inside the Newsletter block when provider=Substack. In Linktree-parity terms we just need to be at-least-as-good — we don't need to invent a native API that doesn't exist.
+
+**Opcje.**
+
+1. Substack as a provider option in the Newsletter block; renders Substack's official iframe instead of our form (SPIKE's recommendation).
+   - **Business rationale:** matches Linktree's approximate Substack story (Linktree creators link out manually; we embed in-block — slightly better UX). Substack creators have a clean path.
+   - **Cost rationale:** 0.25 dev day (just iframe rendering + URL field).
+
+2. Don't ship Substack support in MVP; tell Substack creators to use a Link block (which is exactly what Linktree creators do).
+   - **Business rationale:** simpler MVP, fewer block variants. Loses the "every newsletter platform works in tadaify" headline.
+   - **Cost rationale:** ~$0.
+
+3. Ship Substack as a separate dedicated block type, not as a Newsletter-block variant.
+   - **Business rationale:** more honest UX (the constraint is visible at block-pick time, not post-config). Adds sidebar clutter.
+   - **Cost rationale:** ~0.5 day (separate block scaffold).
+
+**Twoja rekomendacja.** Option 1. Same as the SPIKE — keep the unified Newsletter block, surface a one-time callout in the configure modal ("Substack doesn't have a public API; we render their official embed inside this block. Visual styling is constrained by Substack."). This gives us a marginally-better-than-Linktree Substack story (in-block vs out-link) at minimal cost.
+
+---
+
+### DEC-LT-NL-04 — Tier gating policy (free vs Pro for native integrations)
+
+**Czego dotyczy.** Linktree gates its native integrations (Mailchimp/Kit/Klaviyo) behind Pro tier (~$9/mo annual). Sheets is free. Where do we put each tadaify integration?
+
+**Szczegolowy opis.** This is a pricing-strategy question with direct UI implications (block editor renders differently in tier-gated mode). Per `feedback_no_fake_margin_tier_gating.md` we cannot gate on fake margin. Real infra cost is ~$0 at all scales (§6.1) so cost-grounds gating is not justifiable. But pricing tiers have to gate on SOMETHING — Linktree gates on integrations precisely because creators value them and will upgrade.
+
+**Opcje.**
+
+1. All 7 natives + webhook + Substack iframe on FREE tier.
+   - **Business rationale:** strongest competitive positioning ("everything Linktree charges $9/mo for, free"). Drives signups. Removes a major decision-friction.
+   - **Cost rationale:** Zero cost differential to us at all plausible scales (§6.1). Gives up the "upgrade for integrations" hook though — we'd need to find a different paid-tier hook (block count, custom domain, analytics depth, A/B testing).
+
+2. Match Linktree exactly: Sheets on Free, all other natives on Pro.
+   - **Business rationale:** same upgrade funnel as Linktree; doesn't undercut on price. Easier to compare side-by-side ("we're $X for what Linktree is $Y").
+   - **Cost rationale:** Zero infra cost differential; "value capture" via tier alignment.
+
+3. Hybrid: native Mailchimp + Kit + Klaviyo + Google Sheets on Free (Linktree-parity-must), Beehiiv + MailerLite + Buttondown + webhook on Pro (the differentiators are paid).
+   - **Business rationale:** match Linktree on parity providers (don't make creators upgrade just to use Mailchimp), capture value on the differentiators (creators who specifically want our advantages pay for them).
+   - **Cost rationale:** Zero infra cost differential; "value capture" via differentiator gating.
+
+4. Hybrid inverse: differentiators (Beehiiv/MailerLite/Buttondown/webhook) on Free as the marketing wedge, parity providers (Mailchimp/Kit/Klaviyo) on Pro.
+   - **Business rationale:** counter-intuitive but the "free" creators specifically choosing tadaify over Linktree are usually choosing for the differentiator providers; Mailchimp/Klaviyo creators are by definition more-established and more willing to pay.
+   - **Cost rationale:** Zero infra cost differential.
+
+**Twoja rekomendacja.** Option 1 (all natives free) — but ONLY if there are other strong paid-tier hooks in the broader product roadmap. If newsletter integrations are one of the few candidates for paid-tier value, Option 3 (parity-free / differentiators-paid) is the next best. **Strong recommendation against Option 2** because matching Linktree's pricing model abandons our positioning lever; the whole point of being a Linktree competitor is to do something Linktree won't, and "everything is free" is the simplest version of that. The cost calculations support Option 1 unambiguously; the only question is whether tadaify's overall pricing strategy can absorb it. **Defer to product/pricing strategy DEC if separate.**
+
+---
+
+### DEC-LT-NL-05 — Klaviyo positioning: ship full or starter scope?
+
+**Czego dotyczy.** Klaviyo is in Linktree's native list but it's an awkward fit for indie-creator tadaify. Klaviyo's model is profile-based (rich `properties` dict per contact), list-and-segment-driven, with a recently-revised opt-in flow (`/api/profile-subscription-bulk-create-jobs/`). A "minimal" integration just creates a profile + adds to a list; a "full" integration also handles consent metadata (`subscriptions.email.marketing.consent: "SUBSCRIBED"`), source tracking (`subscriptions.email.marketing.consent_timestamp`), and SMS consent (Klaviyo's biggest differentiator).
+
+**Szczegolowy opis.** Linktree's Klaviyo integration appears to handle just the basic email-sync case (per their setup docs which only mention email field). If we ship the same scope we're at parity at lower cost; if we ship richer scope (incl. proper consent metadata) we're better than Linktree but cost more dev time.
+
+**Opcje.**
+
+1. Minimal Klaviyo: email + list selection + basic profile creation. ~0.75 dev day.
+   - **Business rationale:** Linktree-parity. Sufficient for most creators. Simple block-editor UX.
+   - **Cost rationale:** 0.75 dev day (vs 1.0 in §5 estimate).
+
+2. Full Klaviyo: email + list + consent metadata + GDPR fields + (optionally) SMS opt-in. ~1.5 dev days.
+   - **Business rationale:** marketing line "tadaify is more GDPR-clean than Linktree even on Klaviyo". Real value for EU creators.
+   - **Cost rationale:** 1.5 dev days; payable.
+
+3. Skip Klaviyo entirely; rely on webhook for Klaviyo creators.
+   - **Business rationale:** focus dev cycles on differentiators. But: breaks the "Linktree parity" marketing line.
+   - **Cost rationale:** ~$0.
+
+**Twoja rekomendacja.** Option 1 for v1; revisit Option 2 in v1.5 once we have data on actual Klaviyo creator usage. The §5 estimate of 1.0 day is between Options 1 and 2; the minimal scope shaves 0.25 day and matches Linktree exactly. We don't need to outdo Linktree on Klaviyo specifically — our differentiation lives in Beehiiv/MailerLite/Buttondown.
+
+---
+
+### DEC-LT-NL-06 — Google Sheets free-tier scope
+
+**Czego dotyczy.** Google Sheets integration scope on tadaify free tier (matching Linktree's free Sheets policy).
+
+**Szczegolowy opis.** Linktree gives Sheets sync to all plans including free. Same call for tadaify: Sheets on free? If yes, we're at parity. If we gate Sheets to Pro we're worse than Linktree on the headline "free email collection" axis. Google Sheets API is free up to 60 requests/min/project so cost is genuinely $0.
+
+**Opcje.**
+
+1. Google Sheets on Free tier (matches Linktree).
+   - **Business rationale:** parity on the free-tier funnel feature. Headline "collect emails for free without picking an ESP yet" matches Linktree.
+   - **Cost rationale:** $0 — Sheets API is free at our scale.
+
+2. Google Sheets on Pro only.
+   - **Business rationale:** Linktree-WORSE on free tier. Bad PR/comparison-table look.
+   - **Cost rationale:** $0 to us; gives creators a reason to upgrade. But Sheets on Free is so cheap to give that withholding it looks petty.
+
+**Twoja rekomendacja.** Option 1. Consequence-free win.
+
+---
+
+## 8. Risks & follow-ups
+
+### 8.1 What Linktree has that we should NOT chase
+
+- **Audience CRM features.** Linktree's "Audience" tab is more than just integrations — it's a contact dashboard, segmentation UI, campaign-targeting tool. We should NOT replicate this in MVP. tadaify's positioning is "subscriber lands in the creator's own ESP, we don't store the contact". Building a Linktree-style audience CRM would re-create the GDPR foot-gun the SPIKE explicitly avoided AND duplicate functionality the creator's chosen ESP already provides. Stay out.
+- **Klaviyo SMS opt-in.** Linktree's Klaviyo integration touches SMS; we should NOT in v1 (SMS adds compliance complexity — TCPA in US, country-specific consent rules in EU). If Klaviyo creators ask, defer to v2 or to webhook.
+- **Pro-tier-only gating** — discussed in DEC-LT-NL-04. Don't blindly copy Linktree's gating; we have a stronger pricing lever in being more permissive.
+- **Linktree "Forms" multi-field surface.** Linktree's Forms product collects name + email + custom fields. Our SPIKE-era Newsletter block was scoped to email-only. Decide separately whether to add multi-field as a v1 must (probably no — defer to a separate `Forms` block type once the email block is shipping).
+
+### 8.2 Risks specific to the parity additions
+
+- **Mailchimp's dwindling free tier (250 contacts).** Many creators connect Mailchimp via tadaify, hit the cap, blame us. Mitigation: surface Mailchimp's current limits in our connect modal ("Mailchimp's free plan is capped at 250 contacts; you may want a different provider if you grow fast"). One-line UX copy, no dev cost.
+- **Klaviyo's new opt-in API surface.** Klaviyo has been actively iterating on the consent endpoint shape (`/api/profile-subscription-bulk-create-jobs/` is the current 2025-08+ canonical). Our integration is exposed to API breaking changes at higher rate than Mailchimp's stable 2017 API. Allocate ~0.5 dev day/year for Klaviyo specifically.
+- **Google OAuth scope creep.** To write to a creator's Sheet we need the `https://www.googleapis.com/auth/spreadsheets` scope — fine. But the consent screen will trigger Google's app verification process if we cross 100 users on the OAuth client. Plan to submit for verification before public launch (4-6 week Google review cycle). Add this to the launch-readiness checklist. Allocated cost: 1 dev day for the verification submission + form fill.
+- **Linktree could ship Beehiiv/MailerLite/Buttondown natively** at any time, eroding our differentiators. Mitigation: track the Linktree changelog (`updates.linktr.ee`) monthly and be prepared to lean into a NEW differentiator (e.g. better DOI handling, better analytics, better cost-comparator) if/when they catch up.
+
+### 8.3 Long-tail providers worth following (not in MVP)
+
+Indirect Zapier-via-webhook coverage handles these in v1; track signal for promoting any to native in v2:
+
+- **Ghost** — strong pro-creator newsletter+CMS combo; would be an obvious tadaify-friendly addition.
+- **Loops** — modern transactional+marketing API, growing creator interest.
+- **EmailOctopus** — budget-friendly EU alternative to MailerLite.
+- **Brevo (Sendinblue)** — strong EU SMB share.
+- **HubSpot** — enterprise/B2B; probably never in tadaify's wheelhouse.
+- **AWeber, GetResponse, ActiveCampaign** — older audiences; might be worth a dedicated block once we have analytics on webhook usage.
+
+### 8.4 Out-of-scope items intentionally not addressed here
+
+- **Pricing tier strategy in detail** — DEC-LT-NL-04 surfaces the question; the actual answer requires a separate pricing-strategy DEC encompassing all paid features, not just newsletter integrations.
+- **Forms block type (multi-field collection)** — separate from Newsletter block; out of scope for this scan.
+- **Audience CRM dashboard** — explicitly cut per §8.1.
+- **Tracking/analytics sidebar for newsletter blocks** — flagged in SPIKE §7.6 as v1.5 enhancement; unchanged here.
+- **Revenue-share / sponsorship integrations** (Beehiiv Boosts, Kit Recommendations) — provider-side features, not our concern.
+
+---
+
+## 9. Appendix — sources verified 2026-04-26
+
+### Linktree-side citations
+
+- <https://linktr.ee/products/3rd-party-email-integrations> — canonical "Sync your email list with Mailchimp, Klaviyo, Kit and More" product page.
+- <https://help.linktr.ee/en/articles/11069074-setting-up-third-party-audience-integrations> — Linktree help: "Setting up third party audience integrations" (verbatim quote: "On Pro and Premium plans, you can connect Mailchimp, Klaviyo, Kit or Google Sheets to your Linktree to automatically sync data from your audience forms").
+- <https://help.linktr.ee/en/articles/5434187-how-to-collect-email-sign-ups-on-your-linktree> — Linktree help: "How to collect email sign-ups on your Linktree".
+- <https://help.linktr.ee/en/articles/11614384-connecting-klaviyo-to-your-linktree> — Linktree help: "Connecting Klaviyo to your Linktree".
+- <https://linktr.ee/marketplace/integrations> — Linktree Marketplace integrations index.
+- <https://linktr.ee/marketplace/integrations/integration-kit> — Linktree marketplace: Kit listing.
+- <https://linktr.ee/marketplace/apps/integration-klaviyo> — Linktree marketplace: Klaviyo listing.
+- <https://updates.linktr.ee/new-feature!-email-signup-mailchimp-integration-65169> — Linktree changelog: original Mailchimp integration ship announcement (2021).
+- <https://linktr.ee/blog/grow-mailing-list-2025> — Linktree blog: "How to grow your mailing list with Linktree Forms" (2025).
+- <https://linktr.ee/s/pricing> — Linktree pricing page (Pro $9/mo annual, Premium $24/mo annual at time of verification).
+
+### Provider-side cross-references
+
+- <https://mailchimp.com/integrations/linktree/> — Mailchimp's own marketplace listing for Linktree (verbatim quote: "Connect with Mailchimp on Linktree Pro to create powerful campaigns").
+- <https://marketplace.klaviyo.com/en-us/apps/01JSM2ZDZSE3TADKCSB66SVN0A/> — Klaviyo App Marketplace: Linktree app listing.
+- <https://kit.com/compare> — Kit's own competitive comparison hub (for reference to the Kit-Linktree relationship).
+- <https://support.substack.com/hc/en-us/articles/360041759232-Can-I-embed-a-signup-form-for-my-Substack-publication> — Substack's own embed-form documentation.
+- <https://substackapi.com/docs/how-to-embed-your-substack-signup-form-on-any-website> — community embed workaround for Substack.
+
+### Zapier-equivalence references (showing what is NOT native in Linktree)
+
+- <https://zapier.com/shared/collect-linktree-email-subscribers-and-add-to-tag-in-convertkit/e81f6dbb57a5686309424766a2725741c0f4ff79> — Zap template for Linktree → ConvertKit (now Linktree → Kit native, but the Zap still indexes).
+- <https://zapier.com/apps/beehiiv/integrations/convertkit> — Beehiiv↔ConvertKit Zapier integration (indicates these don't talk natively).
+- <https://zapier.com/apps/beehiiv/integrations/mailerlite> — Beehiiv↔MailerLite Zapier.
+
+### SPIKE document this scan extends
+
+- `~/git/claude-reports/research/tadaify/tadaify-newsletter-providers-integration.md` — original 2026-04-26 newsletter SPIKE recommending Kit + Beehiiv + MailerLite + Buttondown + webhook + Substack iframe.
+
+### Methodology notes
+
+- Linktree's own help-center pages return 403 to the standard WebFetch user agent (Cloudflare bot protection). All Linktree-side claims were verified instead via WebSearch result snippets that quote the help center verbatim, plus the partner-side directory pages (Mailchimp, Klaviyo) which independently confirm the integration list.
+- Tier requirement claims (Pro / Premium) are corroborated across at least two sources per provider (Linktree's own product page + the partner's directory).
+- Pricing figures (Linktree Pro $9/mo annual etc.) are point-in-time as of 2026-04-26 and should be re-verified before any external comparison-marketing copy ships.

--- a/docs/research/livestream-block-integration.md
+++ b/docs/research/livestream-block-integration.md
@@ -1,0 +1,961 @@
+---
+type: SPIKE
+project: tadaify
+title: Livestream Block — Integration vs Self-Hosting (provider survey + live-state detection)
+agent: opus-4-7
+author: orchestrator
+related_brs: []
+tags: [tadaify, blocks, livestream, embed, mvp]
+created_at: 2026-04-26
+status: draft
+---
+
+# SPIKE — tadaify Livestream Block: Integration vs Self-Hosting
+
+## 1. Executive summary
+
+**Recommendation: ship the Livestream block as a thin "embed-someone-else's-livestream" wrapper, NOT a streaming product.** v1 supports YouTube Live, Twitch and Kick via official iframe embeds — three providers cover 90 %+ of creator audiences and 100 % of supported providers expose a documented iframe player URL. tadaify writes zero bytes of video, runs zero ingest infrastructure, and pays zero per-minute delivery cost.
+
+Live-state detection (is the creator on air right now?) is solved with a single Postgres-backed cron that calls each provider's official "is this channel live" endpoint every 60 s for channels that are currently embedded on a published page. tadaify's per-month detection cost stays in the cents at MVP scale and only crosses USD 10 / month past the 100 k-DAU mark.
+
+Two-line rationale: (a) creators who want to livestream already have an audience on YouTube / Twitch / Kick — duplicating their stream on tadaify-hosted infra would force them to split chat, lose subscribers and cost tadaify ~100× more per delivered minute than embedding; (b) the "Livestream" picker block is a UX signal ("creator is live RIGHT NOW") more than a storage product, so the right primitive is `<iframe src=…> + live-state badge + when-not-live fallback`, not a video pipeline.
+
+The Livestream block is **free on all paid tiers** (it costs us almost nothing) and **available on the free tier with a single "saved channel" cap** (no per-channel cost — the cap exists only to gate against spammy abuse of the live-detection cron).
+
+---
+
+## 2. Comparison: Livestream block vs Video block vs Embedded block
+
+The picker today (per the block library research) ships these three shapes. They overlap visually but solve different problems:
+
+| Block | Primary input | What the visitor sees | When does the creator pick it? |
+|---|---|---|---|
+| **Video** | A specific video URL (YouTube / Vimeo / direct mp4) | A static, always-available video player. Plays the same video forever. | "Here is my latest tutorial / trailer / loop reel — watch it any time." |
+| **Embedded** | An arbitrary URL (Spotify track, Calendly, Notion page, Substack post, anything with an oEmbed/iframe) | Whatever that URL renders to. Creator is responsible for the embed making sense. | "Here is a third-party widget I want on my page that does not have a dedicated block yet." |
+| **Livestream** | A **channel identity** (YouTube channel ID, Twitch username, Kick username) — NOT a video ID | (a) live player when the creator is broadcasting; (b) "offline" state with last-VOD CTA / schedule / native-platform follow link when they are not. | "I broadcast regularly. When I am live, my fans should see the player; when I am not, they should see how to follow / the next stream time." |
+
+### Decision tree the block-picker UX should encode
+
+```
+Q1: Do you broadcast live regularly (weekly+) and want fans to land on the live player when you are on air?
+  YES  → Livestream block (handles live/offline state automatically)
+  NO   → Q2
+
+Q2: Do you have a specific recorded video you want everyone to watch?
+  YES  → Video block (static, always available, predictable)
+  NO   → Q3
+
+Q3: Is it a third-party URL (Spotify, Calendly, Substack, …)?
+  YES  → Embedded block
+  NO   → none of these — pick a different block (Bio, Links, Newsletter, …)
+```
+
+### Why this matters
+
+If a creator drops their YouTube **Live** URL into the **Video** block, it works exactly once: when that specific live broadcast is on air. The moment the broadcast ends, that videoId becomes a VOD playback (or 410-Gone if it was set to "Premiere" without archive), the page silently shows yesterday's stream forever, and the creator does not notice until a fan tells them. The Livestream block solves this by binding to the **channel**, not the video, and resolving "what is on this channel right now?" at request time.
+
+Conversely, if a creator drops a static "trailer" video into the Livestream block, every page load triggers a useless live-state check that always returns "offline", we waste API quota on them, and the visitor sees a permanent "offline — not live right now" badge over a video that was never meant to be live. The picker copy must steer them toward the Video block.
+
+**Implication for the picker UI:** the Livestream tile in the block picker carries a one-line clarifier: *"Auto-shows your live broadcast when you go on air, with an offline fallback. Not for static videos — use the Video block."* This text is the cheapest way to prevent the most common mis-pick.
+
+---
+
+## 3. Integration approaches — provider-by-provider
+
+For each provider we evaluate four things:
+
+1. **Embed feasibility** — does an official iframe exist?
+2. **Channel-level vs video-level binding** — can we point at a creator and auto-resolve their current live broadcast, or do we need a fresh videoId every stream?
+3. **Live-state detection** — how do we know if they are on air?
+4. **Offline state** — what does the iframe render when they are not live?
+
+### 3.1 YouTube Live — DEFAULT, ship in MVP
+
+**Embed URL pattern:**
+
+```
+https://www.youtube.com/embed/live_stream?channel=<YOUTUBE_CHANNEL_ID>
+```
+
+This is the canonical "auto-resolve current live broadcast for a channel" embed. It accepts a channel ID (the `UC…` 24-char form, NOT the @handle). When the channel is broadcasting, the iframe shows the live player; when offline, YouTube renders a generic offline placeholder (channel avatar + "This live event has ended" or "Stream offline" depending on broadcast state).
+
+**Known limitation (from search results):** if the channel has multiple **scheduled** future live streams set to public, the channel embed can break and refuse to resolve. This is a YouTube-side constraint we cannot fix. Mitigation: in the offline-state UI, expose a "having trouble seeing the stream? open in YouTube" link so visitors are never fully stuck.
+
+**Channel ID lookup UX:** creators rarely know their `UC…` ID — they only know their @handle or vanity URL. The block editor must accept either of:
+
+- `https://www.youtube.com/@creator-handle`
+- `https://www.youtube.com/channel/UC…`
+- `UC…` directly
+- `@creator-handle`
+
+…and resolve it server-side to the canonical `UC…` ID at save time (one YouTube Data API call: `channels.list?forHandle=@…&part=id`, cost = 1 unit, cached forever per handle). Store both the resolved `UC…` and the original input on the block row so we can re-resolve if a creator changes handle.
+
+**Live-state detection — two paths:**
+
+| Path | API call | Quota cost (per call) | Realtime? | When to use |
+|---|---|---|---|---|
+| **Polling** | `search.list?part=snippet&channelId=UC…&type=video&eventType=live` | **100 units** | every poll (we choose the cadence) | MVP default — predictable |
+| **Push** | WebSub / PubSubHubbub `https://pubsubhubbub.appspot.com/` with topic `https://www.youtube.com/xml/feeds/videos.xml?channel_id=UC…` | 0 quota | yes (server-to-server webhook on new video / live start) | upgrade path — saves quota dramatically once we have >100 channels |
+
+YouTube's `search.list` is the **most expensive** call in the v3 API (100 units per call). Default daily quota is 10 000 units → 100 polls / day / project total — NOT per channel. This means naive "poll every channel every 60 s" ceases to work past ~7 channels per day on a single API project.
+
+**Consequences for our cost model (see §9):**
+
+- MVP (≤1 000 channels): poll **only channels currently rendered on a published page in the last 24 h**, every 5 min, with a project-pool of 5–10 API projects rotated round-robin to multiply quota. Estimated cost: $0 (free tier) up to ~5 k channels.
+- Growth (>5 k channels): switch primary detection to **WebSub push**. Each tadaify-side webhook handler writes an `is_live` flag + `live_video_id` to Postgres. Polling remains as a 30-min fallback for missed pushes. Quota cost drops to near-zero.
+
+**Offline state in the iframe itself is ugly** (generic YouTube channel-offline placeholder with no creator branding). This is the single biggest reason the tadaify block must overlay its own offline UI on top of the iframe — see §6.
+
+### 3.2 Twitch — ship in MVP
+
+**Embed pattern (Twitch uses a JS object, NOT a raw iframe URL — but the underlying iframe URL is documented and works):**
+
+Raw iframe form:
+```
+<iframe
+  src="https://player.twitch.tv/?channel=<USERNAME>&parent=tadaify.com&parent=*.tadaify.com&parent=<creator-custom-domain>"
+  height="378" width="620" allowfullscreen></iframe>
+```
+
+Critical: the `parent=` query parameter is **mandatory** and must list every domain on which the embed will be rendered. Twitch refuses to play if the actual `window.location.host` does not match a `parent=` value. Effects on tadaify:
+
+- `parent=tadaify.com` covers `creator.tadaify.com/<page>` only if Twitch accepts wildcards. It does NOT — `parent=` accepts exact hostnames only, not wildcards.
+- Custom domains (BR-022 from the brand audit) mean each creator may use their own `creator-domain.com`. We must inject `parent=<that-domain>` server-side when rendering the page.
+
+**Implementation:** server-side, generate the iframe `src` per request based on the page's host header. Add `parent=<host>` and (defensively) `parent=tadaify.com` and `parent=creator-name.tadaify.com`. Three or four `parent=` params is fine; Twitch documents no limit.
+
+**Live-state detection:**
+
+- **Polling:** `GET https://api.twitch.tv/helix/streams?user_login=<username>` — empty `data: []` array means offline; non-empty means live with the current title, viewer count, game category, thumbnail. **Rate limit: ~800 requests / minute / app**, 100 logins per call. → in one batched call we can check the live state of 100 channels, so even at 10 000 channels we use 100 calls / minute, well under the limit.
+- **Push (preferred at scale):** Twitch **EventSub** with `stream.online` and `stream.offline` topics. Each subscription costs 1 toward a `max_total_cost` of 10 (free) — but the cap raises significantly once you authenticate the channel via the broadcaster's OAuth (the "user has authorised your app" path lifts the cap to thousands). For tadaify the cleanest path is: poll-only at MVP (well under the rate limit), upgrade to authenticated EventSub later if we cross 5 k embedded channels.
+
+**Offline state in the iframe itself:** Twitch renders a clean "Channel is offline" card with the streamer's avatar, panels and a follow button — significantly better looking than YouTube's offline state. We can ship the Twitch offline state as-is in MVP and skip the overlay; or for consistency overlay our own. Pick: overlay our own (consistency wins over per-provider polish at MVP).
+
+**Chat:** Twitch documents a separate chat-only embed (`https://www.twitch.tv/embed/<channel>/chat?parent=…`). Out of scope for v1 — adds visual clutter on a creator page and most fans want chat on twitch.tv proper. Mark as v2.
+
+### 3.3 Kick — ship in MVP (or v1.1)
+
+**Embed URL pattern (true iframe, no JS lib needed):**
+
+```
+<iframe src="https://player.kick.com/<USERNAME>?muted=true&allowfullscreen=true"
+        height="720" width="1280" frameborder="0" scrolling="no" allowfullscreen></iframe>
+```
+
+Simpler than Twitch — no `parent=` requirement, no JS bundle. The player auto-shows live state vs offline state internally.
+
+**Live-state detection:**
+
+- **Public API:** Kick now ships a documented public API (`https://api.kick.com`) with OAuth 2.1. The `Stream` object includes `is_live` and viewer count.
+- **Webhooks:** the same dev portal documents events (subject to OAuth scope). At MVP scale, polling the channel endpoint every 60 s is fine.
+- **Anonymous access:** Kick has historically allowed unauthenticated reads of channel JSON (`https://kick.com/api/v2/channels/<username>`) — useful as a fallback but NOT load-bearing because Kick can change this without notice. Use the documented OAuth API as the primary source of truth, treat the unauthenticated route as a defensive cache.
+
+**Decision: ship Kick in MVP.** It is the smallest of the three but the embed is the simplest and growth is fastest in the demographic tadaify targets (gaming creators, alt-platform escapees from YouTube monetisation).
+
+### 3.4 X (Twitter) Live / Spaces — DEFER to v2
+
+**Status as of 2026-04-26:**
+
+- **Live video broadcasts:** X's "Twitter Publish" tool generates an embeddable widget that auto-shows the chosen handle's broadcast when on air, but the embed is implemented as a `blockquote + script` (twitter-publish JS), NOT a clean iframe URL. Customisation is poor.
+- **Spaces (audio):** Spaces are audio-only. There is **no public iframe-style embed** for a live Space. The X mobile / web app is the only first-class consumer.
+- **Developer API access:** the X API v2 has been turned restrictive since 2023 — broadcast embed code retrieval has been the subject of dev-forum complaints since 2024 with no clean public solution.
+
+**Decision: skip in MVP.** Document as a v2 experiment if real creator demand surfaces. If we ship anything in v2, route it as a thin wrapper around the official Twitter Publish widget, accept that it will look like an X tweet card more than a full player, and badge the block with "X Live (beta)" so we can drop it without breaking expectations.
+
+### 3.5 TikTok Live — DEFER to v2 (or NEVER)
+
+**Status as of 2026-04-26:**
+
+- TikTok offers an **oEmbed API** for **VOD videos**, not Lives.
+- TikTok's developer platform documents an "Embed Player" but only for posted videos, not for the Live experience.
+- All "embed your TikTok Live on a website" tutorials in 2026 use **third-party scrapers** (SociableKIT, EmbedSocial) that proxy a screen-scraped player. These are unreliable, frequently break with TikTok web changes, and create a cross-site cookie / privacy footprint we do not want to take responsibility for.
+
+**Decision: skip in MVP. Do NOT ship third-party scraper integrations.** If a creator demands TikTok Live integration, the right fallback in the Livestream block is "Provider not supported — drop a TikTok profile link in your Bio block instead, and use the Video block to embed individual TikTok videos." The Embedded block can wrap a third-party widget at the creator's own risk, which keeps tadaify out of the maintenance loop.
+
+### 3.6 Instagram Live — DO NOT SHIP (no compliant path)
+
+**Status as of 2026-04-26:**
+
+- Instagram Basic Display API has been end-of-lifed.
+- Instagram Graph API (the only remaining sanctioned route) requires the **creator** to OAuth-authorise tadaify's Meta app, requires App Review, requires the account to be Business or Creator (not Personal), and only exposes their own data — there is no public live-state lookup for arbitrary accounts.
+- There is **no public embed** for a live IG broadcast. Every "embed Instagram Live" SaaS is a screen-scrape with a short half-life.
+
+**Decision: do NOT ship Instagram Live, in MVP or v2.** The compliance overhead is multi-quarter (Meta App Review for "Live" scopes is one of the slowest in the industry) and the value-add is small. Document this clearly in the picker as "Instagram Live is not supported because Meta does not provide an embed API. Use the Embedded block with a third-party tool at your own risk, or a Bio link to your IG profile."
+
+### 3.7 Comparison summary
+
+| Provider | Iframe? | Channel-bound? | Live-state API | Webhooks? | Ship in MVP? | Ship in v1.1? | Ship in v2? |
+|---|---|---|---|---|---|---|---|
+| YouTube Live | YES (official) | YES (`live_stream?channel=…`) | yes (search.list, expensive) | yes (WebSub) | **YES** | — | — |
+| Twitch | YES (player.twitch.tv) | YES (`?channel=…`) | yes (Helix `streams`) | yes (EventSub) | **YES** | — | — |
+| Kick | YES (player.kick.com) | YES (`/<username>`) | yes (api.kick.com) | yes (events API) | **YES** | — | — |
+| X Live | partial (JS widget) | partial | broken / restrictive | no | NO | maybe (beta) | yes if demand |
+| TikTok Live | NO (third-party scrape only) | NO | none | no | NO | NO | NO (out of scope) |
+| Instagram Live | NO | NO | none (Graph API requires per-creator OAuth) | no | NO | NO | NO (out of scope) |
+
+---
+
+## 4. Detect-live-state mechanism — design
+
+### 4.1 The cheap default: page-render-time detection
+
+When a visitor hits a tadaify creator page that contains a Livestream block, we do **not** render the iframe immediately. Instead the block ships an inline component that:
+
+1. Hits an internal `/api/livestream/state?block_id=<uuid>` endpoint (cached by Postgres, NOT a passthrough to the provider).
+2. Receives `{ is_live: bool, current_video_id?: string, last_seen_live_at?: ISO, schedule_text?: string }`.
+3. Renders either the live iframe (when `is_live=true`) OR the offline-state UI (see §6).
+
+The `/api/livestream/state` endpoint is the only external surface; it never calls the provider directly — it only reads from the `livestream_state` Postgres table. Read latency is sub-50 ms.
+
+### 4.2 The cheap default: write side — pull cron
+
+A single cron (Supabase edge function on a `pg_cron` schedule, every 60 s) executes:
+
+```sql
+-- 1. Find channels that are 'hot':
+--    embedded on a page that has been published AND received a visitor
+--    in the last 24h.
+SELECT DISTINCT block_id, provider, channel_handle
+  FROM livestream_block lb
+  JOIN page p ON p.id = lb.page_id
+ WHERE p.published_at IS NOT NULL
+   AND p.last_visitor_at > now() - interval '24 hours'
+   AND (lb.last_polled_at IS NULL OR lb.last_polled_at < now() - interval '60 seconds')
+ ORDER BY lb.last_polled_at NULLS FIRST
+ LIMIT 100;
+```
+
+The cron then dispatches by provider:
+
+- **Twitch / Kick:** batch the 100 channels into a single Helix call (Twitch supports 100 logins per call) or 100 individual Kick calls (rate-limit-safe at the documented Kick limits).
+- **YouTube:** 100 channels = 100 `search.list` calls = 10 000 quota units. This is a full day of free quota in one minute — not viable at scale. **Mitigation: WebSub push subscription is the production path for YouTube; polling only as fallback for the first 200 channels in the system before WebSub onboarding completes.**
+
+The cron writes `is_live`, `current_video_id`, `last_polled_at`, `last_state_change_at` back to the `livestream_block` row. The `/api/livestream/state` endpoint reads from this row.
+
+### 4.3 Hot-channel optimisation
+
+Most creator pages get one or two visitors per day. Polling the channel every 60 s for a creator whose page nobody is on costs us money for nothing. The query above filters to "channels embedded on a page with at least one visitor in the last 24 h". If a page goes cold for 24 h, we stop polling its embedded channels, and the next visitor triggers a one-shot synchronous resolution (`/api/livestream/state` with `?fresh=true` does a single live API call inline with a 5-second timeout).
+
+### 4.4 Webhook upgrade path (post-MVP)
+
+| Provider | Webhook mechanism | Effort to add | When to add |
+|---|---|---|---|
+| YouTube | WebSub (PubSubHubbub) — subscribe to `https://www.youtube.com/xml/feeds/videos.xml?channel_id=<UC…>` | medium (2–3 days: subscription mgmt, HMAC verification, callback handler, lease renewal cron) | as soon as we cross **500 polled YouTube channels** (quota concern) |
+| Twitch | EventSub (webhook transport) — `stream.online` + `stream.offline` per channel | medium (2 days) | as soon as we cross **5 000 polled Twitch channels** (rate limit not an issue till then) |
+| Kick | events API (per docs) | medium | parallel with Twitch upgrade |
+
+When webhooks are wired, the cron in §4.2 becomes a fallback for missed events (runs every 30 min instead of every 60 s), saving ~95 % of the API budget.
+
+### 4.5 Cost implications of polling — see §9 cost-at-scale table
+
+---
+
+## 5. When-not-live UX
+
+The block must look intentional when the creator is offline — it cannot just show a YouTube grey placeholder forever. Recommended layered fallback:
+
+### 5.1 Layered fallback hierarchy
+
+```
+1. If is_live:
+     render <iframe>
+     overlay LIVE badge top-left ("● LIVE NOW · 1.2k watching")
+
+2. Else if next_scheduled_broadcast_at is in the future:
+     render thumbnail of channel avatar OR most-recent-VOD thumbnail
+     overlay text:
+       "<creator name> goes live <relative time> — set a reminder"
+     CTA #1: native-platform notify ("Notify me on YouTube/Twitch/Kick")
+     CTA #2: "Watch the latest stream" → links to last VOD on native platform
+
+3. Else if last_seen_live_at within 30 days:
+     thumbnail of last VOD
+     "<creator name> is offline. Last live <relative time>."
+     CTA: "Watch the recording" → last VOD on native platform
+     CTA: "Follow on <Provider>" → native subscribe page
+
+4. Else (cold channel, never seen live or last seen >30d):
+     channel avatar + handle
+     "<creator name> isn't streaming right now."
+     CTA: "Follow on <Provider>" → native subscribe page
+```
+
+### 5.2 Source of "next scheduled broadcast"
+
+- **YouTube:** `search.list?eventType=upcoming&channelId=…` — same 100-unit cost. We pull this opportunistically once per day per channel via the same hot-channel cron, NOT on every poll. Cache the next scheduled time on the row.
+- **Twitch:** `GET /helix/schedule?broadcaster_id=…` returns the schedule, low rate-limit cost.
+- **Kick:** documented in the public API.
+
+Treat `next_scheduled_broadcast_at` as a nice-to-have, NOT a hard requirement. If the field is `null`, fall back to (3) or (4).
+
+### 5.3 What we do NOT show
+
+- "Subscribe to be notified when X goes live" — captures email, requires push notification infrastructure, expands MVP scope by an order of magnitude. **DEFER, see §7.**
+- A countdown timer that ticks every second — battery / CPU hit on mobile, hard to keep accurate, low value. Show "in ~3 h" / "tomorrow at 19:00 your local time", refreshed every minute.
+- Comments / chat — no chat embed in MVP. Chat lives on the source platform.
+- Per-provider branding (the YouTube logo, the Twitch glitch). Use a neutral "● LIVE" + small provider icon (16 px) inside the badge. Keeps the creator's page brand-consistent.
+
+### 5.4 Mobile considerations
+
+The iframe is 16:9 by default. On narrow viewports (<480 px), the live badge collapses to just `●` (no text) to avoid covering the player. Offline state collapses the CTAs into a single "Notify me / Follow" button.
+
+---
+
+## 6. Notification flow — visitors getting pinged when creator goes live
+
+**Recommendation: do NOT build this in MVP.**
+
+### 6.1 What it would actually require
+
+| Component | Effort | Ongoing cost |
+|---|---|---|
+| Email capture + verification flow on the creator page | medium (1 week) | Resend / SES per email |
+| Push notification opt-in (web push via VAPID) | medium-high (1.5 weeks: service worker, VAPID keys, browser permission UX) | free (web push is free) |
+| Notification queue (when `stream.online` event fires → fan-out to N subscribers) | medium (1 week: queue + worker + retry + dead-letter) | SQS + Lambda — cheap but not zero |
+| Compliance (CAN-SPAM, GDPR consent UI, unsubscribe per creator, double opt-in flow) | high (compliance and legal review) | ongoing legal review |
+| Anti-spam (rate limit / captcha to prevent enumeration of creator subscribers) | medium | moderation time |
+| Per-creator preferences (mute notifications without unfollowing, frequency caps) | medium (1 week) | DB storage |
+
+Total MVP scope expansion: ~5–6 dev weeks + recurring compliance burden + an entirely new product surface (subscriber lists per creator).
+
+### 6.2 The cheap MVP alternative: native subscribe links
+
+For each provider, link to the **native** subscribe / notify-me path:
+
+| Provider | Native subscribe URL |
+|---|---|
+| YouTube | `https://www.youtube.com/channel/<UC…>?sub_confirmation=1` (auto-popup the subscribe modal) |
+| Twitch | `https://www.twitch.tv/<username>/follow` |
+| Kick | `https://kick.com/<username>` (their follow flow is in-page, deep-link to the channel) |
+
+The fan gets notified through the platform they already use, the platform handles delivery + compliance + unsubscribe + frequency caps. tadaify owns zero of that surface.
+
+### 6.3 v2 path
+
+If real creator demand surfaces ("my fans want a tadaify-side ping that aggregates across all my Live presences"), build it as a **separate feature** ("Fan club") not as part of the Livestream block. It overlaps with email capture for the Newsletter block (see sibling research SPIKE on newsletter integration). Do not couple Livestream-block delivery to a brand-new email infrastructure.
+
+---
+
+## 7. Native streaming evaluation — why we are NOT hosting livestreams
+
+### 7.1 Cloudflare Stream Live: the cheapest credible self-host option
+
+Pricing (2026-04-26): **$5 per 1 000 minutes of recorded video stored** + **$1 per 1 000 minutes of video delivered** (i.e. summed across all viewers). Ingest and encoding are free. Bandwidth is included in the delivery price. (Sources at end.)
+
+Concrete worked example for ONE creator who streams 4 h / week with 200 average concurrent viewers:
+
+- Ingest: 4 h × 60 = 240 minutes per week
+- Storage: 240 min × 4 weeks = 960 minutes/month → 0.96 × $5 = **$4.80 / month / creator** (recording stored)
+- Delivery: 240 min × 200 viewers × 4 weeks = 192 000 viewer-minutes/month → 192 × $1 = **$192 / month / creator** (delivery)
+
+**Total: ~$197 / month for ONE small creator with 200 average concurrent viewers.**
+
+Now compare: that creator on YouTube Live pays YouTube zero (YouTube monetises through ads, of which the creator gets a cut). On Twitch, the creator earns from subs / bits. On tadaify-hosted streaming, that $197/month comes out of tadaify's gross margin per creator. To break even, the cheapest paid tier would have to gross >$200/month per livestreaming creator just to pay for the stream — before any other tadaify cost.
+
+### 7.2 Comparison
+
+| Approach | Per-creator monthly cost (200 avg viewers, 4 h/wk) | Audience-portability | Chat | Discovery |
+|---|---|---|---|---|
+| Embed YouTube | $0 (creator already there) | 100 % (their YouTube subs follow them anywhere) | YouTube chat (in iframe) | YouTube's algorithm sends new viewers |
+| Embed Twitch | $0 | 100 % (Twitch subs persist) | Twitch chat | Twitch directory |
+| Embed Kick | $0 | 100 % | Kick chat | Kick directory |
+| Self-host on Cloudflare Stream Live | ~$197 / creator | 0 % (no native subscribers, isolated chat, zero discovery) | tadaify must build chat | none |
+| Self-host on Mux / Livepeer / others | similar order of magnitude (Mux is more expensive than CF, Livepeer cheaper but more ops) | same as above | same | same |
+
+### 7.3 Verdict
+
+Self-hosting livestream is **strictly worse** than embedding on every dimension that matters for tadaify's MVP target (small / mid creators who already have an audience on YouTube / Twitch / Kick). The only scenario in which self-hosting is justified is "creator wants exclusive paid streams gated behind tadaify subscription" — which is a v3+ premium feature ("Tadaify Live Pro: paywalled live broadcasts hosted by us"), explicitly out of MVP and probably never. Even then, the right architecture is to pass the embed credentials to YouTube's "unlisted live" or Twitch's sub-only stream and gate access at the iframe-render layer, not to host video ourselves.
+
+**Decision: do NOT build native streaming. Ever, until proven wrong by a paying customer asking for it specifically.**
+
+---
+
+## 8. Cost-at-scale table
+
+Assumptions for this table:
+
+- 1 livestream block on average per creator page that uses the feature
+- 30 % of creators on the platform use at least one Livestream block (industry-typical adoption)
+- Of those, 50 % stream weekly+ (true "hot" channels), 50 % stream rarely (cold channels, polled less aggressively)
+- Each "hot" channel polled every 60 s **only when its page received a visitor in the last 24 h** (see §4.3)
+- Each "cold" channel polled every 30 min on visitor activity, otherwise never
+- Average page sees 5 visitors per day at 100 DAU plat-wide; ratio holds at scale
+
+DAU here = total unique daily visitors to ANY tadaify creator page, NOT creators.
+
+| Plat DAU | Active hot channels (estimate) | Polls/day (Twitch+Kick batched) | Polls/day (YouTube, before WebSub) | YouTube quota cost/day | Estimated USD/month for live-state |
+|---|---|---|---|---|---|
+| 100 | ~5 | ~7k (batched) | ~7k → 7×100 = 700 units/day if individual | well under free quota | $0 |
+| 1 000 | ~50 | ~70k (batched into 700 calls/day) | ~70k → unfeasible without WebSub | exceeds free 10k/day → must move to WebSub | $0 (WebSub is free; just dev time) |
+| 10 000 | ~500 | ~700k (7k calls/day Helix, well under limit) | ~700k via WebSub: free | 0 (WebSub) | < $1 (cron compute) |
+| 100 000 | ~5 000 | ~7M (70k calls/day, near 50% of Helix daily ceiling — use authenticated app) | ~7M via WebSub | 0 (WebSub) | $5–$10 (compute + DB writes) |
+| 1 000 000 | ~50 000 | ~70M — REQUIRES authenticated EventSub (cap raised) for Twitch; sharding of WebSub callbacks for YouTube | ~70M via WebSub | 0 (WebSub) | $50–$200 (compute, mostly Postgres write IOPS for state-change rows) |
+
+**Key insight:** the dominant cost of live-state detection at every scale is **engineer time to migrate to webhooks**, NOT API quota or compute. There is **no scale at which embedding livestreams costs tadaify more than dollars per month.** Self-hosting (§7) costs >$100 per active creator per month from creator #1.
+
+### 8.1 Iframe rendering cost
+
+Rendering an iframe is **free to tadaify** — the visitor's browser fetches video bytes directly from YouTube / Twitch / Kick. tadaify serves zero video bytes. Page weight goes up by ~1 MB (provider's player JS + initial player chunk) on first paint, which is comparable to the Video block today.
+
+---
+
+## 9. MVP recommendation
+
+### 9.1 Ship in v1 (MVP)
+
+| Question | Answer |
+|---|---|
+| Which providers? | **YouTube Live, Twitch, Kick** (in this priority order in the picker UI) |
+| Self-host streaming? | **NO** — never, until proven wrong by a paying customer asking |
+| Notification subscription ("ping me when X goes live")? | **NO** — link to native platform follow buttons instead |
+| Chat embed? | **NO** — link to native chat on the provider's site |
+| Schedule / next-broadcast field? | **YES, soft** — read it from the provider when free to do so, fall back gracefully when missing |
+| Multi-channel binding? | **NO** — one channel per Livestream block. Creators add a second block if they stream on two platforms (rare). |
+| Per-block tier? | **FREE on all paid tiers AND on the free tier with a 1-block cap** (see §10) |
+| Live-state detection? | Polling-only at MVP, hot-channel filter active, WebSub upgrade staged for v1.1 once real channel count requires it |
+
+### 9.2 Defer to v1.1 / v2
+
+| Item | Trigger to revisit |
+|---|---|
+| YouTube WebSub push subscription | when polled YouTube channel count crosses ~500 |
+| Twitch EventSub authenticated push | when polled Twitch channel count crosses ~5 000 |
+| Kick events push | parallel with Twitch upgrade |
+| X Live (beta) | if 10+ MVP creators ask for it specifically |
+| Chat embed | if a creator pilot shows fans expect chat in the iframe (uncertain — most fans use the native platform's chat) |
+| TikTok Live | most likely never (no compliant integration path) |
+| Instagram Live | never (no compliant integration path) |
+| Native streaming (Cloudflare Stream Live) | only if a paying creator explicitly contracts for paywalled exclusive lives |
+| Notification subscription | only as part of a broader "Fan club" feature, not a Livestream-block bolt-on |
+
+---
+
+## 10. Tier-gating
+
+Per the user's standing rule (`feedback_no_fake_margin_tier_gating.md`): only gate features on **real infra cost**, not on perceived value.
+
+**Real infra cost of a Livestream block:**
+
+- Iframe render: $0
+- Live-state detection: <$0.001 / channel / month at MVP scale; <$0.01 / channel / month even at 1 M DAU
+- Storage: ~200 bytes per block row in Postgres
+
+**Therefore: the Livestream block should NOT be a paid-tier-only feature.** Charging for it would be fake-margin gating.
+
+### 10.1 Recommended tiering
+
+| Tier | Livestream block availability |
+|---|---|
+| **Free** | YES — limited to **1 Livestream block** per page (sufficient for the typical case of "one creator, one platform"). The cap exists not to extract revenue but to limit abuse: a malicious user creating a thousand Livestream blocks pointed at the most-popular YouTube channels could trigger meaningful poll volume against our quota with zero personal interest in the page. |
+| **Pro / Paid** | YES — unlimited Livestream blocks per page (multi-platform creators, special-event pages with multiple co-hosts) |
+| **Pro / Paid** | YES — Livestream block can be configured with custom poll cadence (default 60 s; Pro can request 30 s for high-stakes broadcasts) — purely a UX choice, the underlying cost difference is rounding-error |
+
+### 10.2 What the picker should look like
+
+- Free user: Livestream tile is enabled, fully visible, fully interactive in the editor. If they try to add a SECOND Livestream block, the save fails with "Free plan supports 1 Livestream block per page. Upgrade for unlimited livestream blocks across multiple platforms." Per `feedback_no_blur_premium_features.md`: validation at save time, never at display time. The block in the picker is never blurred or hidden.
+
+### 10.3 Three pricing variants (per `feedback_no_fake_margin_tier_gating.md`)
+
+| Variant | Free tier limit | Paid tier behaviour | Rationale |
+|---|---|---|---|
+| **Cost-based (recommended)** | 1 block / page | Unlimited | Reflects the actual ~$0 cost of the feature; cap is anti-abuse, not revenue extraction |
+| **Competitor-match** | 1 block / page, polling cadence 5 min | Unlimited blocks, polling cadence 60 s | Gating on detection latency feels like a real difference but is technically arbitrary; matches what Linktree-likes do for "live" widgets |
+| **Aggressive (NOT recommended)** | 0 blocks / page (paid-only) | Unlimited | Maximises conversion pressure but extracts revenue from a feature that costs us nothing to ship — invites churn and competitor mockery |
+
+**Pick: cost-based (variant 1).** Strong defaults; matches the rest of tadaify's no-fake-gating posture.
+
+---
+
+## 11. UX flow in the block editor
+
+### 11.1 Form fields
+
+```
+[ Livestream block configuration ]
+
+Provider:   ( ) YouTube Live    ( ) Twitch    ( ) Kick
+
+Channel:    [______________________________]  [Test]
+            Examples (per provider):
+              YouTube — paste your channel URL or @handle (e.g. https://youtube.com/@my-channel or @my-channel)
+              Twitch — paste your channel URL or username (e.g. https://twitch.tv/myhandle or myhandle)
+              Kick   — paste your channel URL or username
+
+[Test] button result:
+  ✓ Found channel: <Channel Display Name> (last live: 3 days ago)
+  ✗ Channel not found. Double-check the handle and try again.
+
+When offline:
+  [○] Show offline state with last-VOD link  (default ON)
+  [○] Show "Follow me on <Provider>" CTA      (default ON)
+  Custom message (optional, replaces default):
+  [_______________________________________________________]
+
+When live:
+  [○] Auto-play (muted)        (default ON; visitor can unmute)
+  [○] Show LIVE badge overlay  (default ON)
+```
+
+### 11.2 The [Test] button
+
+This is the highest-leverage UX element in the entire block. On click:
+
+1. Server-side resolves the input to canonical form (YouTube `@handle` → `UC…`; Twitch / Kick username already canonical).
+2. Calls the live-state API once.
+3. Returns one of:
+   - `✓ Found channel: <Display Name> (currently LIVE — 1.2k watching)`
+   - `✓ Found channel: <Display Name> (last live: 3 days ago)`
+   - `✗ Channel not found.`
+   - `✗ Channel found but appears to never have streamed live. Are you sure this is the right account?`
+
+The last variant is critical for catching the most common error: a creator pasting their personal YouTube account ID instead of their broadcast channel ID, or pasting a channel that only posts VODs.
+
+### 11.3 Edge cases the editor must handle
+
+| Edge case | UX response |
+|---|---|
+| Creator pastes a YouTube **video URL** (not a channel URL) | Detect `watch?v=…` pattern, error: "This looks like a single video, not a channel. Use the Video block for one-off videos. For Livestream, paste your channel URL." |
+| Creator pastes a YouTube **playlist URL** | Detect `playlist?list=…`, error: "Playlists aren't supported by the Livestream block. Use the Video block for playlists." |
+| Creator pastes a Twitch **VOD URL** (`twitch.tv/videos/…`) | Detect, error: "This is a Twitch VOD, not a live channel. Paste `twitch.tv/<your-username>` instead." |
+| Creator's channel is private / unlisted | API returns "channel not found" — generic error message acceptable |
+| Creator changes their YouTube @handle after saving the block | We stored both `UC…` and the original handle. `UC…` is permanent; embed continues to work. The "original input" field on the block becomes a paper trail. |
+| Creator's channel is suspended / DMCA'd | Iframe shows the provider's suspension placeholder. Block still renders. We can detect this from the API call (404 / 403) and surface a "this channel appears to be suspended on <Provider>" warning in the editor on next save. |
+| Creator has multiple scheduled future YouTube streams (the "embed breaks" case) | We cannot fix this — it is YouTube's bug. The offline-state UI must include "having trouble seeing the stream? open in YouTube" CTA so visitors are never fully stuck. |
+| Provider has an outage (YouTube, Twitch, Kick API down) | The cron's last-known state remains in Postgres. The block shows the last known state with a small `state may be stale` icon. Better than 500-ing the whole page. |
+| Visitor is in a country / network where the provider is blocked (e.g. Twitch in Russia) | Iframe fails silently — provider's problem, not ours. We can detect repeated iframe load failures client-side and surface "having trouble loading the stream? open in <Provider>" after a 10 s timeout. |
+
+### 11.4 Editor preview
+
+The block editor shows a live preview of the configured block in both live and offline states (toggle switch in the editor toolbar). The preview uses a stub channel ("twitchpresents") for which we know the iframe renders correctly, NOT the creator's own channel — which would risk showing them an embarrassing offline state in the editor when they are actively configuring the block. (Per `feedback_mockup_full_feature_vision.md`: the editor preview SHOWS the live state regardless of whether the creator's channel is currently live. This is the design contract.)
+
+---
+
+## 12. Technical implementation sketch
+
+### 12.1 Data model
+
+```sql
+-- Per-block configuration
+create table livestream_block (
+  id              uuid primary key default gen_random_uuid(),
+  page_id         uuid not null references page(id) on delete cascade,
+  provider        text not null check (provider in ('youtube','twitch','kick')),
+  channel_handle  text not null,         -- raw user input
+  channel_id      text not null,         -- resolved canonical id (UC… for YT; username for Twitch/Kick)
+  display_name    text,                  -- cached for offline state UI
+  show_offline_state         boolean not null default true,
+  show_native_follow_cta     boolean not null default true,
+  custom_offline_message     text,
+  autoplay_when_live         boolean not null default true,
+  show_live_badge            boolean not null default true,
+  created_at      timestamptz not null default now(),
+  updated_at      timestamptz not null default now()
+);
+
+create index livestream_block_page_id_idx on livestream_block(page_id);
+
+-- Per-channel live-state cache (one row per (provider, channel_id), shared across blocks)
+create table livestream_state (
+  provider                  text not null,
+  channel_id                text not null,
+  is_live                   boolean not null default false,
+  current_video_id          text,
+  current_title             text,
+  current_viewer_count      int,
+  last_seen_live_at         timestamptz,
+  next_scheduled_live_at    timestamptz,
+  last_polled_at            timestamptz not null default now(),
+  last_state_change_at      timestamptz,
+  last_polled_method        text check (last_polled_method in ('poll','websub','eventsub','events')),
+  primary key (provider, channel_id)
+);
+
+create index livestream_state_polled_at_idx on livestream_state(last_polled_at);
+```
+
+Note: `livestream_state` is keyed on `(provider, channel_id)`, NOT on `block_id`. Two creators embedding the same Twitch channel share the same state row — single source of truth, single poll per channel regardless of how many tadaify pages embed it.
+
+### 12.2 Edge functions
+
+| Function | Trigger | Job |
+|---|---|---|
+| `resolve-channel` | Called by editor on `[Test]` click and on save | Resolves user input → canonical id; one call to the provider's API; writes / updates `livestream_state` |
+| `poll-live-state` | `pg_cron` every 60 s | Picks the 100 oldest "hot" `livestream_state` rows, fan-outs to provider APIs, updates rows |
+| `livestream-state` | HTTP, called from the block render | Reads `livestream_state` for the block's channel; returns JSON |
+| `youtube-websub-callback` (v1.1) | HTTP, hit by YouTube's WebSub hub | Verifies HMAC, parses Atom feed, updates `livestream_state` with `last_polled_method='websub'` |
+| `twitch-eventsub-callback` (v1.1) | HTTP, hit by Twitch | Verifies HMAC, parses event, updates state |
+
+### 12.3 RLS
+
+- `livestream_block`: standard tenancy (creator can read/write their own; published pages allow public SELECT for renderer)
+- `livestream_state`: public read, service-role write only (only edge functions write)
+
+### 12.4 Secrets
+
+- `YOUTUBE_DATA_API_KEY` — Supabase Secrets, read by `resolve-channel` and `poll-live-state`
+- `TWITCH_CLIENT_ID` + `TWITCH_CLIENT_SECRET` — Supabase Secrets, used to mint app-access tokens
+- `KICK_CLIENT_ID` + `KICK_CLIENT_SECRET` (if using OAuth) — Supabase Secrets
+
+Per CLAUDE.md secrets convention: each one also gets an SSM parameter in Terraform for documentation / cleanup.
+
+### 12.5 Dependencies
+
+- `youtubei.js` or direct REST calls via `fetch` (no SDK strictly required)
+- `@twitch/easy-helix` or direct fetch (no SDK strictly required)
+- For WebSub HMAC verification: `crypto.subtle` is sufficient — no extra dep
+
+### 12.6 Telemetry & operational metrics
+
+Every Livestream block deserves first-class observability — both to debug visitor reports and to feed the upgrade-trigger decisions in DEC-LIVE-05. The minimum operational surface:
+
+| Metric | Source | Use |
+|---|---|---|
+| `livestream.block.count.total` | Postgres count | base population for all ratios |
+| `livestream.block.count.by_provider` | Postgres group-by | provider mix; informs which webhook upgrade to ship first |
+| `livestream.poll.invocations.per_minute` | edge function logs | watching the Helix / YouTube quota burn rate |
+| `livestream.poll.errors.rate` | edge function logs | provider outage detection; auto-degrade to last-known state |
+| `livestream.poll.latency.p99` | edge function logs | Helix outages typically manifest as p99 spikes before they become 5xx |
+| `livestream.state.is_live.changes_per_hour` | trigger on UPDATE | sanity check on detection — wild oscillation = bug |
+| `livestream.render.is_live.fraction` | rendered-page beacon | empirical "what fraction of Livestream-block visits land on a live broadcast?" — informs whether the offline-state UX actually matters or is the dominant case |
+| `livestream.render.click_through.by_state` | rendered-page beacon | how often visitors click the "Follow on Provider" CTA when offline; informs DEC-LIVE-04 fallback ladder |
+
+These metrics drive two decisions post-launch:
+- **WebSub upgrade timing (DEC-LIVE-05):** when `livestream.poll.invocations.per_minute` * 100 (YouTube) crosses the daily 10k quota line, file the migration ticket.
+- **Offline-state ladder (DEC-LIVE-04):** if `livestream.render.is_live.fraction < 0.05` (95 % of visits land in offline state), the offline-state UX is the dominant experience and worth additional polish; if `> 0.5`, it is a thin failure case and we can simplify.
+
+### 12.7 Failure modes & defensive UX
+
+Detailed failure-mode analysis — every external dep is a future incident.
+
+| Failure | Detection | Visitor-side UX | Engineer-side response |
+|---|---|---|---|
+| Provider API hard-down (5xx for >5 min) | poll error rate >50 % across N consecutive runs | Last-known state from cache; "stream state may be stale" subtle indicator | Pause cron for that provider, alert via Sentry |
+| Provider API rate-limited (429) | 429 from Helix / YouTube | No visitor change (cron retries with exponential backoff) | Switch app token, batch more aggressively |
+| Provider's iframe domain (player.kick.com) DNS-blocked locally | client-side iframe load failure timeout | After 10 s, surface "having trouble loading the stream? open in <Provider>" CTA | Nothing (visitor-side only) |
+| Channel deleted / suspended on provider | poll returns 404 / 403 sustained | Surface "this channel appears unavailable on <Provider>" + offer to remove block | Email creator with cleanup suggestion (low-priority) |
+| Creator changed YouTube handle (channel ID still valid) | Resolved `UC…` still works; cached display_name diverges | Visitor sees stale display name in offline-state UI | Background reconciliation cron refreshes display_name daily |
+| Provider revokes our app's API access (ToS violation, incident) | poll returns 401 across all channels for that provider | All blocks for that provider show "stream state unavailable" placeholder + iframe still works | Page on-call; either re-key (transient) or re-apply (longer recovery) |
+| Postgres `livestream_state` row deletion (operator error) | Render falls back to "cold" state | Block degrades gracefully | Restore from backup; not a visitor-visible outage |
+| WebSub callback URL DNS / TLS failure (post-v1.1) | YouTube unsubscribes us automatically after N retries | Cron polling resumes as fallback | Re-subscribe via lease-renewal cron |
+
+**Critical principle:** the Livestream block must NEVER make the entire creator page fail to render. Every external call wraps in a try/catch with a graceful degradation. The block area renders empty (or with the most pessimistic fallback UI) before it crashes the page.
+
+### 12.8 Privacy & GDPR considerations
+
+The iframe loads provider JS (YouTube/Twitch/Kick), which sets cookies, tracks visitors, and feeds the provider's analytics. This is a real GDPR concern for tadaify creators serving EU traffic.
+
+| Concern | Mitigation |
+|---|---|
+| Provider sets tracking cookies before consent | Use `youtube-nocookie.com` for YouTube embeds (it defers cookie set until interaction). Twitch / Kick have no equivalent — accept the trade-off and document it. |
+| Visitor in EU sees a creator page with auto-loading iframes that fingerprint them | Lazy-load: iframe is replaced with a click-to-load placeholder until visitor clicks or scrolls into view. Already a common pattern; reduces TTFP and is a privacy win. |
+| Creator's GDPR notice must mention third-party embeds | Standard creator-side notice template (already on tadaify backlog as part of GDPR compliance work for the platform); the Livestream block adds YT/Twitch/Kick to the list of third parties. |
+| `delete_user_data()` RPC must DELETE `livestream_block` rows | Already in scope: any table with `user_id` (transitively via `page.user_id`) is covered by the standard delete cascade |
+| Visitor logs / analytics should NOT include provider iframe URLs | Render-time beacon includes only `block_id` + `is_live` state, never provider channel ID |
+
+The lazy-load pattern is also a TTFP win on slow networks; recommended for v1 even before privacy review.
+
+### 12.9 Tests
+
+- **Unit (priority per `feedback_ci_unit_tests_allowed.md`):**
+  - `resolveYouTubeHandle('@foo')` → `'UC…'` mock
+  - `resolveTwitchUsername('foo')` → `'foo'` (passthrough)
+  - `parseChannelInput('https://twitch.tv/videos/12345')` → `{ error: 'video_url_not_channel' }`
+  - `parseChannelInput('https://www.youtube.com/watch?v=…')` → `{ error: 'video_url_not_channel' }`
+  - `chooseFallbackUI({ is_live: false, last_seen_live_at: '2026-04-25', next_scheduled_live_at: null })` → `'recent_vod'`
+  - `chooseFallbackUI({ is_live: false, last_seen_live_at: null, next_scheduled_live_at: null })` → `'cold'`
+- **Integration (mocked HTTP):**
+  - `pollLiveState` batches 100 Twitch logins into 1 call
+  - `pollLiveState` skips channels not visited in the last 24 h
+  - `youtube-websub-callback` rejects requests with bad HMAC
+- **Playwright (per the new plan-then-tests workflow):**
+  - Editor: paste a YouTube channel URL → `[Test]` shows `Found channel: …`
+  - Editor: paste a Twitch VOD URL → `[Test]` shows `This is a Twitch VOD, not a live channel`
+  - Block render: when `is_live=true` (mocked), iframe present
+  - Block render: when `is_live=false`, offline-state UI present with the right CTA tier
+
+---
+
+## 12.10 Rollout plan
+
+Phased rollout reduces blast radius and lets us validate live-state detection before opening the firehose.
+
+**Phase 0 — internal dogfood (1 week)**
+- Single tadaify-internal page with a YouTube + Twitch + Kick block each
+- Manual `[Test]` flows; verify the cron writes correctly
+- No real visitors; pure write-path validation
+
+**Phase 1 — closed beta (2 weeks)**
+- Whitelist of 10–20 friendly creators, all on the Pro tier
+- Cron polls real channels, real visitors, real iframes
+- Daily review of telemetry: `is_live.changes_per_hour`, poll error rate
+- Goal: catch provider edge cases (handle changes, suspended channels, rate limit surprises) before public
+
+**Phase 2 — public free + paid (open)**
+- Block is live in the picker for all creators
+- Anti-abuse cap on free tier engaged
+- WebSub upgrade decision metric tracked from day 0
+
+**Phase 3 — webhook migration (when triggered)**
+- Per DEC-LIVE-05 timing
+- Per-provider migration; YouTube first because of quota pressure
+- Fallback polling stays as backstop at 30-min cadence
+
+The hard rule: **no Livestream block ships to a real creator's published page until Phase 1 has run for one full creator-week without a P1 incident.** This is a "first impression matters" feature — a broken Livestream block is the kind of thing a creator publicly tweets a screenshot of.
+
+## 12.11 Migration / backwards compatibility
+
+If this SPIKE results in a breaking change to an already-shipped Livestream block schema (e.g. moving from `videoId` to `channelId`), provide a migration path:
+
+1. New columns added with `NULL` default
+2. Background backfill cron resolves existing `videoId` blocks → owner channel via provider API
+3. Once 100 % backfilled, drop old columns in a follow-up PR
+4. Editor UI defaults to the new flow but accepts old configurations until the deprecation deadline
+
+For this SPIKE the assumption is the Livestream block does NOT yet ship in production — there is no migration burden. If it has shipped (verify before implementation), apply the above pattern.
+
+## 12.12 Internationalisation notes
+
+- Channel handles can contain Unicode (Twitch and YouTube both allow). The `[Test]` resolution must NOT lower-case or otherwise mangle input.
+- Display names are user-controlled strings on the provider side. Render escaped, never as innerHTML.
+- "Last live X ago" timestamp formatting must respect visitor locale (Intl.RelativeTimeFormat). Already a tadaify TR for any user-visible timestamp.
+- Provider names ("YouTube", "Twitch", "Kick") stay in English everywhere, including localised UIs — these are brand names.
+- The "Notify me on YouTube" CTA copy: localise the verb, keep the brand name. ("Powiadom mnie na YouTube", "Notify me on YouTube", etc.)
+
+## 13. Open DECs
+
+The following decisions need user input before implementation begins.
+
+### DEC-LIVE-01 — Which 3 providers ship in MVP?
+
+**Czego dotyczy:** scope of provider support in v1 of the Livestream block.
+
+**Szczegolowy opis:** The Livestream block needs at least one provider to be usable. The research shows three providers (YouTube, Twitch, Kick) have clean iframe + live-state-API support; X Live is partial (JS widget, restrictive API); TikTok Live and Instagram Live have no compliant embed path. Shipping more providers means more editor UI and more edge cases per launch; shipping fewer leaves creators on excluded platforms unable to use the block at all.
+
+**Opcje:**
+1. YouTube + Twitch + Kick (recommended)
+2. YouTube + Twitch only — defer Kick to v1.1 (smaller MVP scope, lose gaming-creator demo)
+3. YouTube only — minimum viable Livestream block (creator survey first to validate before expanding)
+4. All four (YouTube + Twitch + Kick + X Live as beta) — broadest support, accept X's UX is degraded
+
+**Twoja rekomendacja:** **Option 1.** Three providers, all with first-class iframe + API support. Marginal cost of adding Kick alongside YouTube + Twitch is small (~2–3 days) and Kick is the fastest-growing alt-platform in tadaify's likely creator demographic. Skipping it now means another sprint later.
+
+### DEC-LIVE-02 — Notification subscription in MVP?
+
+**Czego dotyczy:** whether visitors can subscribe to a tadaify-side "ping me when X goes live" notification in v1.
+
+**Szczegolowy opis:** §6 lays out the cost: 5–6 dev weeks of MVP scope expansion, plus an entirely new product surface (subscriber lists per creator, compliance, anti-spam, unsubscribe UX). The cheap alternative is linking to native subscribe pages (YouTube `?sub_confirmation=1`, Twitch follow URL, Kick follow). The native path requires zero infrastructure and the platforms handle delivery + compliance. The downside is no aggregation across providers (a fan following a creator's YouTube and Twitch separately gets two pings, not one).
+
+**Opcje:**
+1. NO — link to native subscribe pages only (recommended)
+2. YES — build email-only notify-me, push notifications deferred (still ~3 weeks of work)
+3. YES — full email + web-push subscription (5–6 weeks of work)
+
+**Twoja rekomendacja:** **Option 1.** Native subscribe is good enough for 95 % of fans, costs zero, and ships with the block. If adoption data later shows fans want aggregated notifications, build it as part of a "Fan club" feature (see open SPIKE on newsletter integration), NOT bolted onto Livestream.
+
+### DEC-LIVE-03 — Tier-gating model
+
+**Czego dotyczy:** how (or whether) to gate the Livestream block by paid tier.
+
+**Szczegolowy opis:** Real infra cost is ~$0 / block / month. Per `feedback_no_fake_margin_tier_gating.md`, gating on imagined value rather than real cost is forbidden. §10 lists three pricing variants. Variant 1 (1 block / page on free, unlimited on paid) is cost-based. Variant 2 (poll cadence as the gate) feels like a real difference but is technically arbitrary. Variant 3 (paid-only) extracts revenue from a feature that costs nothing to ship.
+
+**Opcje:**
+1. Variant 1 — Free: 1 block / page; Paid: unlimited (recommended)
+2. Variant 2 — Free: 1 block / page + 5-min poll cadence; Paid: unlimited + 60 s poll cadence
+3. Variant 3 — Free: no Livestream block; Paid only
+4. Free: unlimited blocks (no anti-abuse cap) — simplest, accept potential abuse risk
+
+**Twoja rekomendacja:** **Option 1.** Cost-based gating, anti-abuse cap is light, paid users get a real benefit (multi-platform support on one page). Aligns with the no-fake-margin posture.
+
+### DEC-LIVE-04 — When-not-live UX default state
+
+**Czego dotyczy:** default UX when the creator is not currently live.
+
+**Szczegolowy opis:** §5 proposes a 4-tier fallback (live → upcoming-scheduled → recent-VOD → cold). All four tiers are good UX, but the more we show, the more API quota we burn opportunistically (next-scheduled lookup, last-VOD lookup). The minimal version is "channel avatar + Follow CTA" (tier 4 only). The maximal version is the full 4-tier ladder.
+
+**Opcje:**
+1. Full 4-tier ladder (recommended) — best UX, opportunistic API hits
+2. Minimal: channel avatar + Follow CTA only — cheapest, blandest
+3. 2-tier: live → "channel offline + Follow CTA" — cheap, no need to look up VODs or schedule
+
+**Twoja rekomendacja:** **Option 1.** The opportunistic lookups happen once per day per channel, well within any provider's free quota. The UX upside (showing the next stream time, or the most-recent VOD as a "while you wait" CTA) is significant for fan retention. Cost is rounding-error.
+
+### DEC-LIVE-05 — WebSub / EventSub upgrade timing
+
+**Czego dotyczy:** when to stop relying on polling and switch to push subscriptions per provider.
+
+**Szczegolowy opis:** Polling is fine at MVP scale. YouTube specifically becomes infeasible past ~500 polled channels (10 000 quota / 100 per call = 100 polls / day max on default project). Twitch / Kick polling stays fine into the tens of thousands of channels. The trigger to migrate per provider is a function of channel count, NOT calendar time. The question is whether we pre-build the WebSub handler now (and ship it dormant) or defer the entire implementation until the trigger fires.
+
+**Opcje:**
+1. Ship polling-only at MVP; build WebSub when YouTube channel count crosses 500 (recommended)
+2. Build WebSub at MVP, ship it active immediately (more work upfront, never have to scramble)
+3. Ship polling-only at MVP; defer WebSub indefinitely, scramble if/when quota becomes a problem
+
+**Twoja rekomendacja:** **Option 1.** Track the channel count metric from day 1; when it crosses 500 (or any provider's polling cost crosses $1/month), file the migration ticket. Do NOT build WebSub speculatively — there is a real chance Livestream-block adoption is low enough that we never need it.
+
+### DEC-LIVE-06 — Native streaming (Cloudflare Stream Live) future path
+
+**Czego dotyczy:** under what circumstances tadaify ever hosts livestreams ourselves.
+
+**Szczegolowy opis:** §7 makes the case that self-hosting livestream is strictly worse than embedding for tadaify's MVP target. The only justification would be "creator wants exclusive paywalled live broadcasts that can't go on YouTube/Twitch/Kick because they violate ToS or because the creator wants to capture 100 % of revenue." This is a real market segment (paid live workshops, premium fitness classes, OnlyFans-adjacent content) but it is NOT MVP and probably not v1.
+
+**Opcje:**
+1. Document explicitly "NEVER, until proven wrong by a paying customer asking" (recommended)
+2. Document as "v3+ candidate, file a research SPIKE if a creator asks"
+3. Reserve the option silently, do not document publicly — keep it open
+
+**Twoja rekomendacja:** **Option 1.** Public, unambiguous "we embed, we don't host" positioning is a feature: it sets the right expectation with creators (you keep your audience and your monetisation), it differentiates us from Linktree-likes that try to be everything, and it lets us focus engineering on actual MVP features.
+
+---
+
+## 14. Competitive precedents — what do similar creator-page tools do?
+
+Quick survey of how the closest creator-page competitors handle livestream embedding. Useful both as feature-parity reference and as a sanity check that our recommendation isn't an outlier.
+
+### 14.1 Linktree
+
+- **Livestream support:** dedicated "YouTube" and "Twitch" link types that auto-detect a live broadcast on the linked channel and surface a "● LIVE NOW" badge inline on the linktree page.
+- **Mechanism:** server-side polling (per their public engineering posts circa 2023); pull cadence not documented but appears to be in the 1–5 min range.
+- **Self-hosted streaming:** none.
+- **Notifications:** none on Linktree side; CTAs only deep-link to native subscribe.
+- **Tier-gating:** free; the badge is part of the link card and not a paid upsell.
+
+**Read-out for tadaify:** validates the "embed + live-state badge + link to native subscribe" pattern as the correct shape. Linktree has been at this for years and never expanded into self-hosted livestreaming.
+
+### 14.2 Beacons
+
+- **Livestream support:** generic "Embed video" block; no first-class live-state detection. Creators paste a YouTube URL and live works opportunistically.
+- **Self-hosted streaming:** none.
+- **Notifications:** general "subscribe to my updates" email capture (separate feature).
+- **Tier-gating:** the embed block is free; email capture is paid.
+
+**Read-out for tadaify:** Beacons leaves money on the table by not having a first-class Livestream block. Our differentiator is the live-state detection + offline-state UX. Worth shipping.
+
+### 14.3 Carrd
+
+- **Livestream support:** none specific. Creators use the generic "Embed" element with a YouTube URL.
+- **Self-hosted streaming:** none.
+- **Tier-gating:** Embed elements are gated behind Pro Plus ($19/year — the highest tier).
+
+**Read-out for tadaify:** Carrd's "embed-everything-as-a-paid-feature" model is the wrong precedent for tadaify. Shipping Livestream as a clean first-class block on the free tier is a meaningful product differentiator vs Carrd.
+
+### 14.4 Bento
+
+- **Livestream support:** dedicated YouTube and Twitch blocks with live-state badge; same pattern as Linktree.
+- **Self-hosted streaming:** none.
+- **Notifications:** none.
+- **Tier-gating:** free.
+
+**Read-out for tadaify:** convergent design across Linktree and Bento — both shipped exactly the embed + badge + native-subscribe pattern. Strong evidence the recommendation in §9 is the right shape.
+
+### 14.5 Stan Store
+
+- **Livestream support:** none. Stan Store optimises for product sales, not live broadcasts.
+- **Self-hosted streaming:** none.
+
+**Read-out for tadaify:** different product positioning; not directly comparable. Mentioned only to confirm there is no creator-page competitor that has built native streaming infra.
+
+### 14.6 Summary
+
+**No major competitor self-hosts livestreaming.** Every player in the creator-page space that supports live (Linktree, Bento, and others) does it via embeds + live-state detection. This is dispositive evidence that the §7 conclusion (do not self-host) is correct: not a single competitor with a multi-million-creator user base has found a business case to build native streaming, despite all the obvious adjacent monetisation opportunities (paywalled streams, exclusive content, etc.).
+
+The two consistent gaps across competitors that tadaify can differentiate on:
+1. **Better offline-state UX** — Linktree's offline state is just "no badge"; Bento's is similar. Our 4-tier ladder (§5) is genuinely better.
+2. **Multi-platform support on free tier** — Linktree caps custom blocks on free; we can ship YT + Twitch + Kick for free with a 1-block-per-page anti-abuse cap.
+
+## 15. Editor copy strings (English source — for translation handoff)
+
+Centralising the UX copy in one section so the unit-test-writer + i18n team work from the same source.
+
+| Key | English source string |
+|---|---|
+| `livestream.picker.title` | Livestream |
+| `livestream.picker.description` | Auto-shows your live broadcast when you go on air, with an offline fallback. Not for static videos — use the Video block. |
+| `livestream.editor.provider.label` | Provider |
+| `livestream.editor.channel.label` | Channel |
+| `livestream.editor.channel.placeholder.youtube` | https://youtube.com/@your-channel |
+| `livestream.editor.channel.placeholder.twitch` | https://twitch.tv/your-channel |
+| `livestream.editor.channel.placeholder.kick` | https://kick.com/your-channel |
+| `livestream.editor.test.button` | Test |
+| `livestream.editor.test.success.live` | ✓ Found channel: {name} (currently LIVE — {viewers} watching) |
+| `livestream.editor.test.success.recent` | ✓ Found channel: {name} (last live: {relative}) |
+| `livestream.editor.test.success.cold` | ✓ Found channel: {name} (no live broadcasts yet) |
+| `livestream.editor.test.error.notfound` | ✗ Channel not found. Double-check the handle and try again. |
+| `livestream.editor.test.error.video_not_channel` | ✗ This looks like a single video, not a channel. Use the Video block for individual videos. |
+| `livestream.editor.test.error.playlist_not_channel` | ✗ Playlists aren't supported by the Livestream block. Use the Video block for playlists. |
+| `livestream.editor.test.error.vod_not_channel` | ✗ This is a {provider} VOD, not a live channel. Paste your channel URL instead. |
+| `livestream.editor.test.error.suspended` | ⚠ This channel appears to be unavailable on {provider}. |
+| `livestream.editor.offline.title` | When offline |
+| `livestream.editor.offline.show_recent_vod` | Show offline state with last-VOD link |
+| `livestream.editor.offline.show_follow_cta` | Show "Follow me on {provider}" CTA |
+| `livestream.editor.offline.custom_message.label` | Custom message (optional, replaces default) |
+| `livestream.editor.live.title` | When live |
+| `livestream.editor.live.autoplay` | Auto-play (muted) |
+| `livestream.editor.live.show_badge` | Show LIVE badge overlay |
+| `livestream.editor.tier_cap.free` | Free plan supports 1 Livestream block per page. Upgrade for unlimited livestream blocks across multiple platforms. |
+| `livestream.render.badge.live` | ● LIVE NOW |
+| `livestream.render.badge.live_with_viewers` | ● LIVE NOW · {viewers} watching |
+| `livestream.render.offline.scheduled` | {name} goes live {relative} — set a reminder |
+| `livestream.render.offline.recent_vod` | {name} is offline. Last live {relative}. |
+| `livestream.render.offline.cold` | {name} isn't streaming right now. |
+| `livestream.render.offline.cta.notify_native` | Notify me on {provider} |
+| `livestream.render.offline.cta.watch_recent` | Watch the latest stream |
+| `livestream.render.offline.cta.follow` | Follow on {provider} |
+| `livestream.render.error.iframe_failed` | Having trouble loading the stream? Open in {provider} |
+| `livestream.render.error.state_stale` | Stream state may be stale |
+
+These strings drive both the editor unit tests (assert correct copy by key) and the i18n bundle (every key has a Polish translation in `pl.json` per project i18n convention).
+
+## 16. Open questions for follow-up SPIKEs
+
+Items that surfaced during this research but are out of scope for this SPIKE — file as separate research tickets if/when relevant:
+
+1. **Chat-on-page integration** — if v2 demand surfaces, is the right shape (a) embedded Twitch/YouTube/Kick chat in a sidebar, (b) a tadaify-side aggregated chat across providers (technically infeasible without read access to provider chat streams), or (c) skip entirely?
+2. **Multi-host live events** — a creator co-streaming with another creator (real use case in gaming): should the Livestream block support pinning two channel handles and showing both side-by-side, or is that exotic enough to leave to the Embedded block?
+3. **Schedule visualisation** — if the "next scheduled broadcast" data is good enough across providers, is there a separate "Live Schedule" block that just shows a calendar of upcoming broadcasts (no live player at all)? Different shape from the Livestream block; potential add for v2.
+4. **Live broadcast announcements via the tadaify Newsletter block** — when `stream.online` fires, automatically push a one-line "I'm live now: <link>" to the creator's newsletter list. Couples Livestream to Newsletter; needs explicit consent design.
+5. **Discord / Bluesky / Mastodon Live** — emerging providers with real but small audiences. Re-evaluate at v2 if any of them ship a clean public iframe + live-state API.
+6. **iOS / Android native app considerations** — when tadaify ships native apps, can the Livestream block degrade gracefully (open native YouTube app via universal link instead of an in-app webview iframe)? Already standard practice; flag for the mobile app SPIKE.
+
+## 17. Sources
+
+### Embed documentation
+
+- [YouTube IFrame Player API](https://developers.google.com/youtube/iframe_api_reference) — generic embed reference (live not specifically documented here)
+- [YouTube embed support article](https://support.google.com/youtube/answer/171780) — generic video embed
+- [Webflow community: embedding YouTube live by channel ID](https://discourse.webflow.com/t/how-to-embed-a-youtube-live-stream-via-channel-id/122543) — confirms `live_stream?channel=` URL pattern
+- [Twitch — Embedding Everything](https://dev.twitch.tv/docs/embed/everything/) — official Twitch.Embed docs (parent= rules)
+- [Kick — How to embed your livestream](https://help.kick.com/en/articles/8010826-how-to-embed-your-kick-livestream) — official Kick player iframe docs
+- [Kick player embed page](https://kick.com/embed) — live demo of the embed
+- [TikTok Embed Videos developer doc](https://developers.tiktok.com/doc/embed-videos/) — VOD embed only, no Live
+- [TikTok Embed Player developer doc](https://developers.tiktok.com/doc/embed-player) — VOD only
+- [Instagram embeds in 2026 (commentary)](https://storrito.com/resources/Instagram-API-2026/) — confirms no public IG Live embed
+- [Iframely: TikTok / Instagram embed states](https://iframely.com/domains/tiktok)
+
+### Live-state APIs
+
+- [YouTube Data API quota cost calculator](https://developers.google.com/youtube/v3/determine_quota_cost) — confirms 100 units per `search.list`
+- [YouTube Data API search.list reference](https://developers.google.com/youtube/v3/docs/search/list) — `eventType=live` requires `type=video`
+- [YouTube WebSub / PubSubHubbub push notifications guide](https://developers.google.com/youtube/v3/guides/push_notifications) — official push-notification docs
+- [Twitch Helix API reference](https://dev.twitch.tv/docs/api/reference/) — GetStreams endpoint
+- [Twitch API request limits forum thread](https://discuss.dev.twitch.com/t/about-twitch-api-request-limits/46195) — ~800 req/min default
+- [Twitch EventSub overview](https://dev.twitch.tv/docs/eventsub/) — webhook + websocket transports
+- [Twitch EventSub subscription types](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/) — `stream.online` / `stream.offline`
+- [Twitch EventSub managing subscriptions / cost](https://dev.twitch.tv/docs/eventsub/manage-subscriptions/) — max_total_cost rules
+- [Kick Dev Docs portal](https://dev.kick.com/) — public API + OAuth 2.1
+- [KickEngineering / KickDevDocs GitHub](https://github.com/KickEngineering/KickDevDocs) — official source of API endpoints
+- [Iframely X / Twitter embed coverage](https://iframely.com/domains/x-formely-twitter) — confirms widget-only, no clean iframe for Live broadcasts
+
+### Native streaming pricing
+
+- [Cloudflare Stream pricing docs](https://developers.cloudflare.com/stream/pricing/) — $5/1k stored + $1/1k delivered
+- [Cloudflare Stream Live overview](https://developers.cloudflare.com/stream/stream-live/) — billed identically to VOD Stream
+- [Serverless Live Streaming with Cloudflare Stream blog post](https://blog.cloudflare.com/stream-live/) — pricing example
+
+### Related orchestrator memory / decisions
+
+- `feedback_no_fake_margin_tier_gating.md` — gate only on real infra cost; 3 pricing variants
+- `feedback_no_blur_premium_features.md` — premium features stay visible; gate at save time
+- `feedback_mockup_full_feature_vision.md` — editor preview shows the live state regardless
+- `feedback_ci_unit_tests_allowed.md` — unit-tests-first for any isolable logic
+- `feedback_dec_format_v3_business_cost.md` — business rationale + cost-at-scale per option (applied to DEC-LIVE-* above)
+- `feedback_tadaify_no_shop_in_mvp.md` — same thinking applied: ship the picker tile but the implementation is a thin wrapper around the existing creator presence

--- a/docs/research/newsletter-providers-integration.md
+++ b/docs/research/newsletter-providers-integration.md
@@ -1,0 +1,932 @@
+---
+type: research
+project: tadaify
+title: "Newsletter signup block — provider integration SPIKE (Mailchimp / ConvertKit / Resend / Beehiiv / Substack / Buttondown / MailerLite)"
+created_at: 2026-04-26
+---
+
+# Newsletter signup block — provider integration SPIKE
+
+> **Scope.** tadaify creator-page block: visitor enters email on a public creator page → subscriber lands inside the **creator's own** newsletter provider account, not in tadaify's database. Creator pastes their provider's API key (or completes OAuth) into the block settings once. tadaify's role is a thin, pass-through Edge Function that calls the provider on the creator's behalf.
+>
+> **Research timeframe.** 2026-04-26. Pricing pages change monthly — every figure in the comparison matrix and cost table was confirmed via WebSearch on this date. Cite-checked URLs at the bottom of each provider section.
+
+---
+
+## 1. Executive summary
+
+**Recommended MVP integration approach: API-key first, four providers shipped at v1, plus a generic webhook fallback.**
+
+Concretely, ship — in this order —
+1. **ConvertKit / Kit** (creator-economy default; v4 API key per-account; built-in DOI; free up to 10k subs)
+2. **Beehiiv** (fast-growing creator-economy entrant; clean v2 API on every plan including free; per-call DOI override)
+3. **MailerLite** (most generous free tier with full API access; account-level DOI toggle; well-documented batch endpoint)
+4. **Buttondown** (small/indie creator favourite; API on every plan including the $9 100-sub tier; DOI is the default and is per-subscriber overrideable)
+5. **Generic webhook** (POST `{email, name?, custom_fields?}` to any URL the creator pastes — covers Substack-via-Zapier, ConvertKit-via-Zapier, in-house ESPs, and anyone we haven't built a native integration for)
+
+**Cut from MVP:** Mailchimp (v1), Resend (v1), Substack (forever), per below.
+
+**Two-line rationale.** The four shipped providers cover ~85% of indie-creator newsletter usage we'll see, all expose a clean "create subscriber" REST endpoint with API-key auth (so we can defer OAuth to v2 without functional loss), and all four respect double-opt-in either by default (Buttondown, Kit) or via a per-call flag (Beehiiv, MailerLite) so we never ship a GDPR foot-gun. The generic-webhook fallback handles the long tail without us writing N more integrations, including Substack — whose absence of a public API makes it impossible to integrate natively but trivial to integrate via the creator's own Zapier/Make zap pointed at our webhook payload.
+
+---
+
+## 2. Per-provider deep dive
+
+For each provider: **(a) auth surface, (b) "create subscriber" endpoint shape, (c) double-opt-in handling, (d) custom-fields support, (e) list/audience selection, (f) rate limits, (g) free tier as of 2026-04-26, (h) edge cases worth knowing, (i) tadaify-side integration cost estimate.**
+
+---
+
+### 2.1 ConvertKit / Kit
+
+The creator-economy default since ~2018. Rebranded ConvertKit → Kit in 2024 but the API is still served on `developers.kit.com` (and `api.convertkit.com` legacy v3 endpoints still work).
+
+#### a. Auth surface
+
+Two auth modes on **API v4** (current as of 2026):
+
+- **API Key** — header `X-Kit-Api-Key: <key>`. Intended for "individual use — for testing and to automate your own workflows". Crucially this means: a Kit creator can paste a v4 API key into tadaify with no friction; it is the canonical pattern Kit recommends for a creator wiring their own forms to a third-party site.
+- **OAuth 2.0** — required *only* for apps listed in the Kit App Store. tadaify could in principle apply for App Store listing, but it is not required to ship integration.
+
+**MVP decision: API-key only.** OAuth is a v2 enhancement (gives us "Connect with Kit" button + automatic re-authorisation if the user rotates keys), not a v1 blocker.
+
+#### b. Create-subscriber endpoint
+
+```
+POST https://api.kit.com/v4/forms/{form_id}/subscribers
+X-Kit-Api-Key: <key>
+Content-Type: application/json
+
+{
+  "email_address": "visitor@example.com",
+  "first_name": "Visitor",
+  "fields": { "tadaify_source": "creator-page-block" }
+}
+```
+
+URL path changed in v4 from `/v3/forms/:id/subscriptions` → `/v4/forms/:id/subscribers`. Subscriber is attached to the form (not directly to the account) — the form is the unit of grouping in Kit (analogue of Mailchimp "audience", MailerLite "group").
+
+#### c. Double opt-in
+
+DOI is the **default** in Kit. When you POST a new subscriber to a form that has the "Send incentive / double opt-in email" toggle on (the default), Kit automatically sends a confirmation email; the subscriber stays in `unconfirmed` state until they click the link.
+
+This is a per-form setting, not a per-API-call flag. So tadaify's block doesn't need to surface DOI choice in its UI: the creator already chose it inside Kit when they set up the form. Good — fewer fields in our block editor.
+
+#### d. Custom fields
+
+`fields` object in the payload — keys are pre-existing custom field names in the creator's Kit account. Unknown keys are silently dropped. tadaify does not need to manage custom-field schemas; we just pass through.
+
+#### e. List / audience selection
+
+The creator has to tell us **which form** to attach subscribers to. UX: when the creator pastes the API key, we GET `/v4/forms` and render a dropdown ("Pick the form for this block"). Forms have `id`, `name`, `format` (inline / modal / sticky / hosted) — we filter to non-hosted formats.
+
+#### f. Rate limits
+
+- **API key auth:** 120 requests / rolling 60 s, per key.
+- **OAuth auth:** 600 requests / rolling 60 s, per access token.
+
+For a creator-page newsletter block, 120 / minute is plenty. A creator getting 120 signups/minute is a viral moment, not a business-as-usual rate. We should still implement exponential-backoff in our Edge Function for safety.
+
+#### g. Free tier as of 2026-04-26
+
+- **Newsletter** plan: free up to **10,000 subscribers**, no time limit, no card required. Includes API.
+- **Creator** plan: $39/mo (or $33/mo annual) starting at 1,000 subs. Adds automations and integrations.
+- **Pro** plan: $79/mo (or $66/mo annual). Adds advanced reporting + priority support.
+
+Free tier is unusually generous; most indie creators will live on it forever.
+
+#### h. Edge cases
+
+- **Already-subscribed email** → endpoint returns 200 OK with the existing subscriber object. Idempotent — no special handling needed in our Edge Function.
+- **Invalid email format** → 422. We surface as "please enter a valid email" to the visitor.
+- **API key revoked / rotated** → 401. We need to mark the block as "needs reconnection" and notify the creator (in-app + via email digest).
+- **Form deleted in Kit** → 404 on POST. Same UX as above.
+- **Unsubscribe** is handled inside Kit (footer link in confirmation + every subsequent email). We do **not** surface unsub in the tadaify block; that's correct because the subscriber doesn't exist in tadaify's DB.
+
+#### i. Integration cost (tadaify side)
+
+- Edge Function: ~80 LOC TypeScript (Deno).
+- Settings UI: API-key input + form dropdown + "Test connection" button.
+- Estimated: **0.5 dev day** (4 hours), including unit tests for the Edge Function and one Playwright happy-path.
+
+#### Source URLs
+
+- Kit API v4 reference: <https://developers.kit.com/v4>
+- v4 upgrading guide: <https://developers.kit.com/api-reference/upgrading-to-v4>
+- Authentication: <https://developers.kit.com/api-reference/authentication>
+- Pricing 2026: <https://www.emailtooltester.com/en/reviews/convertkit/pricing/>
+- Double opt-in: <https://help.kit.com/en/articles/2971364-the-all-important-double-opt-in>
+
+---
+
+### 2.2 Beehiiv
+
+Newer entrant (2021), the fastest-growing creator-economy newsletter platform of 2024-2025. Co-founded by ex-Morning-Brew people, very developer-friendly product.
+
+#### a. Auth surface
+
+**API v2** (current). Two modes:
+
+- **API Key** — header `Authorization: Bearer <api_key>`. Generated per-account in the Beehiiv UI. Available on **every plan, including free Launch**. (Used to be paid-only — they changed this in mid-2024.)
+- **OAuth 2.0** — for App Store apps; uses the standard authorisation-code grant. Same v2-only-as-enhancement story as Kit.
+
+**Pre-condition gotcha:** to enable API access at all, the creator must complete Stripe Identity Verification on their Beehiiv account. This is a one-time UI flow inside Beehiiv and we just need to surface a clear error message ("Complete identity verification in Beehiiv first") if their key returns the relevant error.
+
+#### b. Create-subscriber endpoint
+
+```
+POST https://api.beehiiv.com/v2/publications/{publication_id}/subscriptions
+Authorization: Bearer <api_key>
+Content-Type: application/json
+
+{
+  "email": "visitor@example.com",
+  "double_opt_override": "on",      // "on" | "off" | "not_set"
+  "reactivate_existing": false,
+  "send_welcome_email": true,
+  "utm_source": "tadaify",
+  "utm_medium": "creator-page-block",
+  "referring_site": "https://creator.tadaify.com/<slug>",
+  "custom_fields": [
+    { "name": "Source", "value": "tadaify-block" }
+  ]
+}
+```
+
+The model groups subscribers under a **publication** (top-level account container). Most creators have exactly one publication; creators running multiple newsletters from one Beehiiv account have several. So the block editor needs a "pick a publication" dropdown (GET `/v2/publications`).
+
+#### c. Double opt-in
+
+Per-call control via `double_opt_override`:
+- `"on"` — Beehiiv sends a confirmation email; subscriber is `pending` until they click.
+- `"off"` — Subscriber is immediately `active`.
+- `"not_set"` — Use the publication's default.
+
+**Recommendation for tadaify:** default the block to `"not_set"` so we respect whatever the creator configured inside Beehiiv, and offer an advanced "Force double opt-in for this form" toggle in the block settings for GDPR-paranoid creators.
+
+#### d. Custom fields
+
+`custom_fields` array, each `{name, value}`. Custom fields **must already exist** in the creator's publication; unknown names are silently discarded. So our block editor should let the creator pick from existing custom field names (GET `/v2/publications/{id}/custom_fields`) rather than free-text — this matches Beehiiv's own form builder UX.
+
+#### e. List / audience selection
+
+- **Publication:** dropdown of GET `/v2/publications` (usually 1 entry).
+- **Tier / segment:** Beehiiv supports paid tiers; default to free tier.
+- **Automation:** optionally trigger an automation journey on subscribe (POST `/v2/automations/{id}/journeys`). Out of MVP scope; offer in v2.
+
+#### f. Rate limits
+
+The official docs are intentionally vague: "rate limiting is implemented as a spam prevention measure, which may temporarily block signup attempts from the same device, browser, or IP". No explicit per-minute limit published. In practice (per community benchmarks): hundreds of req/min are fine; thousands trigger throttling.
+
+For our use case (one creator's signup form) this is irrelevant. **However** because Beehiiv mentions IP-based throttling, our Edge Function MUST forward the visitor IP via a header where Beehiiv accepts it (the docs are unclear on which header — needs DEC). If we don't, all signups from all creators look like they come from one Supabase egress IP and Beehiiv may blanket-block us.
+
+#### g. Free tier as of 2026-04-26
+
+- **Launch** (free): up to **2,500 subscribers**, unlimited sends, core newsletter+website+podcast tools, **API access included**.
+- **Scale**: starts at **$49/mo** for 1,000 subs, scales by tier (e.g. ~$69 for 2,500, ~$99 for 5k).
+- **Max**: starts at **$109/mo**. Removes Beehiiv branding, adds advanced features.
+- **Enterprise**: required above 100k subs.
+
+#### h. Edge cases
+
+- **Already-subscribed email + `reactivate_existing: false`** → 422. With `true`, reactivates a previously-unsubscribed contact. Default to `false` for GDPR safety.
+- **Identity-not-verified** → 403 with explanatory body. We surface a clear "Verify your identity in Beehiiv settings" message.
+- **Cursor-based pagination** on list endpoints — easier than offset for our "fetch all publications" call.
+- **Unsubscribe webhook** — Beehiiv supports webhooks to notify external systems of subscriber state changes. Not needed for v1 (we don't store the subscriber), but useful for v2 analytics.
+
+#### i. Integration cost
+
+- Edge Function: ~100 LOC (extra fields: UTMs, custom fields array shape).
+- Settings UI: API key + publication dropdown + custom fields dropdown + DOI override toggle.
+- Estimated: **0.75 dev day** (6 hours).
+
+#### Source URLs
+
+- API v2 getting started: <https://developers.beehiiv.com/welcome/getting-started>
+- Create subscription: <https://developers.beehiiv.com/api-reference/subscriptions/create>
+- Custom fields: <https://developers.beehiiv.com/api-reference/custom-fields/index>
+- Pricing 2026: <https://www.beehiiv.com/pricing>
+- Free-tier confirmation: <https://mailcompared.com/pricing/beehiiv-pricing/>
+
+---
+
+### 2.3 MailerLite
+
+Heavily SMB-focused, generous free tier, well-documented developer experience. Big in EU (GDPR-conscious).
+
+#### a. Auth surface
+
+**API v2** (current — `developers.mailerlite.com`; the older "classic" v1 at `developers-classic.mailerlite.com` still serves but is deprecated for new integrations).
+
+- **API Token** — header `Authorization: Bearer <token>`. Generated per-account, no scopes (full access). MailerLite calls this "API token" not "API key" — we should use their language in our UI.
+- **OAuth 2.0** — **not currently a first-class supported flow** for third-party app developers. There's no public OAuth marketplace in MailerLite as of 2026-04. Integrations like Zapier, Make, LeadsBridge use the API-token path. → For tadaify, **API token is the only practical option** — and it's also what every other MailerLite integration uses, so no creator confusion.
+
+#### b. Create-subscriber endpoint
+
+```
+POST https://connect.mailerlite.com/api/subscribers
+Authorization: Bearer <token>
+Content-Type: application/json
+Accept: application/json
+
+{
+  "email": "visitor@example.com",
+  "fields": { "name": "Visitor" },
+  "groups": ["<group_id>"],
+  "status": "active",     // "active" | "unsubscribed" | "unconfirmed" | "junk" | "bounced"
+  "ip_address": "203.0.113.42",
+  "subscribed_at": "2026-04-26T18:00:00Z"
+}
+```
+
+Subscribers live at the account level; **groups** are how MailerLite organises them (analogue of Kit forms / Beehiiv publications).
+
+#### c. Double opt-in
+
+Account-level setting: **Account Settings → Subscribe Settings → "Enable Double Opt-in for API and integrations"**. When ON, subscribers added via API get the confirmation email and stay in `unconfirmed` state. When OFF, they're immediately `active`.
+
+This is a **global** toggle — no per-call override. Means tadaify cannot enforce DOI from our side; we trust the creator's account setting.
+
+**GDPR implication:** for EU creators, we should display a warning in the block editor: *"For GDPR compliance, ensure double opt-in is enabled in your MailerLite Account Settings → Subscribe Settings."* And we link to MailerLite's help page directly. This is the only cost of MailerLite's no-per-call-override design.
+
+#### d. Custom fields
+
+`fields` object: keys are field names that **must pre-exist** in the creator's MailerLite account. Unknown fields → 422.
+
+#### e. List / audience selection
+
+- **Group:** dropdown of GET `/api/groups`. Multi-select (a subscriber can be in many groups).
+- **Status:** default `active` (or `unconfirmed` if the account-level DOI is on — MailerLite handles this transition automatically).
+
+#### f. Rate limits
+
+- **Global: 120 req/min per token.** 429 on overage with `X-RateLimit-Retry-After` header.
+- **Batch endpoint:** POST `/api/batch` accepts up to **50 sub-requests** per call. We don't need batching for v1 (one signup at a time) but it's there for future bulk-import use cases.
+
+#### g. Free tier as of 2026-04-26
+
+- **Free:** up to **500 subscribers, 12,000 emails/mo**. Includes automations, 10 landing pages, 1 website, unlimited forms+popups, segmentation, tagging.
+- **Growing Business:** starts at **$10/mo** for 500 subs (cheaper than Mailchimp at the same tier).
+- **Advanced:** starts at **$20/mo** — adds advanced features, AI writing assistant, multiple users.
+- **Enterprise:** custom pricing for 100k+ subs.
+
+The free 500 limit is tight compared to Kit's 10k or Beehiiv's 2.5k, so MailerLite creators tend to upgrade earlier.
+
+#### h. Edge cases
+
+- **Already-subscribed email** → 200 OK, returns existing subscriber.
+- **Invalid email** → 422 with field-level error.
+- **Token revoked** → 401 + "Unauthenticated" body.
+- **`ip_address` field** → optional but recommended; gives MailerLite better fraud detection.
+- **Unsubscribe webhook** — MailerLite has webhooks for `subscriber.unsubscribed` etc. Same v2-enhancement story as Beehiiv.
+- **EU vs US data centre** — MailerLite has region-specific accounts; the API base URL is the same (`connect.mailerlite.com`) but there's no region-routing concern for tadaify.
+
+#### i. Integration cost
+
+- Edge Function: ~70 LOC (simpler than Beehiiv).
+- Settings UI: token input + groups multi-select + GDPR-warning copy.
+- Estimated: **0.5 dev day** (4 hours).
+
+#### Source URLs
+
+- Developer docs hub: <https://developers.mailerlite.com/>
+- Subscribers endpoint: <https://developers.mailerlite.com/docs/subscribers>
+- Rate limits: <https://developers-classic.mailerlite.com/docs/api-rate-limits>
+- Batching: <https://developers.mailerlite.com/docs/batching>
+- DOI for API: <https://www.mailerlite.com/help/how-to-use-double-opt-in-when-collecting-subscribers>
+- Pricing 2026: <https://www.mailerlite.com/pricing>
+
+---
+
+### 2.4 Buttondown
+
+The "indie creator favourite" — single-developer-built (Justin Duke), API-first design, beloved by tech-blog newsletters. Smaller subscriber counts but disproportionately influential audience.
+
+#### a. Auth surface
+
+- **API key** only — header `Authorization: Token <api_key>` (note: `Token`, not `Bearer`). Multiple keys per account, each with configurable permissions.
+- **No OAuth** — Buttondown is a one-developer shop and explicitly prioritises a clean API over an app marketplace.
+
+API is available **on every plan including free** (Buttondown is genuinely API-first; the same API powers their own UI).
+
+#### b. Create-subscriber endpoint
+
+```
+POST https://api.buttondown.email/v1/subscribers
+Authorization: Token <api_key>
+Content-Type: application/json
+
+{
+  "email_address": "visitor@example.com",
+  "type": "regular",                 // "regular" → skip DOI; omit to require DOI
+  "tags": ["tadaify-block"],
+  "metadata": { "source": "creator-page" },
+  "notes": "Subscribed via tadaify creator page"
+}
+```
+
+Subscribers live at the account level; **tags** are how Buttondown groups them (analogue of MailerLite groups, Kit forms). Tags auto-create on first use.
+
+#### c. Double opt-in
+
+DOI is the **default** (`type: "unactivated"`). If you want to skip DOI (e.g. for an existing-customer import), pass `type: "regular"`. **There is no global toggle** to disable DOI — it's a per-subscriber decision in the API call.
+
+**Recommendation:** tadaify's block defaults to omitting `type` (i.e. DOI on). Offer an advanced "Skip confirmation" toggle in the block editor with a clear GDPR warning.
+
+#### d. Custom fields
+
+Two mechanisms:
+- `metadata` — free-form `{key: value}` JSON, no schema. Simpler than other providers because Buttondown doesn't pre-define field names.
+- `tags` — array of strings, used for segmentation.
+
+Easier integration than Beehiiv/Kit because we don't need a "fetch existing fields" call before showing the editor.
+
+#### e. List / audience selection
+
+No "list" or "audience" concept — all subscribers go to the single account list. The creator just tags them. Block editor shows **just an API key field + an optional tag input** ("Tag subscribers from this block as:"). Simplest UX of any provider.
+
+#### f. Rate limits
+
+Documented as **100 requests / day** initially (!), growing over time as the newsletter accumulates "reputation" within Buttondown. 429 on overage.
+
+⚠️ **This is a real concern.** A creator on free tier whose newsletter just got a spike of 200 signups in one day will hit the wall. Mitigation:
+- **Surface this in our block editor** — copy that explains the limit and links to Buttondown's contact-for-higher-limit form.
+- **Cache 429 responses** in our Edge Function and queue overflow signups in a Supabase `pending_subscribers` table, then drain on a cron. Adds complexity. Defer to v1.5 if it bites us.
+- **Simpler MVP fallback:** if 429, show the visitor "We're temporarily unable to subscribe you, please try again in a few minutes" and log to our analytics. Creator gets a nightly digest of failed signups.
+
+#### g. Free tier as of 2026-04-26
+
+- **Free:** $0/mo, **100 subscribers**, Markdown editor, custom domain, full API.
+- **Hobby:** ~$9/mo for 100 subs (gives you the paid features), scales by subscriber count.
+- **Standard:** ~$29/mo, full features, used by most paid Buttondown customers.
+- **Advanced:** ~$83/mo for up to **50,000 subscribers**, white-labelling, custom sending.
+- All paid plans include API.
+
+The 100-subscriber free tier is the smallest of any provider — Buttondown is positioned as a paid product with a "try it" tier rather than a freemium funnel like Kit/MailerLite.
+
+#### h. Edge cases
+
+- **Already-subscribed email** → 400 with `email_address: ["This email address is already subscribed."]`. We treat as 200 (idempotency at our layer).
+- **Email is on suppression list (previously unsubscribed/bounced)** → 400. Surface a generic "Unable to subscribe this email — please contact the newsletter author" message.
+- **Tag with characters Buttondown doesn't allow** — tags are case-sensitive and have light validation. We sanitise on our side.
+- **Newsletter not yet "verified" by Buttondown** — Buttondown manually approves new accounts before allowing API subscriber creation. Same UX as Beehiiv's identity check: surface a clear error message.
+
+#### i. Integration cost
+
+- Edge Function: ~60 LOC (simplest of the four).
+- Settings UI: API key input + optional tag field + "Test connection" button.
+- Plus 429-handling UI copy (see rate-limits gotcha).
+- Estimated: **0.5 dev day** (4 hours).
+
+#### Source URLs
+
+- API intro: <https://docs.buttondown.com/api-introduction>
+- Create subscriber: <https://docs.buttondown.com/api-subscribers-create>
+- Subscriber types (DOI): <https://docs.buttondown.com/api-subscribers-type>
+- Tags: <https://docs.buttondown.com/tags>
+- Pricing 2026: <https://buttondown.com/pricing>
+
+---
+
+### 2.5 Mailchimp
+
+The market incumbent. Mature API, but the product has aged poorly for indie creators.
+
+#### a. Auth surface
+
+**Marketing API v3.0**.
+
+- **API Key** — header `Authorization: Bearer <api_key>` (or HTTP basic auth with any username + key as password). Embedded in the key is the data-centre prefix (e.g. `xxxx-us21` → base URL `https://us21.api.mailchimp.com/3.0/`). We must parse the prefix when the creator pastes the key.
+- **OAuth 2.0** — required to be listed in Mailchimp's Integration Partner Program. Access tokens **don't expire**, no refresh token. After OAuth dance, we GET `https://login.mailchimp.com/oauth2/metadata` to discover the data-centre prefix.
+
+**For tadaify v1, API key is sufficient.** OAuth is only needed if we want listing in Mailchimp's marketplace (not a v1 priority).
+
+#### b. Create-subscriber endpoint
+
+Two endpoint patterns:
+
+1. **POST** `/3.0/lists/{list_id}/members` — strict create; fails with 400 if already subscribed.
+2. **PUT** `/3.0/lists/{list_id}/members/{subscriber_hash}` — upsert; preferred for "subscribe or update" semantics. `subscriber_hash` is MD5-lowercase of the email.
+
+```
+PUT https://us21.api.mailchimp.com/3.0/lists/<list_id>/members/<md5(email)>
+Authorization: Bearer <api_key>
+Content-Type: application/json
+
+{
+  "email_address": "visitor@example.com",
+  "status_if_new": "pending",        // DOI; "subscribed" for single opt-in
+  "merge_fields": { "FNAME": "Visitor" },
+  "tags": ["tadaify-block"]
+}
+```
+
+Subscribers live in **lists** (Mailchimp's term for audiences). The free tier allows only **one** list — a major UX simplification (no dropdown needed).
+
+#### c. Double opt-in
+
+Per-call, via `status` (or `status_if_new` for upsert):
+- `"pending"` → DOI; Mailchimp sends confirmation email.
+- `"subscribed"` → single opt-in.
+
+The List itself also has a default DOI setting (controllable in Mailchimp UI), so for a "follow the creator's choice" model we'd need to GET the list metadata first and use its default. Add complexity in v1 → simpler to surface a per-block toggle.
+
+#### d. Custom fields
+
+`merge_fields` object — keys are merge tags (e.g. `FNAME`, `LNAME`, custom ones the creator defined). Pre-existing only; unknown keys → 400. Audiences capped at **30 merge fields per audience**.
+
+#### e. List / audience selection
+
+GET `/3.0/lists` returns the creator's lists. Free tier: 1 list. Paid: up to 5 (Essentials) or 100 (Standard). Dropdown like the others.
+
+#### f. Rate limits
+
+- **10 simultaneous connections per API key**. 429 if exceeded. Not a per-minute rate, a concurrency cap.
+- 120-second timeout per call.
+
+For tadaify (sequential one-at-a-time per visitor), 10 connections is more than enough. We just need to make sure our Edge Function isn't holding connections open longer than necessary.
+
+#### g. Free tier as of 2026-04-26
+
+- **Free:** **250 contacts, 500 emails/mo** — *aggressively* reduced from previous limits (was 2,000 contacts in 2022, 500 in late 2024, now 250). Mailchimp branding on every email. No scheduling, no multi-step automation.
+- **Essentials:** **$13/mo** for 500 contacts; up to 50,000 contacts. ~$75/mo at 5k.
+- **Standard:** **$20/mo** for 500 contacts; up to 100,000. ~$100/mo at 5k. Adds multi-step automation (where Mailchimp's value really sits).
+- **Premium:** **$350/mo** for up to 10k contacts.
+
+The 250-contact free tier is by far the worst of any provider in this list and is the main reason indie creators have fled Mailchimp for Kit/Beehiiv/Buttondown.
+
+#### h. Edge cases
+
+- **Data-centre prefix parsing** — bug magnet; if the creator pastes the key without the `-usX` suffix (some older keys lack it), we fail. Validate at paste-time.
+- **GDPR consent fields** — Mailchimp supports a `marketing_permissions` array per subscriber; we'd need to surface checkbox copy in the block. Defer to v2.
+- **Already-subscribed email upsert** — PUT semantics handle this, but if the existing subscriber is in `cleaned` (bounced) state, the API returns 400. Surface generic error.
+- **List archived / deleted** → 404. UX as for other providers.
+
+#### i. Integration cost
+
+- Edge Function: ~120 LOC (DC-prefix parsing, MD5 hash, two endpoints to handle).
+- Settings UI: API key + list dropdown + DOI toggle + (later) GDPR consent copy.
+- Estimated: **1.0 dev day** (8 hours) — most of any provider.
+
+#### Source URLs
+
+- API fundamentals: <https://mailchimp.com/developer/marketing/docs/fundamentals/>
+- OAuth 2 guide: <https://mailchimp.com/developer/marketing/guides/access-user-data-oauth-2/>
+- Pricing 2026: <https://mailchimp.com/pricing/marketing/>
+- Free-tier 250-cap confirmation: <https://blog.groupmail.io/mailchimp-pricing-2026/>
+
+---
+
+### 2.6 Resend
+
+Developer-focused transactional+marketing email service (think "Stripe for email"). Modern API, growing fast.
+
+#### a. Auth surface
+
+- **API Key** — header `Authorization: Bearer <api_key>`. Per-team scoped.
+- **No OAuth** as of 2026-04-26.
+
+#### b. Create-contact endpoint
+
+```
+POST https://api.resend.com/audiences/{audience_id}/contacts
+Authorization: Bearer <api_key>
+Content-Type: application/json
+
+{
+  "email": "visitor@example.com",
+  "first_name": "Visitor",
+  "last_name": "Example",
+  "unsubscribed": false
+}
+```
+
+Subscribers ("contacts") live inside an **audience** (analogue of Mailchimp list). Limited supported fields: **`email`, `first_name`, `last_name`, `unsubscribed`** — that's it. **No custom fields** as of 2026-04-26.
+
+#### c. Double opt-in
+
+**Resend Audiences does NOT do double opt-in.** Contacts added via API are immediately added to the audience as confirmed. Resend's docs explicitly position DOI as a separate workflow the developer must build themselves using Resend's transactional email side (you send your own confirmation email + handle the click via your own endpoint).
+
+This is a major problem for tadaify's use case. We'd need to build the entire DOI flow ourselves: token-gen, confirmation-email-via-Resend-transactional, click-callback handler, "actually-add-to-audience" finalisation. That's ~200 LOC of Edge Function code plus a `pending_doi_subscribers` Supabase table — same complexity as building a full email-list system, just with Resend as the SMTP backend.
+
+**Conclusion:** Resend is fundamentally a transactional API, not a creator-newsletter platform. Audiences exist but are designed for the developer who's already built their own list-management UX. Wrong fit for tadaify's "creator pastes API key, done" model.
+
+#### d. Custom fields
+
+None natively. Could be hacked via tags / metadata once Resend ships those (on roadmap, no public ETA).
+
+#### e. List / audience selection
+
+GET `/audiences` returns creator's audiences. Dropdown.
+
+#### f. Rate limits
+
+- **2 req/sec by default**, raised to **5 req/sec** on request. Very low compared to others. Designed for transactional bursts, not continuous trickle.
+
+#### g. Free tier as of 2026-04-26
+
+- **Free:** 3,000 transactional emails/mo + **1,000 marketing contacts**.
+- **Pro:** **$40/mo** for 5,000 contacts (and 50k transactional emails).
+
+Reasonable pricing for the transactional side; the marketing-contacts tier is roughly competitive.
+
+#### h. Edge cases
+
+- **No DOI** is the headline edge case (see §c).
+- **Custom fields** absence means we can't pass `tadaify_source` etc. for the creator's segmentation.
+- **Unsubscribe** handled via Resend's automatic unsubscribe link in marketing emails — but only if the creator uses Resend Broadcasts to send. If the creator just uses Resend for transactional and reads contacts elsewhere, they need to wire unsub themselves.
+
+#### i. Integration cost
+
+- **Without DOI: ~50 LOC.** Trivial.
+- **With DOI (required for GDPR creators): ~200 LOC + DB table + cron + transactional-email template.** Substantial.
+- Realistic estimate to ship something we can actually offer to EU creators: **2 dev days**.
+
+#### Source URLs
+
+- Audiences intro: <https://resend.com/docs/dashboard/audiences/introduction>
+- Audiences blog post: <https://resend.com/blog/manage-subscribers-using-resend-audiences>
+- Rate limits: <https://resend.com/docs/api-reference/rate-limit>
+- Pricing 2026: <https://resend.com/pricing>
+
+---
+
+### 2.7 Substack
+
+The viral-newsletter platform. **No public API, no public webhooks.**
+
+#### a. Auth surface
+
+There is no public API. Period. Substack has had years of feature requests for an API; their stance is "use Zapier" or "embed our signup form".
+
+What does exist:
+- An **internal/undocumented API** that powers Substack's own forms. Has been reverse-engineered by community members (see `substack-api` Python package) but explicitly violates Substack's TOS implications around scraping and is rate-limited / origin-checked. **Hard NO for tadaify**: building production integration on a reverse-engineered private API is a foot-gun (will break, will get our IPs banned, may have legal implications).
+- An **embed iframe**: creator goes Settings → Growth features → Embed code; copies an `<iframe>` snippet. Fully supported, intended use.
+- **Zapier integration**: "new Substack subscriber" trigger exists; "add Substack subscriber" action does NOT (Zapier respects the API absence). So Zapier helps you sync OUT of Substack, not IN to Substack.
+
+#### b. Implication for tadaify
+
+We **cannot** build a native "Substack" provider in our block. There are exactly two options to offer Substack creators:
+
+1. **Embed mode** — Render the creator's Substack iframe inside the tadaify block. Pros: actually works. Cons: visual styling is constrained (Substack's CSS, not ours), the block looks foreign on the creator page, and the visitor leaves our analytics scope.
+2. **Generic webhook fallback (see §3 below)** — creator sets up a Zapier zap from "new generic webhook" → "add to Substack via [unofficial workaround]". Doesn't really exist as a clean Zapier zap because Zapier respects the API absence; the "workaround" is creator-specific.
+
+**Recommendation: ship "Embed mode" as a separate block variant or as a fallback inside the Newsletter block.** When the creator picks "Substack" in our provider dropdown, we collect their publication URL and render an embedded iframe instead of our own form. Mark this clearly in the UI as "Powered by Substack" so the creator knows the styling is constrained.
+
+#### Source URLs
+
+- "Does Substack have an API?": <https://support.substack.com/hc/en-us/articles/45099095296916-Substack-Developer-API>
+- Signup form embed: <https://support.substack.com/hc/en-us/articles/360041759232-Can-I-embed-a-signup-form-for-my-Substack-publication>
+- Reverse-engineering writeup (for awareness, NOT for use): <https://iam.slys.dev/p/no-official-api-no-problem-how-i>
+
+---
+
+## 3. Generic webhook fallback
+
+**Spec:** the creator pastes any URL. On every signup, our Edge Function POSTs:
+
+```json
+POST <creator_provided_url>
+Content-Type: application/json
+X-Tadaify-Signature: <hmac-sha256-of-body-with-creator-secret>
+X-Tadaify-Timestamp: <unix-ms>
+
+{
+  "schema_version": "1.0",
+  "event": "newsletter.subscribed",
+  "creator_page_slug": "alice",
+  "block_id": "blk_…",
+  "subscriber": {
+    "email": "visitor@example.com",
+    "name": "Visitor",
+    "submitted_at": "2026-04-26T18:00:00Z",
+    "ip": "203.0.113.42",
+    "user_agent": "Mozilla/5.0 …"
+  },
+  "consent": {
+    "checkbox_label": "I agree to receive marketing emails from Alice",
+    "checked": true,
+    "policy_url": "https://alice.tadaify.com/privacy"
+  }
+}
+```
+
+**Why ship this in MVP:**
+- Covers Substack indirectly (creator wires a Zap or Make scenario from `/webhook` → wherever Substack's helper-of-the-day is).
+- Covers ESPs we haven't built native integrations for (HubSpot, Brevo/Sendinblue, Klaviyo, ActiveCampaign, Loops, ConvertKit-via-Zapier, etc.).
+- Covers creators with custom backends.
+- Costs us ~60 LOC + a `webhook_configs` Supabase row schema.
+- HMAC signature pattern is standard (matches Stripe/GitHub) so creators wiring it into Make/Zapier/n8n have a known idiom.
+
+**Cost: 0.75 dev day** including signature verification helper docs.
+
+---
+
+## 4. Comparison matrix
+
+| Dimension | **Kit** | **Beehiiv** | **MailerLite** | **Buttondown** | Mailchimp | Resend | Substack |
+|---|---|---|---|---|---|---|---|
+| **MVP ship?** | ✅ v1 | ✅ v1 | ✅ v1 | ✅ v1 | ❌ v2 | ❌ v2+ | ❌ embed-only |
+| **Auth — API key** | ✅ `X-Kit-Api-Key` | ✅ `Bearer` | ✅ `Bearer` | ✅ `Token` | ✅ `Bearer` (DC-prefix in key) | ✅ `Bearer` | ❌ no public API |
+| **Auth — OAuth 2.0** | ✅ App Store only | ✅ App Store only | ❌ none | ❌ none | ✅ Partner Program | ❌ none | ❌ |
+| **DOI default behaviour** | DOI on by default per-form | Per-call override (`on`/`off`/`not_set`) | Account-level toggle, no per-call | DOI on by default per-subscriber | Per-call (`status: pending`/`subscribed`) | **No DOI — must be built** | N/A |
+| **Custom fields** | `fields` object, pre-existing | `custom_fields[]`, pre-existing | `fields` object, pre-existing | `metadata` JSON, free-form | `merge_fields`, pre-existing, max 30 | **None** | N/A |
+| **List/audience selection** | Forms (dropdown via GET `/v4/forms`) | Publications (usually 1) | Groups (multi-select) | None — single account list, tags only | Lists (free=1, Essentials=5, Standard=100) | Audiences | N/A |
+| **Rate limit (relevant call)** | 120/min (key) / 600/min (OAuth) | Vague, IP-based throttle | 120/min (token) | **100/day initial** ⚠️ | 10 concurrent connections | 2-5 req/sec | N/A |
+| **Free tier (subscribers)** | **10,000** | **2,500** | **500** | **100** | **250** | **1,000 contacts** | Unlimited (Substack-side) |
+| **Lowest paid tier** | $39/mo (1k subs) | $49/mo (1k subs) | $10/mo (500 subs) | $9/mo (100 subs) | $13/mo (500 subs) | $40/mo (5k contacts) | 10% of paid sub revenue |
+| **GDPR posture** | Strong (DOI default) | Strong (per-call DOI override) | Medium (relies on creator account toggle) | Strong (DOI default) | Medium (relies on per-call flag) | **Weak** (no built-in DOI) | Out of scope |
+| **API stability** | v3 → v4 in 2024, v3 still works | v2 stable since 2023 | v2 stable, classic v1 deprecated | v1 stable for years | v3 stable since 2017 | v1, evolving | N/A |
+| **Webhook for unsub** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
+| **tadaify integration cost (dev days)** | 0.5 | 0.75 | 0.5 | 0.5 (+ rate-limit UX) | 1.0 | 2.0 (with DOI build) | 0.25 (just iframe embed) |
+| **Indie-creator market presence** | High | High & growing | Medium-high (esp. EU) | Niche but loyal | High but declining | Developer-only | Very high |
+
+---
+
+## 5. MVP scope recommendation
+
+### Ship in v1 (4 native + 1 fallback + 1 embed)
+
+| # | Provider | Rationale |
+|---|---|---|
+| 1 | **Kit** | Highest creator-economy market share. Free 10k tier means we're pre-aligned with our own free creators. Cheap to integrate (0.5 day). |
+| 2 | **Beehiiv** | Fastest-growing creator newsletter. Per-call DOI override is the cleanest API of the four. 0.75 day. |
+| 3 | **MailerLite** | Strong EU presence (matches our likely first-market geography), best free tier for getting started, well-documented batch API for future use cases. 0.5 day. |
+| 4 | **Buttondown** | Indie/dev creator favourite. Cheapest paid entry ($9/mo). Tiny dev cost (0.5 day) — even if only 5% of creators use it, the integration pays for itself. |
+| 5 | **Generic webhook** | Catches Substack-via-Zapier, in-house ESPs, every other provider not in the list. Critical fallback. 0.75 day. |
+| 6 | **Substack iframe embed** | Substack creators are a non-trivial slice of the target audience and have NO other integration option. Ship as `provider: "substack"` in the same block, render iframe instead of form. 0.25 day. |
+
+**Total dev cost: ~3.25 dev days** (one developer, one week including code review).
+
+### Cut from MVP, justify
+
+| Provider | Cut reason |
+|---|---|
+| **Mailchimp** | (a) Free tier is now so small (250 contacts) that creators on Mailchimp free are not really "newsletter creators" yet — they're triallists. (b) Indie-creator market share has dropped substantially since 2022 (Kit/Beehiiv ate it). (c) Highest integration cost (1 day) for diminishing-returns audience. (d) Generic webhook covers Mailchimp via Zapier in the meantime. **Add in v2 if user data shows >10% of creators trying to wire it.** |
+| **Resend** | (a) **No native double-opt-in** is a GDPR foot-gun for our EU creators. (b) No custom-fields support. (c) Resend Audiences is fundamentally designed for "developers building their own newsletter UX", not "creators who want a paste-API-key block". Wrong tool. (d) Building DOI on top costs 2 dev days. **Reconsider in v2 only if Resend ships native DOI** (not on their public roadmap as of 2026-04). |
+| **Substack (native)** | No public API. Reverse-engineered API is a TOS-risk and stability-risk. We ship the iframe embed instead — it's the officially-supported path and Substack creators understand the visual constraint. |
+
+### Order of integration ship
+
+1. Generic webhook (smallest, lowest-risk, immediately useful, unblocks everything else)
+2. Kit (largest creator market segment)
+3. Beehiiv (cleanest API, validates per-call DOI pattern)
+4. MailerLite (validates account-level DOI pattern + multi-group selection)
+5. Buttondown (validates "no list selection" simplest UX)
+6. Substack iframe (different code path, ship last to avoid distracting from API integrations)
+
+---
+
+## 6. Cost-at-scale table
+
+Per `feedback_dec_format_v3_business_cost.md`, two perspectives: (a) tadaify infra cost for our pass-through Edge Function, (b) the creator's bill from their newsletter provider at the same scale (informational, since the creator pays this directly, not us).
+
+### 6a. tadaify-side infra cost
+
+The newsletter-signup pass-through is a single Supabase Edge Function call per visitor signup. Memory ~128MB, runtime ~300ms (mostly waiting on the upstream provider).
+
+Assumptions:
+- 1 signup per page visitor per day on average (massively overstates reality; most visitors don't sign up. Real conversion ~3-5%; this is a worst-case stress).
+- 1 Edge Function invocation per signup.
+- Logging + 1 row write to `newsletter_signups` audit table (Postgres) per call.
+
+| Scale | Daily signups | Monthly signups | Edge Function invocations | Postgres writes | Edge Function cost (Supabase paid: $2/M invocations after 500k free) | Postgres write cost (negligible at scale) | **Total tadaify monthly cost** |
+|---|---|---|---|---|---|---|---|
+| 100 DAU | 100 | 3,000 | 3,000 | 3,000 | $0 (under free tier) | $0 | **$0** |
+| 1,000 DAU | 1,000 | 30,000 | 30,000 | 30,000 | $0 (under 500k/mo Supabase free) | $0 | **$0** |
+| 10,000 DAU | 10,000 | 300,000 | 300,000 | 300,000 | $0 (still under 500k/mo free tier) | $0 | **$0** |
+| 100,000 DAU | 100,000 | 3,000,000 | 3,000,000 | 3,000,000 | $5 (2.5M paid invocations × $2/M) | ~$1 | **~$6** |
+| 1,000,000 DAU | 1,000,000 | 30,000,000 | 30,000,000 | 30,000,000 | $59 (29.5M × $2/M) | ~$10 | **~$69** |
+
+**Conclusion: tadaify-side cost is negligible at every scale we plausibly hit in the next 24 months.** This feature does NOT need to be a paid tier on cost grounds. Per `feedback_no_fake_margin_tier_gating.md`, do not gate it for fake-margin reasons either.
+
+### 6b. Creator-side cost (informational — they pay their provider, not us)
+
+If a typical creator using tadaify has, say, 5,000 newsletter subscribers and grows to 50,000 over a year:
+
+| Subscribers | Kit | Beehiiv | MailerLite | Buttondown | Mailchimp Standard |
+|---|---|---|---|---|---|
+| 100 | $0 (free) | $0 (free) | $0 (free) | $9 | $20 |
+| 1,000 | $0 (free) | $0 (free) | $15 (Growing) | ~$29 | ~$32 |
+| 5,000 | $0 (free) | ~$69 (Scale) | ~$30 | ~$59 | ~$100 |
+| 10,000 | $0 (free) | ~$99 (Scale) | ~$45 | ~$89 | ~$135 |
+| 50,000 | ~$309 (Creator) | ~$179 (Scale) | ~$160 | ~$159 | ~$420 |
+| 100,000 | ~$549 (Creator) | ~$229 (Scale) | ~$320 | ~$229 | ~$700 |
+
+**Implication for our messaging:** when a tadaify creator picks a provider in the block editor, we could surface their estimated provider cost-at-current-subscriber-count as a helper ("You're on Mailchimp Standard at ~$100/mo for 5k subs. Did you know Kit is free at this scale?"). Out of MVP scope; nice for a v1.5 "Newsletter cost optimiser" upsell card.
+
+---
+
+## 7. Block editor UX flow
+
+### 7.1 Initial empty state
+
+Block dropped onto the page → empty state with:
+
+- **Provider** dropdown: `Kit`, `Beehiiv`, `MailerLite`, `Buttondown`, `Substack (embed)`, `Generic webhook`. Default: `Kit`.
+- **Headline** text: defaults to "Subscribe to my newsletter".
+- **Subheadline** text: defaults to "Weekly updates, no spam".
+- **Button text**: defaults to "Subscribe".
+- **Below**: "Connect your provider →" CTA (pulses until configured).
+
+### 7.2 Provider connect modal (centered, ~720px wide per `feedback_no_right_side_drawers.md`)
+
+For each provider variant (drawn here for **Kit**, others differ slightly):
+
+```
+┌─────────────────────────────────────────────────────┐
+│ Connect Kit (formerly ConvertKit)                  X │
+├─────────────────────────────────────────────────────┤
+│                                                       │
+│  How to find your API key:                            │
+│  1. Open kit.com → Settings → Advanced → API & Webhooks│
+│  2. Click "Generate API Key (v4)"                    │
+│  3. Paste below                                      │
+│                                                       │
+│  API key                                             │
+│  ┌─────────────────────────────────────────────────┐│
+│  │ kit_••••••••••••••••••••••••••••••••           ││
+│  └─────────────────────────────────────────────────┘│
+│  [ Test connection ]                                 │
+│                                                       │
+│  ✓ Connected as: alice@example.com                   │
+│                                                       │
+│  Pick a form                                         │
+│  ┌─────────────────────────────────────────────────┐│
+│  │ ▾ Main newsletter signup (inline)               ││
+│  └─────────────────────────────────────────────────┘│
+│                                                       │
+│  ▸ Advanced: tag subscribers from this block        │
+│  ▸ Advanced: pre-fill custom fields                 │
+│                                                       │
+│  ─────────────────────────────────────────────────  │
+│  GDPR / Double opt-in:                               │
+│  Confirmation email is sent by Kit (default).        │
+│  Configure in Kit → Forms → [your form] → Settings.  │
+│  ─────────────────────────────────────────────────  │
+│                                                       │
+│  [ Cancel ]                              [ Save ]    │
+└─────────────────────────────────────────────────────┘
+```
+
+Per provider, the modal differs:
+- **Beehiiv:** add publication dropdown + DOI override toggle.
+- **MailerLite:** add groups multi-select + bold GDPR-warning copy linking to MailerLite settings.
+- **Buttondown:** no list dropdown (single account list); add tag input + 100/day rate-limit warning.
+- **Substack:** input is the publication URL, not API key; preview iframe in modal.
+- **Generic webhook:** input is URL + auto-generated HMAC secret with copy-button + sample payload + signature-verification snippets in 3 languages.
+
+### 7.3 "Test connection" button — validation states
+
+- **Loading:** spinner inside button.
+- **Success (200):** green check, "Connected as <email>", populates list/group dropdowns.
+- **401 / invalid key:** red, "API key invalid or revoked. Double-check and paste again."
+- **403 / insufficient perms (Beehiiv identity verification, Buttondown unverified account):** red, "Provider requires additional setup: <link to provider's setup page>".
+- **404 / unknown provider URL (webhook):** red, "We couldn't reach that URL. Check it's reachable from the public internet."
+- **Network timeout:** orange, "Provider didn't respond in 10s. Try again, or check the provider's status page: <provider status URL>."
+
+### 7.4 Block live state
+
+Once connected: small green dot on the block toolbar with hover-tooltip "Connected to Kit • Form: Main newsletter signup". Click toolbar → reopens modal.
+
+### 7.5 Visitor-facing behaviour (public page)
+
+1. Visitor types email + clicks Subscribe.
+2. Inline spinner on the button.
+3. Edge Function POSTs to provider with appropriate shape.
+4. On success → button text becomes "Check your inbox to confirm" (DOI providers) or "You're subscribed!" (single opt-in).
+5. On 4xx other than already-subscribed → "Something went wrong. Please try again." + analytics event.
+6. On 429 → "Please try again in a few minutes." + queued in failed-signups for creator's nightly digest.
+
+### 7.6 Creator analytics (out of MVP scope but worth tabling)
+
+- Daily/weekly signups per block.
+- Failed signup count + last-error.
+- DOI confirmation rate (provider webhooks → tadaify analytics).
+- "If you switched from Mailchimp to Kit you'd save $X/mo at your current sub count" (the v1.5 upsell card mentioned in §6b).
+
+---
+
+## 8. Open DECs
+
+These need user answers before we file the implementation issue. **Per `feedback_dec_scope_implementation_only.md`, every DEC below directly affects code/UX/cost — no ops or process DECs in this list.**
+
+### DEC-NEWSLETTER-01 — Auth model for MVP
+
+**Czego dotyczy.** API-key vs OAuth for the four shipped providers (Kit, Beehiiv, MailerLite, Buttondown).
+
+**Szczegolowy opis.** Kit and Beehiiv both expose OAuth 2.0 alongside API keys. OAuth means we get a "Connect with Kit" button (one-click flow), automatic re-authorisation if the creator rotates their key, and listing in those providers' app stores (free marketing). API keys are simpler for v1 and don't require us to register as an app developer with each provider. MailerLite and Buttondown have no OAuth so they're API-key regardless.
+
+**Opcje.**
+1. API-key only for all four providers in v1; defer OAuth to v2.
+2. OAuth-first for Kit and Beehiiv (where supported); API-key for MailerLite and Buttondown.
+3. Both OAuth and API-key for Kit and Beehiiv; let the creator pick.
+
+**Twoja rekomendacja.** Option 1. OAuth requires per-provider app registration (paperwork), doesn't materially change the integration code path, and the per-block UX is identical from the creator's POV (they paste a key OR click a button — both are one step). Ship API-key-only in v1, add "Connect with Kit" / "Connect with Beehiiv" buttons in v1.5 once we have user feedback on actual friction.
+
+---
+
+### DEC-NEWSLETTER-02 — DOI default for Beehiiv block
+
+**Czego dotyczy.** When the creator drops a Newsletter block configured for Beehiiv, what value do we send in `double_opt_override`?
+
+**Szczegolowy opis.** Beehiiv's API accepts `on`, `off`, or `not_set`. `not_set` means "use the publication's default", which is the most respectful to creator config but means the block's GDPR posture depends entirely on what the creator already chose. `on` forces DOI regardless of their setting. `off` forces single opt-in.
+
+**Opcje.**
+1. Default `not_set`, advanced toggle to override per-block.
+2. Default `on` (force DOI for every Beehiiv block), advanced toggle to override.
+3. Default `off`, advanced toggle to override.
+
+**Twoja rekomendacja.** Option 2. tadaify is a new product trying to be GDPR-clean by default, and EU creators (our likely first market) cannot afford to ship a block that bypasses their account's DOI settings unintentionally. Forcing `on` by default means the worst-case is a slightly higher friction signup; the best case is we save a creator from a GDPR complaint. The advanced toggle lets US-only creators or transactional-context creators opt out explicitly.
+
+---
+
+### DEC-NEWSLETTER-03 — How to surface Substack support
+
+**Czego dotyczy.** Substack creators have no native-API option. Do we offer Substack as a "provider" in the dropdown that swaps the form for an iframe embed, or as a separate block type entirely?
+
+**Szczegolowy opis.** Option (a) keeps the unified Newsletter-block mental model and makes the substitution invisible to the creator until they hit limitations (no analytics, no styling). Option (b) makes the trade-off explicit upfront ("This is a Substack-embedded block — styling is constrained") which is more honest but adds another block type to the sidebar.
+
+**Opcje.**
+1. Same Newsletter block; Substack is a provider option that triggers iframe embed mode under the hood.
+2. Separate "Substack embed" block type in the sidebar.
+3. No Substack support in MVP; tell Substack creators to use the generic webhook.
+
+**Twoja rekomendacja.** Option 1, with a one-time callout in the configure modal ("Substack doesn't have a public API, so we render their official embed inside this block. Visual styling is fixed by Substack."). Option 2 fragments the sidebar; option 3 abandons a real chunk of our target audience (Substack creators are a meaningful slice of indie-creator universe).
+
+---
+
+### DEC-NEWSLETTER-04 — Webhook payload schema versioning
+
+**Czego dotyczy.** Generic webhook payload — do we version the schema (`schema_version: "1.0"` field) and maintain backwards compatibility forever, or evolve aggressively and break creators' integrations?
+
+**Szczegolowy opis.** Webhook integrations are notoriously hard to evolve because the consumer (creator's Zapier zap, in-house endpoint, whatever) is outside our control. Versioning gives us flexibility but adds maintenance burden (every code path checks `schema_version`).
+
+**Opcje.**
+1. Version field; commit to backwards compat for 12 months minimum after any new version.
+2. No version field; commit to additive-only changes (never remove or rename fields).
+3. Webhook config has explicit "version" dropdown; creator picks; we maintain N versions in parallel.
+
+**Twoja rekomendacja.** Option 2 (additive only). Simpler than version dispatching, lower mental load on creators, and matches the GitHub/Stripe convention for webhook event payloads (they almost never break old fields). Add `schema_version: "1.0"` to the payload as an informational marker but don't actually branch on it. If we ever need a breaking change, we ship a new event_type (`newsletter.subscribed.v2`) and let creators opt in.
+
+---
+
+### DEC-NEWSLETTER-05 — Buttondown 100/day rate-limit handling
+
+**Czego dotyczy.** Buttondown's free-tier API limit of 100 subscribers/day is the lowest of any provider and could realistically bite a creator during a viral moment. Do we (a) just surface the limit to the creator and let them deal, (b) build a queue + retry system, or (c) skip Buttondown from MVP?
+
+**Szczegolowy opis.** The queue approach (Supabase `pending_subscribers` table + drain cron) costs ~0.5 dev day and substantially improves the worst-case UX, but adds operational complexity (cron monitoring, table backups, one more thing to break). Surfacing the limit to the creator is honest but the visitor who can't subscribe doesn't care whose fault it is.
+
+**Opcje.**
+1. Just surface the limit in the block editor; visitor sees "try again later" on 429.
+2. Build the queue+drain system as part of MVP.
+3. Skip Buttondown from MVP; revisit when the queue exists.
+
+**Twoja rekomendacja.** Option 1 for MVP. Buttondown creators are typically smaller (the 100/day limit is a rough proxy for newsletter size — 100 signups/day → ~3,000/month → already paying for Hobby tier where the limit is higher). The queue system is a v1.5 enhancement once we have data on actual 429 frequency. Cutting Buttondown entirely (option 3) loses a beloved indie-creator integration for an edge case that may never bite.
+
+---
+
+### DEC-NEWSLETTER-06 — Where do we store the creator's API keys?
+
+**Czego dotyczy.** Creator pastes a sensitive API key (Kit, Beehiiv, MailerLite, Buttondown). Where does it live?
+
+**Szczegolowy opis.** Three viable options: (a) plaintext in a Postgres column with RLS, (b) encrypted-at-rest in a Postgres column using `pgcrypto` + a Supabase-Vault-managed key, (c) externalised entirely to a per-creator AWS Secrets Manager / SSM path with the Postgres row holding only the path. Each has trade-offs around blast-radius, cost, and operational complexity.
+
+**Opcje.**
+1. Plaintext + RLS (relying on Postgres access controls).
+2. `pgcrypto` symmetric encryption with per-row key derived from a Vault-stored master.
+3. Externalise to AWS Secrets Manager, one secret per creator-block.
+
+**Twoja rekomendacja.** Option 2 (`pgcrypto` + Vault). Option 1 is too low-effort given keys are revocable but visible in plain text to anyone with SQL access (including Supabase support staff in extreme support cases). Option 3 is overkill at our scale (and adds AWS round-trip latency to every signup, which our Edge Function currently doesn't have because Supabase is colocated). Option 2 strikes the balance: keys are unreadable in raw `psql` queries, RLS still enforces creator scope, and rotation is easy via Supabase Vault.
+
+---
+
+### DEC-NEWSLETTER-07 — Failed-signup retention + creator-facing visibility
+
+**Czego dotyczy.** When a visitor signup fails (provider 4xx, network timeout, webhook unreachable), what do we do with the email?
+
+**Szczegolowy opis.** GDPR makes this thorny: we collected the email under one consent contract (subscribe to creator's newsletter); if delivery to the provider fails, do we hold the email for retry (still GDPR-compliant since consent covers the intent), surface it to the creator as a "missed signup" log (provides creator value), or just discard immediately (cleanest GDPR-wise but loses data the creator might want)?
+
+**Opcje.**
+1. Discard on failure; visitor sees error message and is told to try later.
+2. Hold for 24h with auto-retry (3 attempts, exponential backoff); discard if still failing; never surface to creator.
+3. Hold for 7d; auto-retry; surface to creator in a "Failed signups" view with a CSV export so they can manually rescue.
+
+**Twoja rekomendacja.** Option 2 (24h retry, no creator-facing log). Option 1 throws away data that would have been delivered if the provider was just having a 5min outage. Option 3 creates a GDPR question (we're storing personal data without it being delivered to its intended controller, the creator's provider) plus the ick-factor of creators downloading visitor emails outside the provider's pipeline. Option 2 keeps data ephemerally for the legitimate purpose of completing the original consent intent, then deletes.
+
+---
+
+## 9. Appendix — research methodology + citations
+
+All pricing and free-tier figures verified via WebSearch on 2026-04-26. Where two sources disagreed (e.g. Mailchimp's free tier was variously cited as 250, 500, or 2,000 contacts), I trusted the most recent official documentation page over older third-party reviews.
+
+**Gotchas during research worth flagging for any future SPIKE on this topic:**
+- Several "Kit pricing 2026" review sites (e.g. emailtooltester, mailmeteor) had figures that disagreed by ±$5 because they cite annual-billed monthly-equivalent vs monthly-billed. Always check the rendering against the official `kit.com/pricing` page.
+- Beehiiv changed its API-on-free-tier policy in mid-2024 — older articles say API is paid-only. The current truth (per `developers.beehiiv.com`) is API on every plan including Launch/free.
+- MailerLite operates two parallel API surfaces: `developers-classic.mailerlite.com` (v1) and `developers.mailerlite.com` (v2). For new integrations always use v2; v1 still serves to avoid breaking older customers.
+- Buttondown's docs are split between `docs.buttondown.com` (current) and `docs.buttondown.email` (legacy, still resolves). Pin links to `.com`.
+
+**Out of scope for this SPIKE (worth a follow-up if asked):**
+- Klaviyo, ActiveCampaign, HubSpot, Brevo (Sendinblue), Loops, EmailOctopus, Ghost — covered indirectly by the generic webhook fallback for v1; native integrations would each be ~0.5-1 dev day if user data shows demand.
+- **Sponsorship integrations** (e.g. Beehiiv Boosts, ConvertKit Recommendations) are NOT a newsletter-signup concern; they're a provider-side feature creators configure inside their provider account.
+- **Tracking/analytics on the visitor side** (UTM forwarding to the provider, deduplication via local-storage cookie). The endpoints support `utm_source` / `referring_site` (Beehiiv explicitly, others via custom fields) — recommended to wire in v1, full analytics-side query in v2.
+- **Revenue model for tadaify around this feature.** Per §6 we cannot justify a paid gate on cost grounds. Possible non-cost gates (only if user wants to differentiate Free vs Paid plans) include: max number of newsletter blocks per page (e.g. Free=1, Paid=unlimited), multi-provider fallback (try Kit, fall back to Webhook on failure), or the "cost optimiser" upsell card from §6b. Discuss separately.

--- a/docs/research/video-block-cloudflare-cost.md
+++ b/docs/research/video-block-cloudflare-cost.md
@@ -1,0 +1,910 @@
+---
+type: SPIKE
+project: tadaify
+title: Video Block — Cloudflare Stream Cost & Tier-Gating Analysis
+agent: opus-4-7
+author: orchestrator
+related_brs: []
+tags: [tadaify, video, cloudflare-stream, pricing, tier-gating, margin]
+created_at: 2026-04-26
+status: draft
+---
+
+# SPIKE — tadaify Video Block (Creator-Hosted Uploads) on Cloudflare Stream
+
+> **Scope.** tadaify currently ships a Video block that wraps a YouTube embed (free for us — bandwidth is YouTube's problem, encoding is YouTube's problem, storage is YouTube's problem). The user wants to extend the block so creators can **upload their own MP4 / MOV trailer** (intro to a paid product, video bio, behind-the-scenes clip) and have tadaify host it. This SPIKE answers three questions:
+>
+> 1. What does Cloudflare Stream actually cost in 2026 — at the metered level, not bundle marketing?
+> 2. At our four tiers (Free / Creator $4 / Pro $12 / Business $24), what does video hosting cost us per active creator per month, and do those numbers leave the ≥80% margin floor mandated by `feedback_dec_format_v3_business_cost.md`?
+> 3. How do we gate uploads — quota, overage, retention on cancel — so a single viral creator can't shred a quarter of a year of MRR?
+
+---
+
+## 1. Executive summary
+
+**Recommendation (locked variant — see DEC-VIDEO-01..05 for the per-decision write-ups):**
+
+| Tier            | Native upload? | Included video minutes (storage) | Included delivered minutes / month | Overage policy                                  | Cloudflare cost / creator / month (model) | Margin |
+|-----------------|----------------|----------------------------------|------------------------------------|-------------------------------------------------|-------------------------------------------|--------|
+| **Free**        | NO (YouTube embed only) | 0 stored                       | 0 delivered (YouTube serves)       | n/a — block requires a YouTube URL              | $0.00                                     | n/a (revenue $0) |
+| **Creator $4**  | YES — 1 trailer ≤ 60 s | 1 min stored / page              | 1 000 minutes delivered            | Block upload after 1 trailer; soft-cap deliveries at 1 000 min, then auto-fall-back to YouTube prompt + email "you're going viral, upgrade to Pro" | $0.01 storage + ~$0.30 delivery ≈ **$0.31** | 92% |
+| **Pro $12**     | YES — up to 5 videos × ≤ 120 s = 10 min storage cap | 10 min stored                   | 10 000 minutes delivered           | Block upload after 10 min stored; soft-cap delivery at 10 000 min then $1 per 1 000 min overage billed via Stripe metered | $0.05 storage + ~$3.00 delivery ≈ **$3.05** | 75% (below floor — see §5) |
+| **Business $24** | YES — 50 min stored, no per-video limit | 50 min stored                   | 100 000 minutes delivered          | Hard 50 min storage cap, $1 / 1 000 min overage past 100 000 delivered | $0.25 storage + ~$30 delivery ≈ **$30.25** | NEGATIVE — see §5 |
+
+**Two-line rationale:**
+
+- **Cloudflare Stream is dirt-cheap on storage ($0.005/min/mo) but expensive on delivery ($0.001/min) once a creator has real audience.** A single video at 100k views/mo blows past Business's whole subscription on delivery alone. We MUST cap delivered minutes per tier and either pass overage through (Pro) or rate-limit (Business) — otherwise a creator going viral nukes our margin.
+- **Free tier stays YouTube-only.** Giving free creators a free 30-second hosted upload sounds nice but at our projected 1k views/mo per Free creator that's ~30 minutes delivered = $0.03/mo each. Cheap individually, but at 100k Free creators that's $3 000/mo of pure cost burn against $0 revenue. Hard NO.
+
+**Open DECs (must answer before implementation):** 5 — see §9.
+
+---
+
+## 2. Cloudflare Stream pricing breakdown (verified 2026-04-26)
+
+Cloudflare publishes two-axis metered pricing. Sources: https://developers.cloudflare.com/stream/pricing/ and https://www.cloudflare.com/products/cloudflare-stream/ (fetched 2026-04-26).
+
+### 2.1 Storage
+
+- **$5 per 1 000 minutes stored** = **$0.005 per minute stored per month**.
+- Prepaid in $5 increments. Granularity = seconds of video duration; file size is irrelevant (a 4K master and a 480p clip of equal duration cost the same to store).
+- Live recordings consume storage like any uploaded video.
+- Quote: *"Storage is a prepaid pricing dimension purchased in increments of $5 per 1,000 minutes stored, regardless of file size."*
+
+### 2.2 Delivery
+
+- **$1 per 1 000 minutes delivered** = **$0.001 per minute delivered**.
+- Post-paid, metered.
+- Granularity = HLS/DASH segment length. Cloudflare uses 4-second segments for uploaded content; a viewer watching 5 seconds counts as 8 seconds delivered (rounded up to two segments). Important for short trailers — see §5.4.
+- Bandwidth/egress is INCLUDED in this number; there's no second-tier egress fee like S3 → CloudFront.
+- Quote: *"Delivery is a post-paid, usage-based pricing dimension billed at $1 per 1,000 minutes delivered."*
+
+### 2.3 Encoding
+
+- **FREE.**
+- Quote: *"Ingress (sending your content to us) and encoding are always free."*
+- Cloudflare automatically transcodes to a multi-bitrate ladder (240p, 360p, 720p, 1080p; 4K on Enterprise). No CPU bill, no per-job charge.
+- This matters more than people think — Mux charges **up to $0.0384/min for Premium 720p input**. For a 60-second creator trailer ingested from any iPhone, Cloudflare = $0, Mux Premium = $2.30. Multiply by 100k creators uploading once a year → Cloudflare saves $230k/yr in encoding alone.
+
+### 2.4 Live streaming
+
+- Identical billing to on-demand. Live broadcasts with zero viewers cost $0 in delivery; the moment one viewer joins, delivery clock starts.
+- Stored recordings of live streams count against storage at the standard $5/1 000 min.
+- **Out of MVP scope** — tadaify does not need live (no DEC needed, just confirm Block UI hides any "go live" affordance).
+
+### 2.5 Free tier / bundles
+
+- **No standalone free tier on metered usage.** Cloudflare Stream is pay-as-you-go from minute 1.
+- Bundles exist (Stream + Images): "Starter $5/mo" gives 1 000 min stored + 5 000 min delivered, "Creator $50/mo" gives 10 000 min stored + 50 000 min delivered. Bundles are loss-leaders; a single viral video on Starter exceeds 5 000 min delivered easily, then per-minute overage applies.
+- **For tadaify, ignore bundles.** Cloudflare's metered $5/1 000-stored + $1/1 000-delivered is cheaper at our scale and avoids the "is it covered or overage?" UX problem in our internal billing.
+- Cloudflare Pro and Business plans (the $20/mo and $200/mo CDN plans, NOT Stream bundles) include **100 free min storage + 10 000 free min delivery per month** as a perk. tadaify's main domain is on a Cloudflare Pro plan already (~$20/mo) — we should account for that 100 min/10k min freebie in §5 baseline math, but it's noise once we have >1 active creator.
+
+### 2.6 Operational facts
+
+- **Signed URLs available** for paywalled content (24h-default token TTL). We will need this for Pro/Business — a viewer who right-clicks and grabs the .m3u8 URL must not be able to share it indefinitely.
+- **Watermarks** (custom logo) are free.
+- **Captions** — auto-generated free, manual upload free.
+- **Analytics** — basic playback count free, advanced (geo / device / quartile) free.
+- **Hard storage limit per account** = none documented (we'll hit a soft conversation with Cloudflare account exec around 1 PB).
+- **Per-video upload size limit** = 30 GB or 4 hours, whichever first. Easy headroom for any creator trailer.
+
+---
+
+## 3. Alternatives considered
+
+| Vendor               | Pricing model                                            | Verdict for tadaify | Reason                                                                                                              |
+|----------------------|----------------------------------------------------------|---------------------|---------------------------------------------------------------------------------------------------------------------|
+| **Cloudflare Stream**| $0.005/min stored + $0.001/min delivered, encoding free | **WINNER**          | Cheapest end-to-end at our scale; encoding is free; signed URLs included; we already use Cloudflare for DNS/proxy. |
+| **Mux Video**        | $0.0024/min/mo storage (720p), $0.0008/min delivery after 100k free min, encoding $0.025–$0.0384/min | MAYBE (not now)     | 100k free delivery min/mo is amazing for low-DAU stage, but encoding bill at scale (100k creators × $1.50/yr) erodes the saving; Cloudflare ties us into one vendor we already trust. |
+| **Bunny Stream**     | Encoding free, storage $0.01/GB, delivery $0.005/GB     | REJECTED            | Per-GB pricing penalises high-resolution masters; estimating cost is harder for our customers and our internal billing; smaller global PoP footprint than Cloudflare. |
+| **Vimeo Pro embed**  | $20/mo per ACCOUNT (creator pays Vimeo, embeds in tadaify) | REJECTED for native upload | Pushes cost to creator, we earn nothing, branding is wrong (Vimeo logo on every play). Acceptable as a "bring-your-own-Vimeo" link block in the Video block (zero cost to us — just an iframe). |
+| **AWS S3 + CloudFront** | $0.023/GB-mo storage, $0.085/GB delivery (first 10 TB) | REJECTED            | Delivery is **17x more expensive** than Cloudflare Stream per GB at the same bitrate; we'd also have to build encoding (MediaConvert ≈ $0.0075/min for 720p) and the HLS pipeline ourselves. Multi-engineer-month build for worse unit economics. |
+| **Cloudflare R2 + custom HLS.js** | $0.015/GB-mo storage, **$0.00 egress**, encoding done by us | TEMPTING — REJECTED for v1 | Zero egress is genuinely seductive (R2 is the differentiator). But: we have to build the encoder (FFmpeg fleet on Lambda/Fargate), the manifest generator, the segmentation pipeline, signed URL system, and a transcode-failed-retry queue. Conservative estimate: 3–4 weeks of engineer time + ongoing reliability cost. Not worth it at MVP for an estimated <$50/mo savings until we cross 1 000 paid creators. **Revisit in v2 when we cross 1 000 paid Pros.** |
+| **Self-hosted (Plyr + own HLS)** | EC2/Hetzner box + bandwidth | REJECTED            | We're not building a YouTube. Off the table.                                                                       |
+
+**Lock for MVP: Cloudflare Stream.** Revisit R2-based path post-MVP if we hit 1 000+ paid creators and the Stream bill starts to bite.
+
+---
+
+## 4. Workload assumptions for tier modelling
+
+The cost math below depends on two sets of numbers:
+
+**Per-creator video footprint (storage, low-traffic baseline):**
+
+| Tier        | Avg # videos hosted | Avg duration each | Total storage per active creator |
+|-------------|---------------------|-------------------|----------------------------------|
+| Free        | 0 native            | 0                 | 0 min                            |
+| Creator $4  | 1 trailer           | ~30 s             | 0.5 min ≈ 1 min after rounding   |
+| Pro $12     | 3 videos            | ~60 s each        | 3 min                            |
+| Business $24| 8 videos            | ~90 s each        | 12 min                           |
+
+**Page-view → video-play conversion:**
+
+- Industry baseline for "video-on-page autoplay-muted, click-to-unmute" = 35-50% of visitors play the video. We use **40%** as midpoint.
+- Of those who play, average watch time on a sub-90-second creator trailer = **65%** of duration (industry data — short videos see far higher completion than long-form).
+- So **delivered minutes per pageview ≈ #videos_on_page × video_duration × 0.40 × 0.65**.
+
+For modelling, treat one creator-page as having an average of 1 (Creator) / 3 (Pro) / 8 (Business) videos, with the durations above.
+
+**Per-creator monthly traffic (DAU times typical engagement):**
+
+| Tier        | Pageviews / month per active creator | Implied delivered minutes / month |
+|-------------|--------------------------------------|-----------------------------------|
+| Free        | ~500 (long tail)                     | 0 (no native video)              |
+| Creator $4  | ~1 000                               | 1 000 × 1 × 0.5 min × 0.40 × 0.65 ≈ **130 min**   |
+| Pro $12     | ~10 000                              | 10 000 × 3 × 1 min × 0.40 × 0.65 ≈ **7 800 min**  |
+| Business $24| ~100 000                             | 100 000 × 8 × 1.5 min × 0.40 × 0.65 ≈ **312 000 min** |
+
+The Business number is the painful one. We'll use it.
+
+---
+
+## 5. Cost model under the four tiers
+
+Math reminder: Cloudflare = $0.005 × stored_min + $0.001 × delivered_min.
+
+### 5.1 Free tier
+
+- Storage: 0 min × $0.005 = **$0.000**
+- Delivery: 0 min (YouTube serves it) = **$0.000**
+- **Total Cloudflare cost: $0.00 / creator / month.**
+- **Margin: n/a — Free is a funnel, not a profit centre.** Per-Free-creator other-cost (Supabase row, R2 image, Stripe intent, etc.) is a separate concern; this SPIKE only models Stream.
+
+**Recommendation: Free creators continue to embed YouTube only.** No DEC needed on this — both legs of the math (cost burn at scale + product confusion of "wait, why can I upload here but not there?") agree. See §9 DEC-VIDEO-01 for the formal write-up.
+
+### 5.2 Creator tier ($4/mo)
+
+- Storage: 1 min × $0.005 = **$0.005**
+- Delivery: 130 min × $0.001 = **$0.130**
+- **Total Cloudflare cost: $0.135 / creator / month.** Round up to **$0.31** including the headroom for creators who go above the 1k pageview baseline (we expect a fat-tail distribution; the 90th percentile creator does 4× the median).
+- **Subscription revenue (after Stripe ~3%): $4 × 0.97 ≈ $3.88.**
+- **Margin = ($3.88 − $0.31) / $3.88 = 92%.** Comfortably above floor.
+- **Tier-gating:** 1 trailer max, 60 s max length.
+  - Why: caps storage at 1 min so even a creator who tries to misuse Stream as a generic file host can only park 1 minute.
+  - Why 60 s: matches "trailer / hook" use case. Above 60 s, we're encouraging creators to upload long-form content, which we're not optimised for.
+
+**Margin hold check at 90th-percentile creator (4 000 pageviews/mo, 520 delivered min):**
+
+- Storage $0.005 + Delivery $0.520 = **$0.525**.
+- Margin: ($3.88 − $0.525) / $3.88 = **86%**. Still above floor.
+
+**Margin break-even (when delivered min cost equals 20% of revenue):**
+
+- $0.776 / $0.001 = **776 delivered min/mo** = ~6 000 pageviews/mo at our assumed engagement.
+- That's a Creator-tier user who legitimately needs Pro. Soft-cap at 1 000 delivered min then send "you've used your video budget — upgrade to Pro" email.
+
+### 5.3 Pro tier ($12/mo)
+
+- Storage: 3 min × $0.005 = **$0.015**
+- Delivery: 7 800 min × $0.001 = **$7.80**
+- **Total Cloudflare cost: $7.81 / creator / month.**
+- **Subscription revenue (after Stripe ~3%): $12 × 0.97 ≈ $11.64.**
+- **Margin = ($11.64 − $7.81) / $11.64 = 33%.** **BELOW the 80% floor.**
+
+**This is the alarm.** Pro at 7 800 delivered min/mo is a margin emergency. Two options to fix:
+
+**Option A — Lower the delivered-minute included cap.** Cap Pro at 10 000 delivered min/mo (≈ what we model the average to consume), then $0.001/min overage billed via Stripe metered. The included cap costs us $10/mo at full utilisation, leaving ($11.64 − $10) = $1.64/mo gross on the included portion (14% margin) — still bad. Need overage to be the actual margin generator.
+
+**Option B — Two-step cap:** included up to 5 000 delivered min, soft-cap notification at 5 000, hard-cap or per-min charge after.
+
+**Option C — Bake the cost into a higher Pro price ($19/mo).** Brings revenue (after Stripe) to $18.43, margin at average usage = ($18.43 − $7.81) / $18.43 = **58%**. Still not at floor.
+
+**Option D — Throttle bitrate.** Cloudflare bills per minute regardless of bitrate — so this doesn't actually save us money. NOT a fix. Reject.
+
+**Option E — Pro caps storage at 5 min (not 10) AND included delivery at 3 000 min/mo.** At those numbers: $0.025 + $3.00 = $3.025; margin = ($11.64 − $3.03) / $11.64 = **74%**. Still under floor. Closer.
+
+**Option F (recommended) — Pro at $14/mo + included 5 000 delivery min + storage cap 5 min.** After Stripe revenue $13.58, cost at average usage = $0.025 + $5.00 = $5.025; margin ($13.58 − $5.025) / $13.58 = **63%**. Still below floor.
+
+The honest read: **Pro pricing as currently planned ($12) does not survive our delivery model assumption (~10 000 pageviews/mo).** Either:
+
+1. We raise Pro to $19–$24 ("Pro" → "Pro Plus" rebrand).
+2. We assume Pro creators have *fewer* pageviews than 10k/mo (the 1k median creator). At 1 000 pageviews/mo, delivered min = 780, cost = $0.04 + $0.78 = $0.82, margin = **93%**. Healthy. **But that's basically a Creator-tier user with extra video slots, not a real Pro use-case.**
+3. We surface metered overage as a feature, not a bug — "first 5 000 delivered minutes free, $1 per 1 000 after — billed monthly via Stripe."
+
+This is the meat of **DEC-VIDEO-02 and DEC-VIDEO-03**. We must not ship without resolving.
+
+### 5.4 Business tier ($24/mo)
+
+- Storage: 12 min × $0.005 = **$0.060**
+- Delivery: 312 000 min × $0.001 = **$312.00**
+- **Total Cloudflare cost: $312.06 / creator / month.**
+- **Subscription revenue (after Stripe ~3%): $24 × 0.97 ≈ $23.28.**
+- **Margin = NEGATIVE $288.78 per creator.** Business at $24 with native video and 100k pageviews/mo loses us **288 dollars per creator per month**.
+
+This is catastrophic. Three rescues:
+
+1. **Business price raised to $99/mo** (10× current). Revenue after Stripe = $96.03. Still −$216 margin. NOT enough.
+2. **Business price raised to $499/mo**. Revenue after Stripe = $484. Margin = $172 = 36%. Below floor.
+3. **Business priced based on delivery overage as primary line item.** Base Business = $24/mo, includes 25 000 delivery min, then $1 per 1 000 over. At 312 000 delivered min: $24 + 287 × $1 = $311. Revenue ≈ $301. Cost = $312. Still loss of $11/mo. Close to break-even but no margin.
+4. **Business price = $24/mo + $1.50 per 1 000 delivered min over 25 000.** At 312 000 min: $24 + 287 × $1.50 = $454.50. Revenue after Stripe = $441. Cost = $312. Margin = $129/$441 = **29%**. Under floor.
+
+**Honest conclusion on Business:** the model "$24/mo flat with unlimited high-traffic native video" is not a real product. We have three strategic paths:
+
+- **Path 1 — Constrain Business throughput.** Hard-cap delivered min/mo to 50 000. Past the cap, video stops working ("creator over budget — viewers see YouTube fallback or 503"). Cost at cap: $0.06 + $50 = $50.06. With Business at $24: −$26.78 margin. STILL NEGATIVE. Path 1 alone doesn't work either.
+- **Path 2 — Raise Business floor.** Business at $79/mo with 50 000 delivery cap and overage at $1.50/1 000 above. At 50 000 delivered: $0.06 + $50 = $50.06. Revenue after Stripe = $76.63. Margin = ($76.63 − $50.06) / $76.63 = **35%**. Below floor.
+- **Path 3 — Business doesn't include native video at all; it's an add-on metered SKU.** Business stays at $24/mo (analytics + custom domain + collaborators), and "Hosted Video" is a metered add-on starting at $9/mo for first 25 000 delivery minutes, $1 per 1 000 after. **This is the cleanest economically. It keeps Business at its current price for real Business users (consultants, small agencies, "pros pretending to be agencies") and forces real high-bandwidth creators onto a transparent metered SKU.**
+
+**DEC-VIDEO-04** captures the strategic question: do we keep "all video included" as a Business promise (and absorb the loss as customer acquisition), or do we ship a separate metered SKU?
+
+### 5.5 Per-tier summary table
+
+| Tier      | Subscription | Cloudflare cost @ assumed traffic | Margin              | Recommendation                                                  |
+|-----------|--------------|------------------------------------|---------------------|-----------------------------------------------------------------|
+| Free      | $0           | $0                                 | n/a                 | YouTube only — no native upload                                 |
+| Creator   | $4           | $0.31                              | 92% ✅              | Ship as designed                                                |
+| Pro       | $12          | $7.81                              | 33% ❌              | Either raise to $19+ OR cap delivery at 5 000 min + metered overage |
+| Business  | $24          | $312                               | NEGATIVE ❌         | Either raise to $79+ with cap OR move native video to add-on SKU|
+
+---
+
+## 6. Cost-at-scale table (orchestrator standard 100 / 1k / 10k / 100k / 1M DAU)
+
+We assume a tier mix that's realistic for a creator-page SaaS:
+
+- **Free**: 80% of all creators (the long tail — they stay free forever, embed YouTube)
+- **Creator $4**: 15%
+- **Pro $12**: 4%
+- **Business $24**: 1%
+
+We also assume 60% of registered creators are "active" in any given month (so DAU ≈ MAU × ~0.5; we use the user-supplied DAU as MAU for simplicity since the gap is noise at this resolution). Per-tier per-creator Cloudflare cost from §5.1–5.4. Revenue is computed as subscription × tier %, after 3% Stripe.
+
+| DAU      | Free creators (cost $) | Creator-tier creators ($0.31 × N) | Pro creators ($7.81 × N) | Business creators ($312 × N) | **Total Cloudflare bill** | Subscription revenue (after Stripe 3%) | Net (rev − Cloudflare) |
+|----------|------------------------|------------------------------------|--------------------------|------------------------------|---------------------------|-----------------------------------------|------------------------|
+| **100**  | 80 × $0 = $0           | 15 × $0.31 = $4.65                  | 4 × $7.81 = $31.24       | 1 × $312 = $312.00           | **$347.89 / mo**          | (15 × $4 + 4 × $12 + 1 × $24) × 0.97 = **$128.04** | **−$219.85**           |
+| **1k**   | 800 × $0 = $0          | 150 × $0.31 = $46.50                | 40 × $7.81 = $312.40     | 10 × $312 = $3 120.00        | **$3 478.90 / mo**        | $1 280.40 / mo                          | **−$2 198.50**         |
+| **10k**  | 8 000 × $0             | 1 500 × $0.31 = $465                | 400 × $7.81 = $3 124     | 100 × $312 = $31 200         | **$34 789 / mo**          | $12 804 / mo                            | **−$21 985 / mo**      |
+| **100k** | 80 000 × $0            | 15 000 × $0.31 = $4 650             | 4 000 × $7.81 = $31 240  | 1 000 × $312 = $312 000      | **$347 890 / mo**         | $128 040 / mo                           | **−$219 850 / mo**     |
+| **1M**   | 800 000 × $0           | 150 000 × $0.31 = $46 500           | 40 000 × $7.81 = $312 400| 10 000 × $312 = $3 120 000   | **$3 478 900 / mo**       | $1 280 400 / mo                         | **−$2 198 500 / mo**   |
+
+**Reading this table:** Business is **dragging the entire P&L into the red** at every scale. At 1M DAU we'd be losing **$2.2M per month** before even paying our own salaries. The $312/creator/month Business cost is doing 90% of the damage.
+
+If we apply the recommended fix from §5.4 Path 3 — **Business at $24 base + native-video as a metered add-on SKU averaging $50/mo per heavy-video Business user, 30% of Business creators opt in** — the table changes dramatically:
+
+| DAU   | Business base only (no video, no Cloudflare cost) | Business + video add-on ($50 add-on, $50.06 cost) | Cloudflare bill (Business segment) | Net Cloudflare for Business |
+|-------|----------------------------------------------------|----------------------------------------------------|-------------------------------------|------------------------------|
+| 100   | 0.7 × 1 = 0.7 ≈ $0                                 | 0.3 × 1 × $50 = $15 cost ≈ $50.06 actual           | $50                                 | revenue $15 (loss $35)       |
+
+That add-on math also doesn't pencil out unless we price the add-on at $79 (covers $50 cost + 36% margin).
+
+**Bottom line of the cost-at-scale table:** **Business tier as currently sketched ($24/mo, all features) cannot include unlimited native video.** Either reprice Business, gate video by an add-on SKU, or cap delivery hard. **DEC-VIDEO-04 must be answered before we ship anything.**
+
+---
+
+## 7. Tier-gating recommendation (concrete)
+
+This section is intentionally prescriptive — copy/paste-ready for the implementation issue.
+
+### 7.1 Free
+
+- **Native upload: BLOCKED.** Block UI shows YouTube URL field only.
+- If a Free creator pastes a non-YouTube URL: validation error "Native video uploads are available on Creator and above. [Upgrade]".
+- **Storage cap: 0 min.** Hard-enforced server-side (RLS or Edge Function `videos` table check).
+- **Delivery cap: n/a.** YouTube serves.
+
+### 7.2 Creator $4
+
+- **Native upload: ALLOWED — 1 video slot.**
+- **Per-video duration cap: 60 s.** Enforced client-side at upload (FFmpeg.js probe before POST) and server-side via Cloudflare Stream API webhook (if `duration > 60` → mark video deleted, emit error, return 413).
+- **Storage cap: 1 min total.** ("You've used your trailer slot — replace your existing trailer or upgrade to Pro to add more.")
+- **Delivery cap: 1 000 minutes/month soft-cap.**
+  - At 800 min: in-app banner "your video is getting popular — only 200 minutes left this month".
+  - At 1 000 min: video player shows YouTube-fallback prompt for the rest of the month ("creator's video is over budget — [link to YouTube version, if creator added one]"); creator gets one email/day "you're on the verge of needing Pro".
+  - **No overage billing on Creator tier** — the upgrade prompt is the lever, not metering.
+- **Replace video:** allowed, deletes old, recommends "use the same trailer, just edit it" since storage cap is 1.
+
+### 7.3 Pro $12 (subject to DEC-VIDEO-02)
+
+Pending DEC. Two scenarios shipped in mockup:
+
+**Scenario A (Pro stays $12):**
+
+- Native upload allowed, max 5 video slots
+- Per-video duration cap: 120 s
+- Storage cap: 10 min total
+- Delivery cap: **5 000 minutes/month included** (we DROPPED this from the original 10k assumption to protect margin)
+- Overage: $1 per 1 000 delivered minutes via Stripe metered, billed monthly. No silent throttling.
+
+**Scenario B (Pro raised to $19):**
+
+- Same caps, but no overage charges up to 10 000 min/mo (a true unlimited-feeling Pro).
+- Past 10 000 min, $1 per 1 000 metered.
+
+Margin at typical Pro creator (1k pageviews, 780 delivered min): **A = 93% margin, B = 95% margin**. The decision really only matters at the 10k+ pageview Pro creator, where A surfaces overage billing as part of the product (transparent), and B absorbs it as part of the higher base price (simpler).
+
+**Recommendation: Scenario A**, on the principle that surfacing metered video as a feature ("you're going viral — here's exactly what it costs") aligns incentives and lets us keep Pro at the round $12.
+
+### 7.4 Business $24 (subject to DEC-VIDEO-04)
+
+Pending DEC. Three scenarios:
+
+**Scenario X — Business absorbs video, keeps $24:**
+Hard delivery cap at 25 000 min/mo. Past cap, video falls back to "video unavailable" with no overage charge. **NOT recommended** — at 25k delivered min cost is $25, sub revenue after Stripe is $23.28, **margin is already negative at the cap.**
+
+**Scenario Y — Business raised to $79, includes 50 000 delivery min, overage $1.50/1 000:**
+Cost at cap = $50, revenue after Stripe = $76.63, margin = 35% — below floor but at least positive.
+
+**Scenario Z — Business stays $24, native video is a separate add-on SKU "Video Pro" at $19/mo (covers 25 000 delivery min, $1.50/1 000 overage), or $79/mo "Video Plus" (covers 100 000 delivery min, $1/1 000 overage):**
+Business creators who don't need heavy video pay $24. Business creators who do need it self-select onto $24 + $19 = $43 or $24 + $79 = $103. **Cleanest pricing economics, hardest to communicate clearly on the pricing page.**
+
+**Recommendation: Scenario Z** — separate add-on SKU. Pricing page shows Business base, then a separate "Video Hosting" pricing card below. Mockup §8.6 illustrates.
+
+### 7.5 Cancel / downgrade behaviour (universal)
+
+When a creator downgrades or cancels:
+
+- **First 30 days post-cancel**: videos remain in Cloudflare Stream, served read-only (no new uploads). Creator can re-subscribe, everything resumes.
+- **Day 31**: videos hard-deleted from Cloudflare Stream. `videos` row marked `status = 'deleted', deleted_at = now()`. Block falls back to "video no longer available" placeholder. Creator gets a reminder email at day 7, 14, 28.
+- **Re-upload required after 30 days.** No paid resurrection of deleted videos.
+
+This 30-day grace mirrors how we handle Stripe subscriptions and prevents accidental data loss for creators who briefly lapse. Cost during grace: an inactive Business creator with 12 min stored = $0.06/mo storage, **no delivery cost** (the page redirects or the block is hidden once the sub is canceled). Total grace-period cost is noise.
+
+**DEC-VIDEO-05** captures whether 30 days is the right grace window or if we should make it shorter (cost) / longer (UX).
+
+---
+
+## 8. UX flow in the block editor
+
+Walks the implementer through every state. Mockup will live at `claude-reports/mockups/tadaify-video-block-native-upload/`.
+
+### 8.1 Block-editor header
+
+```
+Video Block
+
+[ tab: YouTube embed ]   [ tab: Upload native (Creator+) ]
+                                   ↑ disabled with lock icon for Free, badge with tier on hover
+```
+
+### 8.2 YouTube tab (existing)
+
+- Single text field "YouTube URL"
+- Validates `^https://(www\.)?youtu(\.be|be\.com)/`
+- Preview thumbnail rendered immediately
+- Save button enabled when URL is valid
+
+### 8.3 Native-upload tab
+
+**State 1 — empty (Creator+ only):**
+
+```
+Drag video here, or [Browse]
+
+Max 60 s · MP4/MOV/WebM · ≤ 500 MB
+
+ℹ Your video is hosted on Cloudflare Stream and served at HD.
+   Encoding usually takes 30-90 seconds.
+```
+
+**State 2 — uploading (progress bar):**
+
+```
+[██████████░░░░░░] 62%
+
+Uploading: my-trailer.mp4 (8.4 MB / 13.6 MB)
+Don't close this tab.
+```
+
+**State 3 — encoding:**
+
+```
+[ thumbnail spinner ]
+
+Encoding... usually 30-90s
+
+This step is free — Cloudflare is making your video ready for HD playback.
+Feel free to close this tab; we'll email you when it's done.
+```
+
+**State 4 — ready:**
+
+```
+[ poster frame thumbnail with play overlay ]
+
+▶ my-trailer.mp4 (47s)
+HD · 4 MB · ready to publish
+
+[ Replace ] [ Delete ] [ Edit poster frame ]
+```
+
+**State 5 — error (encoding failed):**
+
+```
+⚠ We couldn't process this video.
+
+Reason: unsupported audio codec (Apple Lossless detected).
+Try re-exporting from your video editor as H.264 + AAC.
+
+[ Try a different file ]
+[ Copy support code: cs-7c9e2... ]
+```
+
+**State 6 — over quota (Creator hitting 1-trailer cap):**
+
+```
+🔒 Upgrade required
+
+You're on the Creator plan, which includes 1 trailer slot.
+Replace your existing trailer, or upgrade to Pro for up to 5 video slots.
+
+[ Replace existing ]
+[ See Pro plan → ]
+```
+
+**State 7 — delivery soft-cap reached:**
+
+(only on Creator tier; on Pro/Business it surfaces as a charge, not a block)
+
+```
+⚡ Your trailer is going viral
+
+You've used 1,000 of 1,000 included video minutes this month.
+Until your renewal on May 1, viewers will see a YouTube fallback if you've added one,
+or a "video unavailable" placeholder.
+
+[ Upgrade to Pro for 5,000 minutes → ]
+```
+
+### 8.4 Replace video flow
+
+Centered modal (not right-side drawer — per `feedback_no_right_side_drawers.md`), 720 px wide:
+
+```
+Replace your video?
+
+Your current trailer "my-trailer.mp4" will be deleted from Cloudflare immediately.
+Upload a new one to take its place.
+
+[ Cancel ]   [ Replace anyway → ]
+```
+
+### 8.5 Pro tier — managing 5 slots
+
+Sidebar showing each slot, drag-to-reorder, slot-level "delete" button. Storage indicator at top: `7m 23s of 10m used`.
+
+### 8.6 Business tier — Video Hosting add-on SKU pricing card
+
+(Only relevant if DEC-VIDEO-04 = Scenario Z.) On the `/settings/billing` page, below the main Business plan card:
+
+```
+─────────────────────────────────
+🎥 Video Hosting
+
+Native upload + HD streaming for your creator pages.
+
+[ ] Off (use YouTube embeds) — current
+[ ] Video Starter — $19/mo
+      • 25,000 video minutes / month
+      • $1.50 per 1,000 minutes after
+[ ] Video Plus — $79/mo
+      • 100,000 video minutes / month
+      • $1 per 1,000 minutes after
+
+[ Activate ]
+─────────────────────────────────
+```
+
+### 8.7 Retention warnings on cancel
+
+In the cancel-subscription flow:
+
+```
+Heads up — what happens to your videos?
+
+You have 3 videos hosted on Cloudflare Stream (4m 12s).
+After cancelling:
+  • Days 1-30: videos remain available
+  • Day 31: videos are permanently deleted from our servers
+  • Your blocks will fall back to the YouTube version if you've added one,
+    or show a "video unavailable" placeholder.
+
+We'll remind you at day 7, 14, and 28.
+
+[ Keep my subscription ]   [ Cancel anyway → ]
+```
+
+### 8.8 Embedded player (viewer-side)
+
+- HLS.js + native iOS Safari fallback
+- Custom skin: tadaify play button, no Cloudflare branding
+- Watermark with creator's chosen logo (Pro+ feature, free on Cloudflare side)
+- Click-to-unmute (default muted autoplay if user opts in)
+- Captions toggle if creator added them
+- Quality selector (auto / 360p / 720p / 1080p)
+- No share/embed button (we want viewers on the creator's tadaify page, not embedding the bare video elsewhere)
+
+### 8.9 Analytics dashboard view
+
+`/dashboard/analytics/videos`:
+
+- Per-video plays, watch time, average % watched, top countries
+- Delivered minutes used this month / cap (with traffic-light bar)
+- Cost projection (Pro/Business): "At current rate, expect ~$X overage this month"
+
+This last item is **critical** — it gives Pro creators agency over whether their video is worth keeping live. No surprise bills.
+
+---
+
+## 9. Open DECs
+
+Concrete decisions the user must answer before implementation. All five must move to `answered` before the first PR opens. Each follows the v3 format mandate from `feedback_dec_format_v3_business_cost.md` (rationale + cost-at-scale).
+
+### DEC-VIDEO-01 — Free tier native upload Y/N
+
+- **Czego dotyczy:** Whether the Free tier offers native video upload at all (vs. YouTube embed only).
+- **Szczegolowy opis:** Cloudflare Stream is cheap per-creator on storage but adds up at scale. A Free creator with even a 30-second trailer and 1k views/mo = $0.03/creator/mo; at 100k Free creators that's $3 000/mo of pure-loss spend. The upside is a smoother upgrade funnel (creators see what hosted video looks like, want more slots, upgrade).
+- **Opcje:**
+  1. Free = YouTube only. Native upload starts at Creator $4. (LOCKED RECOMMENDATION)
+  2. Free = 1 native upload, 15 s max, 250 delivered min/mo cap. After cap, hard YouTube fallback prompt.
+  3. Free = native upload disabled by default; user gets 7-day free trial of native upload then it disables.
+- **Rekomendacja:** Option 1. Margin discipline matters more than funnel polish; the upgrade message "want native video? upgrade to Creator" is clear and doesn't risk a cost runaway.
+- **Cost-at-scale (per option, Free creators only, monthly):**
+
+| Option | 100 DAU | 1k DAU | 10k DAU | 100k DAU | 1M DAU |
+|--------|---------|--------|---------|----------|--------|
+| 1      | $0      | $0     | $0      | $0       | $0     |
+| 2      | $2.40   | $24    | $240    | $2 400   | $24 000|
+| 3      | $0.50 (avg of 7-day on, 23-day off) | $5 | $50 | $500 | $5 000 |
+
+### DEC-VIDEO-02 — Pro tier delivery cap & overage policy
+
+- **Czego dotyczy:** How Pro handles delivered minutes — included cap and overage billing.
+- **Szczegolowy opis:** Pro at $12/mo with our modelled 10k pageviews/mo creator costs us $7.81/creator/mo, leaving 33% margin — below the 80% floor. We need to either price-gate (raise to $19), volume-gate (cap delivery at 5 000 included min), or surface overage as metered billing.
+- **Opcje:**
+  1. Pro = $12, includes 5 000 delivered min/mo, $1 per 1 000 metered overage via Stripe. Upgrade message at 80% utilisation. (RECOMMENDED — see Scenario A above)
+  2. Pro = $19, includes 10 000 delivered min/mo, $1 per 1 000 metered overage via Stripe.
+  3. Pro = $12, includes 10 000 delivered min/mo, no overage — hard cap at 10 000 with creator-side throttle (video stops working).
+- **Rekomendacja:** Option 1. Surfaces actual cost as a transparent line item, keeps the Pro headline price at a round $12, and creators who go viral self-select into being paying-for-video customers. Option 3 is a UX nightmare ("my page just stopped working").
+- **Cost-at-scale (Pro creators × tier mix 4%, monthly net loss/profit per Pro creator at average usage):**
+
+| Option | Cost @ avg | Revenue (after Stripe) | Margin / creator | Net at 100k DAU (4 000 Pro creators) |
+|--------|------------|------------------------|------------------|--------------------------------------|
+| 1      | $5.025 (5 000 incl)   | $11.64 + overage avg $2.80 = $14.44   | 65%        | + $37 660 / mo                      |
+| 2      | $7.81 (10 000 incl)   | $18.43                | 58%       | + $42 480 / mo                      |
+| 3      | $7.81 (10 000 hard cap) | $11.64              | 33%        | + $15 320 / mo (and bad UX)        |
+
+### DEC-VIDEO-03 — Pro storage cap (5 vs 10 minutes)
+
+- **Czego dotyczy:** Total stored minutes a Pro creator can hold across all their videos.
+- **Szczegolowy opis:** Storage is dirt-cheap ($0.005/min) so this isn't a margin lever — it's a *product positioning* lever. 5 min total = "trailers and short hooks". 10 min = "trailers + a couple of mid-length explainers". The implication for upgrade pressure to Business is real.
+- **Opcje:**
+  1. 5 min total, max 60 s per video. Strong upgrade pressure to Business for anything longer.
+  2. 10 min total, max 120 s per video. (RECOMMENDED — matches creator mental model)
+  3. 15 min total, max 180 s per video. Premium-feeling but eats into Business's distinct value prop.
+- **Rekomendacja:** Option 2. 10 min × 2-min videos covers ~5 trailers comfortably; people who need longer should be on Business or YouTube-link.
+- **Cost-at-scale (storage cost only, Pro segment, monthly):**
+
+| Option | Cost / Pro creator | At 4 000 Pro creators (100k DAU) |
+|--------|---------------------|----------------------------------|
+| 1      | $0.025              | $100 / mo                        |
+| 2      | $0.05               | $200 / mo                        |
+| 3      | $0.075              | $300 / mo                        |
+
+(Storage is genuinely a rounding error at every scale. Pick on UX, not cost.)
+
+### DEC-VIDEO-04 — Business tier video model (absorbed vs. add-on SKU)
+
+- **Czego dotyczy:** Whether native video is included in Business $24 or sold separately as a metered add-on.
+- **Szczegolowy opis:** Business at $24 with our modelled 100k pageviews/creator costs $312/creator/mo to host video — a $288 loss per Business creator with native upload. This is unsurvivable. We must either reprice Business, hard-cap delivery at a level that breaks the product promise, or move native video to a separate add-on SKU.
+- **Opcje:**
+  1. Business stays $24, native video included with hard cap 25 000 delivered min/mo. Past cap, video shows fallback. (Path 1 — does not protect margin even at cap)
+  2. Business raised to $79, includes 50 000 delivered min, overage $1.50/1 000. (Path 2 — keeps "all features included" promise)
+  3. Business stays $24 (analytics, custom domain, collab), native video moves to add-on SKU "Video Hosting" at $19 (Starter — 25k min) / $79 (Plus — 100k min) per month with overage. (Path 3 — RECOMMENDED, cleanest unit economics)
+  4. Business raised to $99 with all-you-can-eat video. (Path 4 — simplest pricing page, worst margin protection)
+- **Rekomendacja:** Option 3. Keeps the Business price-point recognisable for the majority of Business creators (who use it for analytics + custom domain + collaborators, not heavy video), and turns native video into a self-selected metered SKU for the small subset who genuinely need it. Highest expected margin and most defensible pricing-page math.
+- **Cost-at-scale (Business segment only, 1% of total, 100k DAU = 1 000 Business creators, monthly):**
+
+| Option | Cost              | Revenue (after Stripe)      | Net Business segment            |
+|--------|-------------------|------------------------------|---------------------------------|
+| 1      | $50.06 × 1 000 = $50 060   | $24 × 1 000 × 0.97 = $23 280 | **−$26 780 / mo**             |
+| 2      | $50.06 × 1 000 = $50 060   | $79 × 1 000 × 0.97 = $76 630 | **+$26 570 / mo**             |
+| 3      | (300 with add-on × $50.06) + (700 base × $0.06) = $15 060   | (1 000 × $24 + 300 × $50) × 0.97 = $37 850 | **+$22 790 / mo**  |
+| 4      | $312 × 1 000 = $312 000    | $99 × 1 000 × 0.97 = $96 030 | **−$215 970 / mo**            |
+
+### DEC-VIDEO-05 — Post-cancel video retention window
+
+- **Czego dotyczy:** How long videos stay alive after a creator cancels their subscription.
+- **Szczegolowy opis:** Storage cost of an inactive creator's videos is negligible ($0.06/mo for a Business creator at the cap, $0.005/mo for a Creator-tier user). Delivery cost during the retention window is also near-zero because we hide the block behind the `subscription_active` check. So the lever is UX (data-loss panic) vs. churn-prevention (creator briefly bounces, then re-subs, expects everything to be there).
+- **Opcje:**
+  1. 30 days. (RECOMMENDED — matches Stripe's grace defaults and our existing UX patterns)
+  2. 7 days. (Aggressive cleanup, more pressure to re-sub fast)
+  3. 90 days. (Generous; creators rarely lose videos to cancellation)
+  4. Forever (storage-only, no delivery). (Soft archive — see §7.5)
+- **Rekomendacja:** Option 1. 30 days is the industry default; 7 days creates anger when a creator's PayPal fails and they don't notice for two weeks; 90/forever increases storage costs minimally but weakens the upgrade pressure.
+- **Cost-at-scale (storage only, assuming 5% of creators churn each month and average 5 min stored per churner, monthly):**
+
+| Option | At 100k DAU (5 000 churners) | At 1M DAU (50 000 churners) |
+|--------|-----------------------------------|------------------------------|
+| 1 (30 d)| $0.025 × 5 000 = $125 / mo (rolling) | $1 250 / mo |
+| 2 (7 d) | ~$30 / mo                        | $300 / mo                   |
+| 3 (90 d)| $375 / mo                        | $3 750 / mo                 |
+| 4 (forever) | grows linearly forever, unbounded | unbounded                |
+
+(Cost is small at every option. Pick on UX.)
+
+---
+
+## 10. Implementation notes (for the eventual feature issue)
+
+- **Database:** new `videos` table — `id, creator_id, source ('cloudflare-stream' | 'youtube'), cloudflare_uid, url, duration_s, status ('uploading' | 'encoding' | 'ready' | 'errored' | 'deleted'), created_at, ready_at, deleted_at`. RLS: only owner can SELECT non-public rows.
+- **`tier_quota_videos` view** computed from `videos` × `subscription.tier`: returns `(stored_min_used, stored_min_cap, delivered_min_mtd, delivered_min_cap)` per creator. Computed live, not denormalised — Cloudflare Stream API returns delivered minutes via webhook + a daily reconcile job.
+- **Upload flow:** browser → Cloudflare Direct Creator Upload (signed URL minted by Edge Function) → Cloudflare Stream → webhook back to our Edge Function → `videos.status = 'ready'`. We never proxy the bytes; the cloud does. (Critical — proxying through Supabase Edge Functions would torch our bandwidth bill.)
+- **Quota check:** at upload-init Edge Function, before minting the Cloudflare Direct Upload URL, check `tier_quota_videos` and reject 413 if over.
+- **Delivery quota:** Cloudflare exposes delivered-minutes via `/accounts/.../stream/analytics`. Cron job every 15 min pulls per-video data, aggregates per-creator, writes to `delivered_min_mtd`. Soft-cap and overage triggered from this number.
+- **Stripe metered billing:** for Pro/Business overage, register a Stripe metered price (`unit = 1000 minutes`, `unit_amount = 100 cents` for Pro / `150 cents` for Business). Daily Edge Function pushes `stripe.subscriptionItems.createUsageRecord(...)` with the day's overage minutes.
+- **Cancel cleanup:** daily cron looks for `subscription.canceled_at + 30d ≤ now()` rows and deletes the corresponding Cloudflare videos via API, then marks `videos.status = 'deleted'`.
+- **Feature flag:** ship behind `FEATURE_NATIVE_VIDEO=true` env var, default false. Lets us do staff-only access during DEC resolution.
+
+---
+
+## 11. Risks and mitigations
+
+| Risk                                                            | Likelihood | Impact | Mitigation                                                                                                     |
+|------------------------------------------------------------------|------------|--------|----------------------------------------------------------------------------------------------------------------|
+| Creator embeds Stream URL on a non-tadaify site to abuse our bandwidth | Medium     | High   | Signed URLs with 24h TTL + `Referer` check; embed our player only on `*.tadaify.com` and creator custom domains tracked in `domains` table. |
+| Cloudflare prices increase                                      | Low        | High   | Contract is metered, not committed — we can pivot to R2-based path (see §3) within ~3 weeks if Stream prices double. |
+| Encoding fails for valid file (bug in Cloudflare's pipeline)    | Medium     | Low    | Retry once automatically; expose error code to creator with action ("re-export as H.264+AAC"); support code for our team. |
+| Creator uploads copyrighted video → DMCA takedown               | Medium     | Medium | Standard DMCA process; surface "report this video" link in viewer; respond within 24h.                         |
+| Large viral spike → unexpected $5k+ Cloudflare bill in a single weekend | Low | High   | Account-wide hard cap on Cloudflare side (talk to account exec for "auto-pause delivery at $X per day" — they have this); internal billing alarm at $100/day delta. |
+| Webhooks from Cloudflare drop → encoding-state stuck            | Medium     | Low    | Reconcile cron every 15 min: any `videos.status = 'encoding'` older than 10 min → query Cloudflare API directly for state, update row. |
+| Stripe metered billing failures (network blip)                  | Medium     | Low    | Idempotency keys on usage records; retry queue for failed pushes; daily reconcile against Cloudflare delivered minutes truth. |
+
+---
+
+## 12. Decision summary (for the orchestrator backlog)
+
+When user accepts this SPIKE:
+
+1. Resolve **DEC-VIDEO-01..05** in the `decisions.json` file.
+2. Open feature issues:
+   - `[VIDEO-NATIVE-01] Database: videos table + tier_quota_videos view`
+   - `[VIDEO-NATIVE-02] Edge Function: cf-stream-direct-upload-url + webhook handler`
+   - `[VIDEO-NATIVE-03] Block editor: native upload tab UI (states 1-7)`
+   - `[VIDEO-NATIVE-04] Viewer player: HLS.js wrapper with tadaify skin + watermark`
+   - `[VIDEO-NATIVE-05] Quota enforcement: storage cap, delivery cap, soft-cap notifications`
+   - `[VIDEO-NATIVE-06] Stripe metered billing: Pro overage product + usage record cron`
+   - `[VIDEO-NATIVE-07] Analytics dashboard: per-video plays + delivered min meter + cost projection`
+   - `[VIDEO-NATIVE-08] Cancel cleanup: 30-day grace + daily cron for hard-delete`
+   - `[VIDEO-NATIVE-09] (only if DEC-VIDEO-04 = Z) Pricing page: Video Hosting add-on SKU card`
+3. Mockup at `claude-reports/mockups/tadaify-video-block-native-upload/index.html` showing every state from §8.
+4. Refinement pass on each VIDEO-NATIVE-NN issue per `skills/refinement` (mockup link, BR diff, TR diff, Playwright plan, unit test plan, edge-case list).
+
+---
+
+## 13. Sources
+
+- Cloudflare Stream pricing (developers.cloudflare.com/stream/pricing/) — fetched 2026-04-26
+- Cloudflare Stream product page (cloudflare.com/products/cloudflare-stream/) — fetched 2026-04-26
+- Mux Video pricing (mux.com/pricing/video) — fetched 2026-04-26
+- Bunny Stream pricing (bunny.net/stream/) — fetched 2026-04-26
+- WebSearch: "Cloudflare Stream pricing 2026 per minute storage delivery" — 2026-04-26
+
+---
+
+## 14. Appendix A — Sensitivity analysis
+
+The §5 cost model is sensitive to two assumptions: **pageviews per active creator** and **engagement (% of pageviews that play the video × watch completion)**. Both are guesses. This appendix sweeps each axis to show how robust the recommendations are.
+
+### 14.1 Pro tier — sensitivity to pageviews
+
+Hold engagement constant at 0.40 × 0.65 = 26%. Vary monthly pageviews per Pro creator (3 videos × 1 min each).
+
+| Pageviews / mo | Delivered min       | Cost     | Margin @ $12  | Margin @ $19  | Verdict                          |
+|----------------|---------------------|----------|---------------|---------------|----------------------------------|
+| 1 000          | 780                 | $0.78    | 93%           | 96%           | Healthy at both prices           |
+| 2 500          | 1 950               | $1.95    | 83%           | 89%           | Above floor at $12               |
+| 5 000          | 3 900               | $3.90    | 67%           | 79%           | $12 below floor; $19 borderline  |
+| 10 000         | 7 800               | $7.80    | 33%           | 58%           | Both below floor — overage needed|
+| 25 000         | 19 500              | $19.50   | NEGATIVE      | NEGATIVE      | Overage required at any price    |
+| 50 000         | 39 000              | $39.00   | catastrophic  | catastrophic  | Forced upgrade to Business       |
+
+**Reading:** at any Pro creator above ~3 000 pageviews/mo, the $12 base price doesn't carry the delivery cost. **The metered-overage pattern (Option 1 in DEC-VIDEO-02) is the only model that survives the long tail of pageview distribution.** A flat-priced Pro will get arbitraged by a single creator with viral content.
+
+### 14.2 Pro tier — sensitivity to engagement
+
+Hold pageviews at 10 000/mo, vary engagement.
+
+| Play rate × completion | Delivered min       | Cost     | Margin @ $12  | Verdict                          |
+|------------------------|---------------------|----------|---------------|----------------------------------|
+| 0.10 × 0.40 = 4%       | 1 200               | $1.20    | 90%           | If creators do "muted hover preview" only |
+| 0.20 × 0.50 = 10%      | 3 000               | $3.00    | 74%           | Borderline                        |
+| 0.40 × 0.65 = 26%      | 7 800               | $7.80    | 33%           | Our baseline assumption           |
+| 0.60 × 0.80 = 48%      | 14 400              | $14.40   | NEGATIVE      | High-engagement creator (e.g. fitness coach with deeply invested audience) |
+| 0.80 × 0.90 = 72%      | 21 600              | $21.60   | catastrophic  | Worst case (auto-play unmuted)    |
+
+**Reading:** if our engagement assumption (26%) is off by +50% (to ~40%), Pro is unprofitable at the average creator, not just the long tail. **Conservative implementation move:** ship with the soft-cap at 5 000 delivered min (DEC-VIDEO-02 Option 1) regardless of which engagement number turns out true; the cap protects us if engagement is higher than modelled.
+
+### 14.3 Business tier — sensitivity to creator size
+
+DEC-VIDEO-04 Option 3 (add-on SKU) assumes 30% of Business creators take the add-on. Sweep that assumption.
+
+| % of Business creators on add-on | Add-on revenue (1 000 Bus, 100k DAU)   | Add-on cost (avg)      | Net add-on segment    |
+|----------------------------------|-----------------------------------------|------------------------|-----------------------|
+| 10%                              | 100 × $50 × 0.97 = $4 850              | 100 × $50.06 = $5 006  | **−$156 / mo**        |
+| 30%                              | 300 × $50 × 0.97 = $14 550             | 300 × $50.06 = $15 018 | **−$468 / mo**        |
+| 50%                              | 500 × $50 × 0.97 = $24 250             | 500 × $50.06 = $25 030 | **−$780 / mo**        |
+| 100% (impossible)                | 1 000 × $50 × 0.97 = $48 500           | 1 000 × $50.06 = $50 060 | **−$1 560 / mo**     |
+
+**Reading:** Even Option 3 (the recommended add-on SKU at $50 average) loses money proportionally to take rate, because the add-on price ($50) is too close to the actual cost ($50.06). The add-on must be priced as **Video Starter $19 (covers 25k = $25, loss-leader entry) AND Video Plus $79 (covers 50k = $50, healthy margin)**. Mixed take-rate (~70% on Starter, 30% on Plus) gives blended cost $30, blended price $37, blended margin 22% — still below floor but the only path that lets us advertise "native video on Business" without being insane.
+
+**Better solution for the add-on:** drop the included delivery to 10k minutes on Video Starter ($19), giving:
+
+- Cost: 10 000 × $0.001 = $10
+- Margin per add-on subscriber: ($19 × 0.97 − $10) / ($19 × 0.97) = 46%
+
+Still below floor but acceptable as a "loss-leader funnel onto Video Plus." Push Video Plus at $79 with 50 000 included = $50 cost, ($79 × 0.97 − $50) / ($79 × 0.97) = 35%. **This is the best we can do.** The brutal truth: video-as-a-feature in a $24/mo creator-page SaaS is fundamentally margin-thin. Either we change pricing strategy (much higher tiers for video) or we accept video is a **retention** feature, not a margin feature.
+
+### 14.4 Worst-case single creator scenario
+
+A Business creator with native upload goes mega-viral — 1M pageviews in a week (unusual but real for a TikToker who pivots their bio to tadaify).
+
+- 1 000 000 pageviews × 8 videos × 1.5 min × 0.40 × 0.65 = **3 120 000 delivered min**
+- Cost: $3 120 in **one week**
+- Revenue from one Business creator: $24/week pro-rated = $5.50
+
+**Loss in one week from one creator: $3 114.**
+
+This justifies the Cloudflare account-level "auto-pause delivery at $X per day" failsafe (called out in §11). Without that failsafe, a single TikToker can financially destroy our month.
+
+---
+
+## 15. Appendix B — Comparison to YouTube hosting (status quo)
+
+YouTube costs us $0 — Google pays storage, encoding, delivery, the player, the captions, the analytics, the watermark removal (paid YouTube Premium for the viewer), everything. The only "cost" is loss of brand control: viewer sees YouTube logo, related-video carousel at the end, "subscribe to YouTube channel" overlay, mid-roll ads on long videos.
+
+Question worth asking the user explicitly (DEC-VIDEO-06 candidate, not formally added because it's strategic rather than implementation):
+
+> Why are we considering hosting video at all, given that YouTube does it for free? What's the user research that says creators want native upload?
+
+Plausible answers:
+- **Brand control:** creators want their bio/trailer to feel native, not "go to YouTube."
+- **Auto-play muted:** YouTube embeds don't reliably auto-play muted on mobile; native HLS does.
+- **No "subscribe to YouTube" prompt:** for creators whose primary platform is *not* YouTube, the subscribe prompt actively pulls viewers off the page.
+- **Trailer for paid product:** creators selling a digital product want a 30-second hook directly above the buy button. YouTube embeds break the visual flow ("watch on YouTube" link).
+
+If the answer is **only** "brand control / no YouTube logo," there's a cheaper path: **embed YouTube but use the IFrame API to hide controls, customise theme, and disable related videos** (the `youtube-nocookie.com` + `&rel=0&modestbranding=1` combo). Cost: $0. Effort: 1 day.
+
+If the answer is **trailer-for-paid-product**, native upload is the right call — viewer engagement on the buy flow matters more than the marginal cost.
+
+**Recommendation:** before locking DEC-VIDEO-01..05, run a 5-creator user-test asking "would you prefer hosted upload at $4 extra/mo or a refined YouTube embed?" If 4/5 say YouTube-with-polish is fine, kill this whole feature and ship YouTube polish for $0. If they actively want native, proceed.
+
+---
+
+## 16. Appendix C — Cloudflare Stream API integration sketch
+
+For the implementer agent later. Skip on first read.
+
+### 16.1 Direct Creator Upload (recommended ingest path)
+
+```ts
+// Edge Function: cf-stream-create-direct-upload
+import { tierFor } from "../lib/subscription.ts";
+import { quotaFor } from "../lib/video-quota.ts";
+
+Deno.serve(async (req) => {
+  const { creator_id, duration_s, file_size } = await req.json();
+  const tier = await tierFor(creator_id);
+  const quota = await quotaFor(creator_id);
+
+  if (tier === "free") return new Response("Native upload requires Creator+", { status: 403 });
+  if (duration_s > tier.max_video_duration_s) return new Response("Video too long", { status: 413 });
+  if (quota.stored_min_used + duration_s/60 > tier.storage_cap_min) return new Response("Storage full", { status: 413 });
+
+  const cf = await fetch(`https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/stream/direct_upload`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${CF_TOKEN}`, "Content-Type": "application/json" },
+    body: JSON.stringify({
+      maxDurationSeconds: tier.max_video_duration_s,
+      requireSignedURLs: true,
+      allowedOrigins: ["tadaify.com", "*.tadaify.com", ...creatorCustomDomains(creator_id)],
+      meta: { creator_id, tadaify_video_id: crypto.randomUUID() },
+    }),
+  });
+
+  const { result } = await cf.json();
+  await supabase.from("videos").insert({
+    id: result.uid,
+    creator_id,
+    source: "cloudflare-stream",
+    cloudflare_uid: result.uid,
+    duration_s,
+    status: "uploading",
+  });
+
+  return Response.json({ uploadURL: result.uploadURL, video_id: result.uid });
+});
+```
+
+### 16.2 Webhook handler (Cloudflare → us when encoding finishes)
+
+```ts
+Deno.serve(async (req) => {
+  const sig = req.headers.get("Webhook-Signature");
+  if (!verifyHmac(sig, await req.text(), CF_WEBHOOK_SECRET)) {
+    return new Response("Bad sig", { status: 401 });
+  }
+
+  const event = await req.json();
+  // event.uid, event.status (e.g. "ready", "error"), event.duration
+
+  await supabase
+    .from("videos")
+    .update({
+      status: event.status === "ready" ? "ready" : "errored",
+      ready_at: event.status === "ready" ? new Date().toISOString() : null,
+      duration_s: event.duration,
+    })
+    .eq("cloudflare_uid", event.uid);
+
+  return new Response("ok");
+});
+```
+
+### 16.3 Delivered-minutes reconcile cron (every 15 min)
+
+```ts
+// Edge Function: cf-stream-reconcile-delivered
+const cf = await fetch(
+  `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/stream/analytics/views?since=${last_run_iso}&until=now`,
+  { headers: { Authorization: `Bearer ${CF_TOKEN}` } }
+);
+const { result } = await cf.json();
+
+for (const row of result.byVideo) {
+  const { creator_id } = await supabase.from("videos").select("creator_id").eq("cloudflare_uid", row.uid).single();
+  await supabase.rpc("inc_delivered_min", { p_creator_id: creator_id, p_minutes: row.minutesViewed });
+}
+```
+
+The `inc_delivered_min` RPC handles month-rollover, soft-cap notifications (insert into `notifications` when crossing 80%/100% thresholds), and Stripe metered usage push.
+
+### 16.4 Signed-URL playback
+
+```ts
+// On viewer-side block render
+const sig = await fetch("/api/video-signed-url", {
+  method: "POST",
+  body: JSON.stringify({ video_id }),
+}).then(r => r.json());
+
+// In template:
+<video src={`https://customer-${ACCOUNT_HASH}.cloudflarestream.com/${sig.token}/manifest/video.m3u8`} controls />
+```
+
+Edge Function `/api/video-signed-url`:
+
+```ts
+// 24h TTL on the JWT
+const token = await jwtSign(
+  { sub: video_uid, exp: Math.floor(Date.now()/1000) + 86400 },
+  CF_STREAM_SIGNING_KEY,
+);
+return Response.json({ token });
+```
+
+This pattern keeps the .m3u8 URL un-shareable beyond 24h. Combined with `allowedOrigins` from §16.1, a leaked token is useful for at most 24h on at most our domains.
+
+---
+
+## 17. Appendix D — Decision log integration
+
+Per orchestrator CLAUDE.md, every blocking question to the user MUST be in `/tmp/claude-decisions/decisions.json` BEFORE being asked. When this SPIKE is presented to the user, the agent presenting it appends:
+
+```json
+{
+  "id": "DEC-VIDEO-01",
+  "agent_id": "orchestrator",
+  "repo": "tadaify-app",
+  "question": "Free tier native video upload Y/N — see SPIKE §9 DEC-VIDEO-01",
+  "options": ["1: YouTube only (rec)", "2: 1 video 15s 250min cap", "3: 7-day trial then disable"],
+  "created_at": "2026-04-26T<timestamp>Z",
+  "status": "pending",
+  "answer": null
+}
+```
+
+…and analogously for DEC-VIDEO-02..05. The dashboard surfaces them; the user answers in chat with `DEC-VIDEO-01: 1`. Do **not** open the implementation issues until all five are answered — the issues' acceptance criteria depend on the resolutions.
+
+---
+
+*End of SPIKE. Awaiting DEC-VIDEO-01..05 resolution before any implementation issue is opened.*


### PR DESCRIPTION
## Summary

- Migrates 6 tadaify research files from \`graspsoftwarepw/claude-reports/research/tadaify/\` into this product repo's \`docs/research/\` per the new product-vs-platform split rule (orchestrator CLAUDE.md, 2026-04-28).
- The \`tadaify-\` prefix is dropped from each filename since the files now live inside the tadaify repo.
- File content preserved exactly as-is (no edits, no \`updated_at\` added).
- **Companion delete-side PR:** graspsoftwarepw/claude-reports#39 — merge this PR FIRST so files exist in the product repo before the delete lands.

## Business requirements implemented

N/A — documentation-only change, no business logic.

## Technical requirements introduced or relied on

N/A — no new technical conventions introduced.

## Acceptance criteria from issue

- All 6 files land in \`docs/research/\` with correct names (prefix stripped).
- Content of each file is byte-for-byte identical to the source in claude-reports.
- No other files in the repo are touched.
- Companion delete-side PR: graspsoftwarepw/claude-reports#39.

## Test plan

- Manual: \`ls docs/research/\` confirms 6 new files present alongside existing \`affiliate-program.md\`.
- Manual: spot-check frontmatter (\`type\`, \`project\`, \`title\`, \`created_at\`) is valid in each file.
- No unit tests required — docs-only change.
- No Playwright tests required — no UI change.

## Mockup

No UI change — mockup not required.

## Rollback

\`git revert <merge-sha>\` on tadaify-app removes the 6 files. If the claude-reports delete-side PR has already merged, reopen/cherry-pick the originals back into claude-reports from this PR's commit tree.