### PR TITLE
chore(requirements): migrate tadaify TRs to per-file MADR records (DEC-DOC-14)

### DIFF
--- a/docs/TECHNICAL_REQUIREMENTS.md
+++ b/docs/TECHNICAL_REQUIREMENTS.md
@@ -1,33 +1,27 @@
-# Technical Requirements — tadaify
+# Technical Requirements — INDEX
 
-This file documents technical conventions, patterns, and architectural decisions that govern implementation. Every new convention introduced by a PR must be added here (enforced by `feature-checklist §1b`).
+> **Auto-generated** on 2026-04-29 by `bin/migrate-records.mjs --kind=tr`.
+> Do NOT hand-edit this file. Edit the individual TR records in `docs/requirements/technical/`.
+> To add a new TR: create `docs/requirements/technical/NNNN-<slug>.md` with MADR frontmatter.
 
-## TR Index
+## All Technical Requirements
 
-### MUST (non-negotiable)
+| ID | Level | Title |
+|----|-------|-------|
+| [TR-001](requirements/technical/0001-tr-001-framework-react-router-7-remix-merged-in-framework-mo.md) | MUST | Framework: React Router 7 (Remix-merged) in framework mode (`ssr: true`), adapter `@react-router/cloudflare` |
+| [TR-002](requirements/technical/0002-tr-002-runtime-cloudflare-workers-not-pages.md) | MUST | Runtime: Cloudflare Workers (NOT Pages). |
+| [TR-003](requirements/technical/0003-tr-003-styling-tailwind-css-v4-via-tailwindcss-vite.md) | MUST | Styling: Tailwind CSS v4 via `@tailwindcss/vite`. |
+| [TR-004](requirements/technical/0004-tr-004-database-supabase-local-docker-on-port-band-5435x-dev.md) | MUST | Database: Supabase (local Docker on port-band 5435X; DEV/PROD via Supabase hosted). |
+| [TR-005](requirements/technical/0005-tr-005-email-local-dev-supabase-inbucket-on-port-54354.md) | MUST | Email (local dev): Supabase Inbucket on port 54354. |
+| [TR-006](requirements/technical/0006-tr-006-guard-hooks-block-supabase-writes-py-blocks-all-supab.md) | MUST | Guard hooks: `block-supabase-writes.py` blocks all Supabase MCP write tools. |
+| [TR-007](requirements/technical/0007-tr-007-supabase-mcp-read-only-in-all-sessions.md) | MUST | Supabase MCP: read-only in all sessions. |
+| [TR-008](requirements/technical/0008-tr-008-language-typescript-everywhere.md) | MUST | Language: TypeScript everywhere. |
+| [TR-009](requirements/technical/0009-tr-009-no-github-workflows-in-this-repo-yet-local-only-phase.md) | MUST | No `.github/workflows/` in this repo yet — local-only phase. |
+| [TR-010](requirements/technical/0010-tr-010-every-commit-body-starts-with-claude-commit-line-huma.md) | MUST | Every commit body starts with `Claude commit:` line (human-scannable attribution). |
+| [TR-011](requirements/technical/0011-tr-011-google-fonts-loaded-via-links-export-in-app-root-tsx-.md) | SHOULD | Google Fonts loaded via `links` export in `app/root.tsx` (no `@import url()` in CSS — avoids render-blocking in Workers SSR) |
+| [TR-012](requirements/technical/0012-tr-012-cloudflare-workers-ai-binding-ai-configured-in-wrangl.md) | SHOULD | Cloudflare Workers AI binding (`AI`) configured in `wrangler.jsonc` [ai] block |
+| [TR-013](requirements/technical/0013-tr-013-supabase-edge-functions-for-server-side-operations-th.md) | MAY | Supabase Edge Functions for server-side operations that need the service role key (GDPR export, account deletion) |
 
-| ID | Requirement |
-|---|---|
-| TR-001 | Framework: React Router 7 (Remix-merged) in framework mode (`ssr: true`), adapter `@react-router/cloudflare`. |
-| TR-002 | Runtime: Cloudflare Workers (NOT Pages). SSR for public creator pages; CSR for authenticated dashboard after hydration. |
-| TR-003 | Styling: Tailwind CSS v4 via `@tailwindcss/vite`. Brand tokens imported from `mockups/tadaify-mvp/shared/tokens.css`. |
-| TR-004 | Database: Supabase (local Docker on port-band 5435X; DEV/PROD via Supabase hosted). All schema changes via `supabase/migrations/`. |
-| TR-005 | Email (local dev): Supabase Inbucket on port 54354. Every auth flow tested e2e through Inbucket — never seeded pre-confirmed users. |
-| TR-006 | Guard hooks: `block-supabase-writes.py` blocks all Supabase MCP write tools. `seed-validator-pretool.py` blocks migration writes that drift from `seed.sql`. |
-| TR-007 | Supabase MCP: read-only in all sessions. All writes via migrations + CI. |
-| TR-008 | Language: TypeScript everywhere. No `any` in new code — use `unknown` + type-guards. |
-| TR-009 | No `.github/workflows/` in this repo yet — local-only phase. CI added in a separate story. |
-| TR-010 | Every commit body starts with `Claude commit:` line (human-scannable attribution). Every PR comment starts with `Claude comment:`. |
+---
 
-### SHOULD
-
-| ID | Requirement |
-|---|---|
-| TR-011 | Google Fonts loaded via `links` export in `app/root.tsx` (no `@import url()` in CSS — avoids render-blocking in Workers SSR). |
-| TR-012 | Cloudflare Workers AI binding (`AI`) configured in `wrangler.jsonc` [ai] block — uncomment when implementing F-AI-SUGGEST. |
-
-### MAY
-
-| ID | Requirement |
-|---|---|
-| TR-013 | Supabase Edge Functions for server-side operations that need the service role key (GDPR export, account deletion). |
+*Generated from 13 MADR records in `docs/requirements/technical/`.*

--- a/docs/requirements/technical/0001-tr-001-framework-react-router-7-remix-merged-in-framework-mo.md
+++ b/docs/requirements/technical/0001-tr-001-framework-react-router-7-remix-merged-in-framework-mo.md
@@ -1,0 +1,20 @@
+---
+id: TR-001
+type: tr
+status: accepted
+date: 2026-04-28
+level: MUST
+topics: [framework, react, router, remix]
+supersedes: []
+superseded_by: null
+authorized_by: vvaser@gmail.com
+authorized_at: 2026-04-28
+---
+
+# TR-001 — Framework: React Router 7 (Remix-merged) in framework mode (`ssr: true`), adapter `@react-router/cloudflare`
+
+> **Level:** MUST
+
+## Migration note
+
+Migrated from `docs/TECHNICAL_REQUIREMENTS.md` on 2026-04-29; see git history for prior context.

--- a/docs/requirements/technical/0002-tr-002-runtime-cloudflare-workers-not-pages.md
+++ b/docs/requirements/technical/0002-tr-002-runtime-cloudflare-workers-not-pages.md
@@ -1,0 +1,22 @@
+---
+id: TR-002
+type: tr
+status: accepted
+date: 2026-04-28
+level: MUST
+topics: [runtime, cloudflare, workers, pages]
+supersedes: []
+superseded_by: null
+authorized_by: vvaser@gmail.com
+authorized_at: 2026-04-28
+---
+
+# TR-002 — Runtime: Cloudflare Workers (NOT Pages).
+
+> **Level:** MUST
+
+SSR for public creator pages; CSR for authenticated dashboard after hydration.
+
+## Migration note
+
+Migrated from `docs/TECHNICAL_REQUIREMENTS.md` on 2026-04-29; see git history for prior context.

--- a/docs/requirements/technical/0003-tr-003-styling-tailwind-css-v4-via-tailwindcss-vite.md
+++ b/docs/requirements/technical/0003-tr-003-styling-tailwind-css-v4-via-tailwindcss-vite.md
@@ -1,0 +1,22 @@
+---
+id: TR-003
+type: tr
+status: accepted
+date: 2026-04-28
+level: MUST
+topics: [styling, tailwind, tailwindcss, vite]
+supersedes: []
+superseded_by: null
+authorized_by: vvaser@gmail.com
+authorized_at: 2026-04-28
+---
+
+# TR-003 — Styling: Tailwind CSS v4 via `@tailwindcss/vite`.
+
+> **Level:** MUST
+
+Brand tokens imported from `mockups/tadaify-mvp/shared/tokens.css`.
+
+## Migration note
+
+Migrated from `docs/TECHNICAL_REQUIREMENTS.md` on 2026-04-29; see git history for prior context.

--- a/docs/requirements/technical/0004-tr-004-database-supabase-local-docker-on-port-band-5435x-dev.md
+++ b/docs/requirements/technical/0004-tr-004-database-supabase-local-docker-on-port-band-5435x-dev.md
@@ -1,0 +1,22 @@
+---
+id: TR-004
+type: tr
+status: accepted
+date: 2026-04-28
+level: MUST
+topics: [database, supabase, local, docker]
+supersedes: []
+superseded_by: null
+authorized_by: vvaser@gmail.com
+authorized_at: 2026-04-28
+---
+
+# TR-004 — Database: Supabase (local Docker on port-band 5435X; DEV/PROD via Supabase hosted).
+
+> **Level:** MUST
+
+All schema changes via `supabase/migrations/`.
+
+## Migration note
+
+Migrated from `docs/TECHNICAL_REQUIREMENTS.md` on 2026-04-29; see git history for prior context.

--- a/docs/requirements/technical/0005-tr-005-email-local-dev-supabase-inbucket-on-port-54354.md
+++ b/docs/requirements/technical/0005-tr-005-email-local-dev-supabase-inbucket-on-port-54354.md
@@ -1,0 +1,22 @@
+---
+id: TR-005
+type: tr
+status: accepted
+date: 2026-04-28
+level: MUST
+topics: [email, local, supabase, inbucket]
+supersedes: []
+superseded_by: null
+authorized_by: vvaser@gmail.com
+authorized_at: 2026-04-28
+---
+
+# TR-005 — Email (local dev): Supabase Inbucket on port 54354.
+
+> **Level:** MUST
+
+Every auth flow tested e2e through Inbucket — never seeded pre-confirmed users.
+
+## Migration note
+
+Migrated from `docs/TECHNICAL_REQUIREMENTS.md` on 2026-04-29; see git history for prior context.

--- a/docs/requirements/technical/0006-tr-006-guard-hooks-block-supabase-writes-py-blocks-all-supab.md
+++ b/docs/requirements/technical/0006-tr-006-guard-hooks-block-supabase-writes-py-blocks-all-supab.md
@@ -1,0 +1,22 @@
+---
+id: TR-006
+type: tr
+status: accepted
+date: 2026-04-28
+level: MUST
+topics: [guard, hooks, block, supabase]
+supersedes: []
+superseded_by: null
+authorized_by: vvaser@gmail.com
+authorized_at: 2026-04-28
+---
+
+# TR-006 — Guard hooks: `block-supabase-writes.py` blocks all Supabase MCP write tools.
+
+> **Level:** MUST
+
+`seed-validator-pretool.py` blocks migration writes that drift from `seed.sql`.
+
+## Migration note
+
+Migrated from `docs/TECHNICAL_REQUIREMENTS.md` on 2026-04-29; see git history for prior context.

--- a/docs/requirements/technical/0007-tr-007-supabase-mcp-read-only-in-all-sessions.md
+++ b/docs/requirements/technical/0007-tr-007-supabase-mcp-read-only-in-all-sessions.md
@@ -1,0 +1,22 @@
+---
+id: TR-007
+type: tr
+status: accepted
+date: 2026-04-28
+level: MUST
+topics: [supabase, read, only, sessions]
+supersedes: []
+superseded_by: null
+authorized_by: vvaser@gmail.com
+authorized_at: 2026-04-28
+---
+
+# TR-007 — Supabase MCP: read-only in all sessions.
+
+> **Level:** MUST
+
+All writes via migrations + CI.
+
+## Migration note
+
+Migrated from `docs/TECHNICAL_REQUIREMENTS.md` on 2026-04-29; see git history for prior context.

--- a/docs/requirements/technical/0008-tr-008-language-typescript-everywhere.md
+++ b/docs/requirements/technical/0008-tr-008-language-typescript-everywhere.md
@@ -1,0 +1,22 @@
+---
+id: TR-008
+type: tr
+status: accepted
+date: 2026-04-28
+level: MUST
+topics: [language, typescript, everywhere]
+supersedes: []
+superseded_by: null
+authorized_by: vvaser@gmail.com
+authorized_at: 2026-04-28
+---
+
+# TR-008 — Language: TypeScript everywhere.
+
+> **Level:** MUST
+
+No `any` in new code — use `unknown` + type-guards.
+
+## Migration note
+
+Migrated from `docs/TECHNICAL_REQUIREMENTS.md` on 2026-04-29; see git history for prior context.

--- a/docs/requirements/technical/0009-tr-009-no-github-workflows-in-this-repo-yet-local-only-phase.md
+++ b/docs/requirements/technical/0009-tr-009-no-github-workflows-in-this-repo-yet-local-only-phase.md
@@ -1,0 +1,22 @@
+---
+id: TR-009
+type: tr
+status: accepted
+date: 2026-04-28
+level: MUST
+topics: [github, workflows, repo, local]
+supersedes: []
+superseded_by: null
+authorized_by: vvaser@gmail.com
+authorized_at: 2026-04-28
+---
+
+# TR-009 — No `.github/workflows/` in this repo yet — local-only phase.
+
+> **Level:** MUST
+
+CI added in a separate story.
+
+## Migration note
+
+Migrated from `docs/TECHNICAL_REQUIREMENTS.md` on 2026-04-29; see git history for prior context.

--- a/docs/requirements/technical/0010-tr-010-every-commit-body-starts-with-claude-commit-line-huma.md
+++ b/docs/requirements/technical/0010-tr-010-every-commit-body-starts-with-claude-commit-line-huma.md
@@ -1,0 +1,22 @@
+---
+id: TR-010
+type: tr
+status: accepted
+date: 2026-04-28
+level: MUST
+topics: [every, commit, body, starts]
+supersedes: []
+superseded_by: null
+authorized_by: vvaser@gmail.com
+authorized_at: 2026-04-28
+---
+
+# TR-010 — Every commit body starts with `Claude commit:` line (human-scannable attribution).
+
+> **Level:** MUST
+
+Every PR comment starts with `Claude comment:`.
+
+## Migration note
+
+Migrated from `docs/TECHNICAL_REQUIREMENTS.md` on 2026-04-29; see git history for prior context.

--- a/docs/requirements/technical/0011-tr-011-google-fonts-loaded-via-links-export-in-app-root-tsx-.md
+++ b/docs/requirements/technical/0011-tr-011-google-fonts-loaded-via-links-export-in-app-root-tsx-.md
@@ -1,0 +1,20 @@
+---
+id: TR-011
+type: tr
+status: accepted
+date: 2026-04-28
+level: SHOULD
+topics: [google, fonts, loaded, links]
+supersedes: []
+superseded_by: null
+authorized_by: vvaser@gmail.com
+authorized_at: 2026-04-28
+---
+
+# TR-011 — Google Fonts loaded via `links` export in `app/root.tsx` (no `@import url()` in CSS — avoids render-blocking in Workers SSR)
+
+> **Level:** SHOULD
+
+## Migration note
+
+Migrated from `docs/TECHNICAL_REQUIREMENTS.md` on 2026-04-29; see git history for prior context.

--- a/docs/requirements/technical/0012-tr-012-cloudflare-workers-ai-binding-ai-configured-in-wrangl.md
+++ b/docs/requirements/technical/0012-tr-012-cloudflare-workers-ai-binding-ai-configured-in-wrangl.md
@@ -1,0 +1,22 @@
+---
+id: TR-012
+type: tr
+status: accepted
+date: 2026-04-28
+level: SHOULD
+topics: [cloudflare, workers, binding, configured]
+supersedes: []
+superseded_by: null
+authorized_by: vvaser@gmail.com
+authorized_at: 2026-04-28
+---
+
+# TR-012 — Cloudflare Workers AI binding (`AI`) configured in `wrangler.jsonc` [ai] block
+
+> **Level:** SHOULD
+
+uncomment when implementing F-AI-SUGGEST.
+
+## Migration note
+
+Migrated from `docs/TECHNICAL_REQUIREMENTS.md` on 2026-04-29; see git history for prior context.

--- a/docs/requirements/technical/0013-tr-013-supabase-edge-functions-for-server-side-operations-th.md
+++ b/docs/requirements/technical/0013-tr-013-supabase-edge-functions-for-server-side-operations-th.md
@@ -1,0 +1,20 @@
+---
+id: TR-013
+type: tr
+status: accepted
+date: 2026-04-28
+level: MAY
+topics: [supabase, edge, functions, server]
+supersedes: []
+superseded_by: null
+authorized_by: vvaser@gmail.com
+authorized_at: 2026-04-28
+---
+
+# TR-013 — Supabase Edge Functions for server-side operations that need the service role key (GDPR export, account deletion)
+
+> **Level:** MAY
+
+## Migration note
+
+Migrated from `docs/TECHNICAL_REQUIREMENTS.md` on 2026-04-29; see git history for prior context.


### PR DESCRIPTION
## Summary

Migrates 13 TRs from the flat `docs/TECHNICAL_REQUIREMENTS.md` table-format file to individual MADR per-file records at `docs/requirements/technical/NNNN-<slug>.md`, rewriting the flat file as an auto-generated INDEX. Implements DEC-DOC-14 for tadaify-app, using the now-extended codemod tool from orchestrator#151.

## Context & background

- **DEC-DOC-14 = 1** — per-file MADR records for TRs (same pattern as DEC migration in #120).
- **orchestrator#149** (merged 2026-04-29) — initial `bin/migrate-records.mjs` codemod tool shipping.
- **orchestrator#151** (merged 2026-04-29) — codemod extended with table-format TR input support + parens/backtick-safe separator splitting (prerequisite for this PR; earlier dry-run failed without it).
- **Parallel A: DEC migration** — tadaify-app#120 (MADR DEC per-file migration) already merged.
- tadaify-app has table-format TRs (`| TR-NNN | description |` rows under `### MUST/SHOULD/MAY` headers), not heading-format. The #151 codemod extension specifically unblocked this run.

## What changed

- `docs/TECHNICAL_REQUIREMENTS.md` → rewritten as auto-generated INDEX with links to per-file records (33 lines → 28 lines, all content preserved in per-files)
- `docs/requirements/technical/` → 13 new MADR record files created:
  - 10 MUST: TR-001..010 (framework, runtime, styling, database, email, guard hooks, supabase MCP, language, no-CI-workflows-yet, commit attribution)
  - 2 SHOULD: TR-011..012 (Google Fonts via links export, Cloudflare Workers AI binding)
  - 1 MAY: TR-013 (Supabase Edge Functions for server-side ops)

## What was deliberately NOT changed

- BR migration is out of scope — only TRs migrated here.
- No manual hand-rolling of records — 100% codemod-generated. No post-edit patches.
- No source code changes — this is a documentation reorganisation only.

## Acceptance criteria (from DEC-DOC-14)

- ✅ Every TR has a per-file record with proper frontmatter (`id`, `status=accepted`, `date`, `level`, `topics`, `supersedes=[]`, `superseded_by=null`, `authorized_by`, `authorized_at`)
- ✅ `docs/TECHNICAL_REQUIREMENTS.md` rewritten as auto-generated INDEX
- ✅ Idempotent: re-running dry-run after migration reports "Nothing to do"
- ✅ 13 TR files created (TR-001..010 MUST, TR-011..012 SHOULD, TR-013 MAY)
- ✅ TR-011 title contains full parenthetical em-dash: "(no `@import url()` in CSS — avoids render-blocking in Workers SSR)" — correctly preserved as whole title
- ✅ TR-012 title ends at the em-dash separator (em-dash NOT inside parens/backticks — valid split); clarifying note "uncomment when implementing F-AI-SUGGEST" moved to record body

## Verification done

**Dry-run output (pre-migration):**
```
Detected table-format TR input (| TR-NNN | ... | rows under ### MUST/SHOULD/MAY headers).
Found 13 TR sections in TECHNICAL_REQUIREMENTS.md
[DRY RUN] would create: 0001-tr-001-... [TR-001] level: MUST
[DRY RUN] would create: 0011-tr-011-... [TR-011] level: SHOULD  ← em-dash inside parens safe
[DRY RUN] would create: 0012-tr-012-... [TR-012] level: SHOULD  ← em-dash outside parens = valid split
[DRY RUN] would create: 0013-tr-013-... [TR-013] level: MAY
[DRY RUN] would rewrite: docs/TECHNICAL_REQUIREMENTS.md as auto-generated INDEX
```

**Real run:**
```
Migrated 13 TR record(s). Skipped 0 already-migrated record(s).
```

**Idempotency check:**
```
TECHNICAL_REQUIREMENTS.md is already an auto-generated INDEX and per-file records exist — migration was already run (idempotent).
Nothing to do. Use --force to regenerate from the existing per-file records.
```

**TR coverage markers in source code:** `grep -rE 'TR-[0-9]+' app/ workers/ docs/specs/ e2e/` → **zero matches**. tadaify post-Story-0 has minimal source code; `// Covers: TR-NNN` annotations are a post-implementation concern for when actual features ship.

**Title smoke checks:**
- TR-011 H1: `TR-011 — Google Fonts loaded via \`links\` export in \`app/root.tsx\` (no \`@import url()\` in CSS — avoids render-blocking in Workers SSR)` ✅ whole-row preserved
- TR-012 H1: `TR-012 — Cloudflare Workers AI binding (\`AI\`) configured in \`wrangler.jsonc\` [ai] block` ✅ clean split; "uncomment..." in body

## Risk + reviewer focus areas

1. **Level detection (MUST/SHOULD/MAY)** — verify each file's `level:` matches the `### MUST/SHOULD/MAY` section it appeared under in the source.
2. **Existing `// Covers: TR-NNN` preservation** — N/A for tadaify (none found). Would be relevant on untiltify-app dispatch.
3. **Chronological numbering** — 0001..0013 matches TR-001..013 sequential order. Same pattern as DEC migration.
4. **INDEX links** — relative paths `requirements/technical/NNNN-<slug>.md` from `docs/` root are correct.

## Related in-flight work

- **#120** — tadaify-app DEC per-file MADR migration (MERGED)
- **orchestrator#149** — initial codemod tool (MERGED 2026-04-29)
- **orchestrator#151** — codemod table-format + parens/backtick-safe extension (MERGED 2026-04-29)
- **untiltify-app#153** — untiltify TR migration (separate dispatch, separate branch)

## Mockup

No UI change — mockup not required.

## Rollback

```bash
git revert ea7a6f1
```
Restores flat `docs/TECHNICAL_REQUIREMENTS.md` and removes all 13 per-file records. No DB migrations involved.

## Codex-pairing notes

- **Why per-file?** DEC-DOC-14 = 1 — matching the MADR pattern already established for DEC records in #120.
- **Why this numbering (0001..0013)?** Matches the DEC migration chronological pattern; padding to 4 digits for alphabetical sort stability.
- **What about untiltify-app?** Separate dispatch on its own branch. This PR is tadaify-app only.
- **Why did TR-012 split at the em-dash?** The em-dash in TR-012's row text (`[ai] block — uncomment when...`) is NOT inside parens or backticks, so it IS a valid title/description split boundary per the codemod's rules. The part before the em-dash is the canonical TR title; the part after is a clarifying implementation note correctly placed in the record body.

## References

- DEC-DOC-14 in `/tmp/claude-decisions/decisions.json`
- orchestrator `bin/migrate-records.mjs` (post-#151)
- MADR spec: `docs/requirements/technical/` format mirrors existing DEC files
