### PR TITLE
chore(tooling): install Supabase MCP + seed-validator guard hooks

### DIFF
--- a/.claude/hooks/block-supabase-writes.py
+++ b/.claude/hooks/block-supabase-writes.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""
+PreToolUse guard: block ALL write operations against Supabase MCP servers.
+
+Why this exists:
+  * The OAuth Supabase connector on claude.ai exposes write tools without
+    any --read-only flag — it is server-side full-access.
+  * The PAT-based MCP server in .mcp.json could theoretically be rewritten
+    by Claude (drop the --read-only flag) before the user notices.
+  * This hook is the only enforcement layer that survives Claude touching
+    config files. It runs INSIDE the Claude Code harness on every tool
+    call, before the tool executes.
+
+Behavior:
+  * For tools matching `mcp__supabase__*` or
+    `mcp__1ddc824f-49c7-4807-9390-f3af643bae04__*` (the OAuth connector's
+    UUID prefix):
+      - Hard-block any tool in WRITE_TOOLS.
+      - For execute_sql: allow only read-only verbs (SELECT/EXPLAIN/SHOW/
+        WITH/TABLE/VALUES) at the start of the query, OR queries that
+        wrap the work in BEGIN ... ROLLBACK (sandboxed test pattern).
+  * Anything else: pass through (exit 0, no decision).
+
+To override the hook in a real emergency, the user can disable it via
+the /hooks UI or by editing .claude/settings.json. Both leave a paper
+trail.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+WRITE_TOOLS = {
+    "apply_migration",
+    "deploy_edge_function",
+    "create_branch",
+    "delete_branch",
+    "merge_branch",
+    "rebase_branch",
+    "reset_branch",
+    "create_project",
+    "pause_project",
+    "restore_project",
+    "confirm_cost",
+}
+
+SUPABASE_PREFIXES = (
+    "mcp__supabase__",
+    "mcp__1ddc824f-49c7-4807-9390-f3af643bae04__",
+)
+
+READ_ONLY_VERBS = ("SELECT", "EXPLAIN", "SHOW", "WITH", "TABLE", "VALUES")
+
+
+def is_supabase_tool(name: str) -> bool:
+    return any(name.startswith(p) for p in SUPABASE_PREFIXES)
+
+
+def short_name(name: str) -> str:
+    for p in SUPABASE_PREFIXES:
+        if name.startswith(p):
+            return name[len(p):]
+    return name
+
+
+def strip_sql_preamble(query: str) -> str:
+    """Remove leading whitespace, BOM, line comments, block comments."""
+    q = query.lstrip("\ufeff").lstrip()
+    while True:
+        if q.startswith("--"):
+            nl = q.find("\n")
+            q = q[nl + 1:].lstrip() if nl != -1 else ""
+        elif q.startswith("/*"):
+            end = q.find("*/")
+            q = q[end + 2:].lstrip() if end != -1 else ""
+        else:
+            break
+    return q
+
+
+def is_read_only_sql(query: str) -> bool:
+    q = strip_sql_preamble(query)
+    if not q:
+        return False
+    head = q[:20].upper()
+    return any(re.match(rf"\b{verb}\b", head) for verb in READ_ONLY_VERBS)
+
+
+def is_sandboxed_test(query: str) -> bool:
+    """Allow a query that explicitly wraps everything in BEGIN..ROLLBACK."""
+    upper = query.upper()
+    return "BEGIN" in upper and "ROLLBACK" in upper and "COMMIT" not in upper
+
+
+def block(reason: str) -> None:
+    """Emit PreToolUse block decision and exit."""
+    payload = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }
+    print(json.dumps(payload))
+    sys.exit(0)
+
+
+def main() -> None:
+    try:
+        data = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        # Don't break on malformed input — let the harness handle it
+        sys.exit(0)
+
+    tool_name = data.get("tool_name", "")
+    if not is_supabase_tool(tool_name):
+        sys.exit(0)
+
+    short = short_name(tool_name)
+
+    if short in WRITE_TOOLS:
+        block(
+            f"BLOCKED by .claude/hooks/block-supabase-writes.py: "
+            f"Supabase MCP write tool '{short}' is forbidden. All schema "
+            f"and data changes must go through supabase/migrations/ and "
+            f"the deploy-prod GitHub Actions workflow. To override in a "
+            f"real emergency, disable this hook in .claude/settings.json "
+            f"and document why in the next commit."
+        )
+
+    if short == "execute_sql":
+        query = data.get("tool_input", {}).get("query", "") or ""
+        if is_read_only_sql(query):
+            sys.exit(0)
+        if is_sandboxed_test(query):
+            sys.exit(0)
+        block(
+            "BLOCKED by .claude/hooks/block-supabase-writes.py: "
+            "Supabase execute_sql appears to be a write query. "
+            "Allowed verbs (after stripping comments/whitespace): "
+            f"{', '.join(READ_ONLY_VERBS)}. To verify a write statement's "
+            "syntax against a live database, wrap it in BEGIN ... ROLLBACK. "
+            "For real changes, write a migration in supabase/migrations/."
+        )
+
+    # Other supabase read tools (list_tables, get_advisors, etc.) — pass through
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/seed-validator-pretool.py
+++ b/.claude/hooks/seed-validator-pretool.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""
+PreToolUse guard: validate that `supabase/seed.sql` still applies after any
+Write or Edit to a file under `supabase/migrations/**`.
+
+Why this exists:
+  * Schema changes that drop a column or rename a table silently break
+    `supabase/seed.sql` — every subsequent `supabase db reset` ends with
+    an empty DB, zero test users, and a flurry of confused "nothing works"
+    Slack messages.
+  * Pre-PR gates already catch this, but by then the author has written
+    the migration, committed, and often moved on. This hook catches the
+    drift at the exact keystroke that introduced it.
+
+Behavior:
+  * Fires only for Write / Edit tool calls (matcher narrows to Write|Edit
+    at the settings.json layer, this script does path filtering).
+  * Path filter: tool_input.file_path must match `supabase/migrations/.*\\.sql$`.
+  * Opt-out: if the post-write file content's first non-whitespace line is
+    `-- seed-validator: skip`, the hook allows the write without running
+    the seed check.
+  * If Supabase / Docker is not available locally, the hook warns but
+    allows (pre-PR gate will catch it proper).
+  * Runs `supabase db reset --no-seed` + `psql -f supabase/seed.sql`.
+    Timeout 60s total. On pass → exit 0. On fail → permissionDecision
+    = "deny" with a human-readable reason.
+
+To override the hook in a real emergency, edit `.claude/settings.json`
+in the target repo and remove the PreToolUse entry whose command is
+`.claude/hooks/seed-validator-pretool.py`. Document why in the next commit.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+MIGRATION_PATH_RE = re.compile(r"supabase/migrations/[^/]+\.sql$")
+SKIP_MARKER = "-- seed-validator: skip"
+TIMEOUT_SECONDS = 60
+
+
+def emit_decision(decision: str, reason: str) -> None:
+    """Emit PreToolUse decision JSON on stdout and exit 0."""
+    payload = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": decision,
+            "permissionDecisionReason": reason,
+        }
+    }
+    print(json.dumps(payload))
+    sys.exit(0)
+
+
+def allow() -> None:
+    """Pass through silently."""
+    sys.exit(0)
+
+
+def warn(msg: str) -> None:
+    """Print warning to stderr but allow the tool call."""
+    print(f"[seed-validator] WARN: {msg}", file=sys.stderr)
+    sys.exit(0)
+
+
+def first_nonblank_line(text: str) -> str:
+    for line in text.splitlines():
+        s = line.strip()
+        if s:
+            return s
+    return ""
+
+
+def extract_pending_content(tool_name: str, tool_input: dict) -> str | None:
+    """
+    Return the post-edit content of the migration file, or None if we can't
+    determine it (in which case we conservatively run the check).
+    """
+    if tool_name == "Write":
+        return tool_input.get("content", "")
+    if tool_name == "Edit":
+        # For Edit we can't cheaply reconstruct the full post-edit file, but
+        # we can peek at the new_string for a skip marker. If it's present,
+        # honour it; otherwise fall through and run the check.
+        new = tool_input.get("new_string", "") or ""
+        old = tool_input.get("old_string", "") or ""
+        # Only short-circuit on a positive skip marker; never short-circuit
+        # when we genuinely don't know what the final file looks like.
+        if SKIP_MARKER in new or SKIP_MARKER in old:
+            return new  # probably contains the marker; caller will re-check
+        return None
+    return None
+
+
+def has_skip_marker(file_path: Path, pending_content: str | None) -> bool:
+    """
+    Check whether the opt-out marker is present, either in the pending
+    content (Write) or in the file on disk (Edit fallback / best-effort).
+    """
+    if pending_content is not None and SKIP_MARKER in pending_content:
+        # Honour it only if it's on the first non-blank line of the pending content.
+        first = first_nonblank_line(pending_content)
+        if first == SKIP_MARKER:
+            return True
+    # Fall back to on-disk content — catches the Edit case where the marker
+    # was already in the file.
+    try:
+        text = file_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return False
+    return first_nonblank_line(text) == SKIP_MARKER
+
+
+def supabase_available(cwd: Path) -> tuple[bool, str]:
+    """Return (ok, reason). ok=False means we should warn + allow."""
+    if shutil.which("supabase") is None:
+        return False, "supabase CLI not on PATH"
+    if shutil.which("docker") is None:
+        return False, "docker CLI not on PATH"
+    # Quick docker-daemon check — cheap.
+    try:
+        r = subprocess.run(
+            ["docker", "info"],
+            cwd=cwd,
+            capture_output=True,
+            timeout=5,
+        )
+        if r.returncode != 0:
+            return False, "docker daemon unreachable"
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        return False, f"docker info failed: {exc}"
+    return True, ""
+
+
+def resolve_db_port(cwd: Path) -> str | None:
+    try:
+        r = subprocess.run(
+            ["supabase", "status", "--output", "json"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if r.returncode != 0:
+        return None
+    try:
+        data = json.loads(r.stdout)
+    except json.JSONDecodeError:
+        return None
+    db_url = data.get("DB_URL", "") or ""
+    m = re.search(r":(\d+)/", db_url)
+    return m.group(1) if m else None
+
+
+def tail(text: str, lines: int = 50) -> str:
+    return "\n".join(text.splitlines()[-lines:])
+
+
+def run_check(cwd: Path, migration_rel: str) -> None:
+    """Run db reset + seed. Emit deny on failure, exit 0 on pass."""
+    ok, reason = supabase_available(cwd)
+    if not ok:
+        warn(
+            f"skipping seed check ({reason}); pre-PR gate will catch drift. "
+            f"Allowing Write/Edit on {migration_rel}."
+        )
+
+    db_port = resolve_db_port(cwd)
+    if db_port is None:
+        warn(
+            "could not resolve local Supabase DB port (is it started?); "
+            f"skipping seed check for {migration_rel}. Pre-PR gate will catch drift."
+        )
+
+    # 1. supabase db reset --no-seed
+    try:
+        r = subprocess.run(
+            ["supabase", "db", "reset", "--no-seed"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        emit_decision(
+            "deny",
+            f"SEED-VALIDATOR BLOCK\n"
+            f"  migration: {migration_rel}\n"
+            f"  stage:     db-reset\n"
+            f"  exit_code: timeout ({TIMEOUT_SECONDS}s)\n"
+            f"  hint: `supabase db reset --no-seed` did not complete in time. "
+            f"Investigate migrations for infinite loops or unresponsive Docker.",
+        )
+    if r.returncode != 0:
+        emit_decision(
+            "deny",
+            f"SEED-VALIDATOR BLOCK\n"
+            f"  migration: {migration_rel}\n"
+            f"  stage:     db-reset\n"
+            f"  exit_code: {r.returncode}\n"
+            f"  stderr (last 50 lines):\n{tail(r.stderr)}\n"
+            f"  hint: migration itself is broken — check ordering, FK refs, column types.",
+        )
+
+    # 2. psql -f supabase/seed.sql
+    seed_path = cwd / "supabase" / "seed.sql"
+    if not seed_path.is_file():
+        # No seed to validate — nothing to block on.
+        sys.exit(0)
+
+    db_url = f"postgresql://postgres:postgres@127.0.0.1:{db_port}/postgres"
+    try:
+        r = subprocess.run(
+            ["psql", db_url, "-v", "ON_ERROR_STOP=1", "-f", str(seed_path)],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        emit_decision(
+            "deny",
+            f"SEED-VALIDATOR BLOCK\n"
+            f"  migration: {migration_rel}\n"
+            f"  stage:     seed\n"
+            f"  exit_code: timeout ({TIMEOUT_SECONDS}s)\n"
+            f"  hint: seed.sql did not complete — check for missing PG extensions.",
+        )
+    except FileNotFoundError:
+        warn("psql not on PATH; cannot validate seed. Pre-PR gate will catch drift.")
+    if r.returncode != 0:
+        emit_decision(
+            "deny",
+            f"SEED-VALIDATOR BLOCK\n"
+            f"  migration: {migration_rel}\n"
+            f"  stage:     seed\n"
+            f"  exit_code: {r.returncode}\n"
+            f"  stderr (last 50 lines):\n{tail(r.stderr)}\n"
+            f"  hint: seed.sql references a column/table/constraint that this migration "
+            f"changed. Either update seed.sql to match, or add `{SKIP_MARKER}` as the "
+            f"first line of the migration if this PR will also rewrite seed.sql.",
+        )
+
+    sys.exit(0)
+
+
+def main() -> None:
+    try:
+        data = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        sys.exit(0)
+
+    tool_name = data.get("tool_name", "")
+    if tool_name not in ("Write", "Edit"):
+        sys.exit(0)
+
+    tool_input = data.get("tool_input", {}) or {}
+    file_path_str = tool_input.get("file_path", "") or ""
+    if not file_path_str:
+        sys.exit(0)
+
+    # Normalise path-separator to forward-slash for regex match.
+    norm = file_path_str.replace(os.sep, "/")
+    if not MIGRATION_PATH_RE.search(norm):
+        sys.exit(0)
+
+    file_path = Path(file_path_str)
+    cwd = Path.cwd()
+
+    pending = extract_pending_content(tool_name, tool_input)
+    if has_skip_marker(file_path, pending):
+        # Opt-out honoured — allow the write silently.
+        sys.exit(0)
+
+    # Use the migration's path relative to cwd for the error message.
+    try:
+        migration_rel = str(file_path.resolve().relative_to(cwd.resolve()))
+    except ValueError:
+        migration_rel = file_path_str
+
+    run_check(cwd, migration_rel)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/feature-checklist.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "mcp__supabase__|mcp__1ddc824f-49c7-4807-9390-f3af643bae04__",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/block-supabase-writes.py",
+            "timeout": 10,
+            "statusMessage": "Verifying Supabase tool is read-only..."
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/seed-validator-pretool.py",
+            "timeout": 60,
+            "statusMessage": "Validating seed.sql still applies..."
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## What
Installs two project-level `PreToolUse` guard hooks:
1. Supabase MCP write guard — blocks `apply_migration`, `deploy_edge_function`, branch/project lifecycle, and write SQL via `execute_sql`.
2. Seed-validator — after any Write/Edit under `supabase/migrations/*.sql`, runs `supabase db reset --no-seed` + `psql -f supabase/seed.sql` and blocks if the seed no longer applies.

Propagated from `claude-project-orchestrator/templates/app-hooks/`.

## Files
- `.claude/hooks/block-supabase-writes.py` — Supabase MCP guard
- `.claude/hooks/seed-validator-pretool.py` — seed-drift guard
- `.claude/settings.json` — two new `PreToolUse` matchers; existing entries preserved

## Behavior — Supabase MCP guard
- Blocks: `apply_migration`, `deploy_edge_function`, `create_branch`, `delete_branch`, `merge_branch`, `rebase_branch`, `reset_branch`, `create_project`, `pause_project`, `restore_project`, `confirm_cost`
- `execute_sql` allowed only for `SELECT` / `EXPLAIN` / `SHOW` / `WITH` / `TABLE` / `VALUES` (after stripping leading whitespace and `--` / `/* */` comments), or queries wrapped in `BEGIN ... ROLLBACK`
- Read-only Supabase tools pass through

## Behavior — seed-validator
- Fires on `Write` / `Edit` targeting `supabase/migrations/*.sql`
- Runs `supabase db reset --no-seed` (must exit 0) then `psql -v ON_ERROR_STOP=1 -f supabase/seed.sql` (must exit 0)
- On failure: emits `permissionDecision: deny` with stage, exit code, last ~50 lines of stderr, and a human-readable hint
- Per-migration opt-out: first non-blank line of the migration is `-- seed-validator: skip`
- Graceful degradation: Docker/Supabase unavailable → warn and allow (pre-PR gate still catches drift)

## Hot-reload caveat (one-time post-merge action)
After this PR merges, any open Claude Code session in this repo needs to either:
- Run `/hooks` once (re-reads settings), or
- Restart the Claude Code process

New sessions started after the merge pick the hook up automatically.

## Test plan
- [ ] Pipe-test MCP guard: `echo '{"tool_name":"mcp__supabase__apply_migration"}' | python3 .claude/hooks/block-supabase-writes.py` → `permissionDecision: deny`
- [ ] Pipe-test seed guard (no migration path): `echo '{"tool_name":"Write","tool_input":{"file_path":"src/foo.ts","content":""}}' | python3 .claude/hooks/seed-validator-pretool.py` → exit 0, no output
- [ ] Pipe-test seed guard opt-out: `echo '{"tool_name":"Write","tool_input":{"file_path":"supabase/migrations/99_x.sql","content":"-- seed-validator: skip\nSELECT 1;"}}' | python3 .claude/hooks/seed-validator-pretool.py` → exit 0
- [ ] In a fresh Claude Code session, attempt a Supabase MCP write → expect deny

🤖 Generated with [Claude Code](https://claude.com/claude-code)