### PR TITLE
chore: AGENTS.md → CLAUDE.md symlink for cross-tool readability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md


### PR DESCRIPTION
## Summary

Adds `AGENTS.md` as a symlink pointing to `CLAUDE.md`. No content changed — the symlink gives every AI coding tool (Codex, Cursor, Copilot, Sourcegraph) the same canonical per-repo instructions that Claude Code already reads via `CLAUDE.md`.

## Business requirements implemented

No BR change — infrastructure/tooling chore.

## Technical requirements introduced or relied on

No new TR introduced. Convention established: `AGENTS.md` → `CLAUDE.md` symlink at repo root for cross-tool readability.

## Acceptance criteria from issue

- ✅ `AGENTS.md` exists at repo root as a symlink to `CLAUDE.md`
- ✅ Reading `AGENTS.md` yields identical content to `CLAUDE.md`
- ✅ No content duplication; single source of truth is `CLAUDE.md`

## Test plan

**Verification (manual):**
```
$ ls -la AGENTS.md
lrwxr-xr-x  AGENTS.md -> CLAUDE.md

$ head -5 AGENTS.md
# Tadaify App — Claude instructions

Project-level guidance for any Claude agent working on `graspsoftwarepw/tadaify-app`.

Applies to every session, every branch, every story. Extends the global `~/.claude/CLAUDE.md`.
```

No unit tests or Playwright tests required — symlink is a one-liner filesystem artefact.

## Mockup

No UI change — mockup not required.

## Rollback

`git revert <merge-sha>` removes the symlink. `CLAUDE.md` is unaffected.

---

**Context:** claude-reports#40 (research dossier, merged) Recommendation #5 — "AGENTS.md symlink: 5-minute lift for cross-tool readability". This is one of 7 parallel PRs propagating the same convention across all active product repos.

**Codex-pairing notes:**
- Why symlink not copy? Symlink avoids drift — one edit to `CLAUDE.md` is immediately visible to all tools. A copy would silently diverge.
- Why not keep separate files? The content would be identical. Separate files = maintenance burden for zero gain.
- Portability across non-Unix? Git stores symlinks as mode `120000` blobs — Windows Git clients handle this correctly since Git 2.26+ with `core.symlinks=true` (default on modern Windows). The risk is low for a dev-instructions file.
