### PR TITLE
[fix] register impl missing 3 visual elements vs mockup (closes #145)

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -20,3 +20,19 @@ body {
     color-scheme: dark;
   }
 }
+
+/* Theme toggle button (mirrors mockups/tadaify-mvp/register.html lines 65-76).
+   The mockup contract is icon-only swap; full palette dark mode is out-of-scope
+   until tokens.css ships a dark variant. */
+.theme-toggle-btn:hover {
+  background: var(--bg-muted);
+  color: var(--fg);
+}
+body.dark-mode .theme-icon-sun {
+  opacity: 0;
+  transform: rotate(30deg) scale(0.6);
+}
+body.dark-mode .theme-icon-moon {
+  opacity: 1 !important;
+  transform: rotate(0) scale(1) !important;
+}

--- a/app/components/ThemeToggleButton.tsx
+++ b/app/components/ThemeToggleButton.tsx
@@ -1,0 +1,113 @@
+/**
+ * ThemeToggleButton — sun/moon SVG toggle that mirrors
+ * mockups/tadaify-mvp/register.html lines 65-76 + 498.
+ *
+ * Behavior matches the mockup precisely: toggles `body.dark-mode` class.
+ * Persists choice in localStorage; respects prefers-color-scheme on first load.
+ *
+ * NOTE: the mockup's `.dark-mode` only swaps the toggle icons themselves —
+ * the page palette does not change because tokens.css doesn't ship a dark
+ * variant. We mirror that contract: this button gives the affordance the
+ * mockup designs, full token-level dark mode is a separate (out-of-scope)
+ * feature.
+ *
+ * Story: F-REGISTER-001a (visual divergence fix #145)
+ */
+
+import { useEffect, useState } from "react";
+
+const STORAGE_KEY = "tadaify.theme";
+
+function readInitialTheme(): "light" | "dark" {
+  if (typeof window === "undefined") return "light";
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (stored === "light" || stored === "dark") return stored;
+  } catch {
+    // localStorage unavailable (private browsing, etc.) — fall through
+  }
+  if (window.matchMedia?.("(prefers-color-scheme: dark)").matches) return "dark";
+  return "light";
+}
+
+export function ThemeToggleButton() {
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+
+  useEffect(() => {
+    const initial = readInitialTheme();
+    setTheme(initial);
+    document.body.classList.toggle("dark-mode", initial === "dark");
+  }, []);
+
+  function toggle() {
+    const next = theme === "light" ? "dark" : "light";
+    setTheme(next);
+    document.body.classList.toggle("dark-mode", next === "dark");
+    try {
+      window.localStorage.setItem(STORAGE_KEY, next);
+    } catch {
+      // ignore — toggle still works in-memory
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      className="theme-toggle-btn"
+      aria-label={theme === "light" ? "Switch to dark mode" : "Switch to light mode"}
+      aria-pressed={theme === "dark"}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        width: 32,
+        height: 32,
+        borderRadius: 8,
+        background: "transparent",
+        border: "1px solid transparent",
+        color: "var(--fg-muted)",
+        cursor: "pointer",
+        transition: "all .12s ease",
+        position: "relative",
+      }}
+    >
+      {/* Sun — visible in light mode */}
+      <svg
+        className="theme-icon-sun"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+        style={{ width: 18, height: 18, transition: "opacity .2s ease, transform .3s cubic-bezier(.2,.8,.2,1)" }}
+      >
+        <circle cx="12" cy="12" r="4" />
+        <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+      </svg>
+      {/* Moon — visible in dark mode */}
+      <svg
+        className="theme-icon-moon"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+        style={{
+          width: 18,
+          height: 18,
+          position: "absolute",
+          opacity: 0,
+          transform: "rotate(-30deg) scale(0.6)",
+          transition: "opacity .2s ease, transform .3s cubic-bezier(.2,.8,.2,1)",
+        }}
+      >
+        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+      </svg>
+    </button>
+  );
+}

--- a/app/components/ThemeToggleButton.tsx
+++ b/app/components/ThemeToggleButton.tsx
@@ -15,39 +15,45 @@
  */
 
 import { useEffect, useState } from "react";
+import {
+  readInitialTheme,
+  applyTheme,
+  nextTheme,
+  type Theme,
+} from "~/lib/theme-utils";
 
-const STORAGE_KEY = "tadaify.theme";
-
-function readInitialTheme(): "light" | "dark" {
-  if (typeof window === "undefined") return "light";
+function getBrowserStorage() {
+  if (typeof window === "undefined") return null;
   try {
-    const stored = window.localStorage.getItem(STORAGE_KEY);
-    if (stored === "light" || stored === "dark") return stored;
+    return window.localStorage;
   } catch {
-    // localStorage unavailable (private browsing, etc.) — fall through
+    return null;
   }
-  if (window.matchMedia?.("(prefers-color-scheme: dark)").matches) return "dark";
-  return "light";
+}
+
+function getPrefersDarkMatcher() {
+  if (typeof window === "undefined" || !window.matchMedia) return null;
+  return window.matchMedia("(prefers-color-scheme: dark)");
+}
+
+function getBodyClassList() {
+  if (typeof document === "undefined") return null;
+  return document.body.classList;
 }
 
 export function ThemeToggleButton() {
-  const [theme, setTheme] = useState<"light" | "dark">("light");
+  const [theme, setTheme] = useState<Theme>("light");
 
   useEffect(() => {
-    const initial = readInitialTheme();
+    const initial = readInitialTheme(getBrowserStorage(), getPrefersDarkMatcher());
     setTheme(initial);
-    document.body.classList.toggle("dark-mode", initial === "dark");
+    applyTheme(initial, getBodyClassList(), getBrowserStorage());
   }, []);
 
   function toggle() {
-    const next = theme === "light" ? "dark" : "light";
+    const next = nextTheme(theme);
     setTheme(next);
-    document.body.classList.toggle("dark-mode", next === "dark");
-    try {
-      window.localStorage.setItem(STORAGE_KEY, next);
-    } catch {
-      // ignore — toggle still works in-memory
-    }
+    applyTheme(next, getBodyClassList(), getBrowserStorage());
   }
 
   return (

--- a/app/lib/theme-utils.test.ts
+++ b/app/lib/theme-utils.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Tests for app/lib/theme-utils.ts — covers Codex round-1 P3 finding on
+ * PR #146: "the exact regression fixed by #145 can recur unnoticed without
+ * at least a focused route/component test asserting these elements render
+ * and the theme toggle changes body.dark-mode + persisted value."
+ *
+ * Strategy: extracted pure helpers from ThemeToggleButton are exercised
+ * with injected Storage / MediaQueryMatcher / ClassList stubs. No DOM
+ * environment required, so this fits the existing Node-only vitest config.
+ * Component-render coverage (RTL) is deferred per `feedback_plan_then_tests.md`.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  readInitialTheme,
+  applyTheme,
+  nextTheme,
+  THEME_STORAGE_KEY,
+  type ThemeStorage,
+  type MediaQueryMatcher,
+  type ClassList,
+} from "./theme-utils";
+
+function makeStorage(initial: Record<string, string> = {}): ThemeStorage & {
+  store: Record<string, string>;
+} {
+  const store: Record<string, string> = { ...initial };
+  return {
+    store,
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+  };
+}
+
+function makeClassList(): ClassList & { toggleSpy: ReturnType<typeof vi.fn> } {
+  const toggleSpy = vi.fn();
+  return { toggle: toggleSpy, toggleSpy };
+}
+
+describe("readInitialTheme", () => {
+  it("returns stored 'light' verbatim", () => {
+    const storage = makeStorage({ [THEME_STORAGE_KEY]: "light" });
+    expect(readInitialTheme(storage, { matches: true })).toBe("light");
+  });
+
+  it("returns stored 'dark' verbatim, ignoring prefers-color-scheme", () => {
+    const storage = makeStorage({ [THEME_STORAGE_KEY]: "dark" });
+    expect(readInitialTheme(storage, { matches: false })).toBe("dark");
+  });
+
+  it("falls back to prefers-color-scheme when no stored value", () => {
+    const storage = makeStorage();
+    expect(readInitialTheme(storage, { matches: true })).toBe("dark");
+    expect(readInitialTheme(storage, { matches: false })).toBe("light");
+  });
+
+  it("defaults to 'light' when storage is null AND no media matcher", () => {
+    expect(readInitialTheme(null, null)).toBe("light");
+  });
+
+  it("ignores invalid stored values (treats as missing)", () => {
+    const storage = makeStorage({ [THEME_STORAGE_KEY]: "purple" });
+    // Invalid → fall through to media query
+    expect(readInitialTheme(storage, { matches: true })).toBe("dark");
+    expect(readInitialTheme(storage, { matches: false })).toBe("light");
+  });
+
+  it("survives storage throwing on getItem (private mode)", () => {
+    const storage: ThemeStorage = {
+      getItem: () => {
+        throw new Error("SecurityError: storage unavailable");
+      },
+      setItem: vi.fn(),
+    };
+    // Should NOT throw; falls through to media matcher
+    expect(readInitialTheme(storage, { matches: true })).toBe("dark");
+    expect(readInitialTheme(storage, null)).toBe("light");
+  });
+
+  it("treats matcher with matches=false as 'no preference'", () => {
+    const storage = makeStorage();
+    const matcher: MediaQueryMatcher = { matches: false };
+    expect(readInitialTheme(storage, matcher)).toBe("light");
+  });
+});
+
+describe("applyTheme", () => {
+  it("toggles dark-mode class ON for 'dark' and persists", () => {
+    const classList = makeClassList();
+    const storage = makeStorage();
+    const result = applyTheme("dark", classList, storage);
+    expect(result).toBe("dark");
+    expect(classList.toggleSpy).toHaveBeenCalledWith("dark-mode", true);
+    expect(storage.store[THEME_STORAGE_KEY]).toBe("dark");
+  });
+
+  it("toggles dark-mode class OFF for 'light' and persists", () => {
+    const classList = makeClassList();
+    const storage = makeStorage({ [THEME_STORAGE_KEY]: "dark" });
+    const result = applyTheme("light", classList, storage);
+    expect(result).toBe("light");
+    expect(classList.toggleSpy).toHaveBeenCalledWith("dark-mode", false);
+    expect(storage.store[THEME_STORAGE_KEY]).toBe("light");
+  });
+
+  it("survives storage throwing on setItem (private mode)", () => {
+    const classList = makeClassList();
+    const storage: ThemeStorage = {
+      getItem: vi.fn(),
+      setItem: () => {
+        throw new Error("QuotaExceededError");
+      },
+    };
+    // Should NOT throw — class still gets toggled
+    expect(() => applyTheme("dark", classList, storage)).not.toThrow();
+    expect(classList.toggleSpy).toHaveBeenCalledWith("dark-mode", true);
+  });
+
+  it("works with null classList (SSR / no DOM)", () => {
+    const storage = makeStorage();
+    expect(() => applyTheme("dark", null, storage)).not.toThrow();
+    expect(storage.store[THEME_STORAGE_KEY]).toBe("dark");
+  });
+
+  it("works with null storage (no persistence available)", () => {
+    const classList = makeClassList();
+    expect(() => applyTheme("light", classList, null)).not.toThrow();
+    expect(classList.toggleSpy).toHaveBeenCalledWith("dark-mode", false);
+  });
+});
+
+describe("nextTheme", () => {
+  it("light → dark", () => {
+    expect(nextTheme("light")).toBe("dark");
+  });
+
+  it("dark → light", () => {
+    expect(nextTheme("light")).toBe("dark");
+    expect(nextTheme("dark")).toBe("light");
+  });
+});
+
+describe("toggle round-trip (Codex regression scenario)", () => {
+  it("simulates the user clicking the button: light → dark → light, asserting body.dark-mode + persistence at each step", () => {
+    const classList = makeClassList();
+    const storage = makeStorage();
+
+    // Initial: light (no stored, no media-pref)
+    let theme = readInitialTheme(storage, { matches: false });
+    expect(theme).toBe("light");
+    applyTheme(theme, classList, storage);
+    expect(classList.toggleSpy).toHaveBeenLastCalledWith("dark-mode", false);
+    expect(storage.store[THEME_STORAGE_KEY]).toBe("light");
+
+    // Click 1: → dark
+    theme = nextTheme(theme);
+    applyTheme(theme, classList, storage);
+    expect(classList.toggleSpy).toHaveBeenLastCalledWith("dark-mode", true);
+    expect(storage.store[THEME_STORAGE_KEY]).toBe("dark");
+
+    // Click 2: → light
+    theme = nextTheme(theme);
+    applyTheme(theme, classList, storage);
+    expect(classList.toggleSpy).toHaveBeenLastCalledWith("dark-mode", false);
+    expect(storage.store[THEME_STORAGE_KEY]).toBe("light");
+
+    // Subsequent visit: should resume from stored
+    const resumed = readInitialTheme(storage, { matches: true });
+    expect(resumed).toBe("light"); // stored wins over media pref
+  });
+});

--- a/app/lib/theme-utils.ts
+++ b/app/lib/theme-utils.ts
@@ -1,0 +1,96 @@
+/**
+ * Theme utility helpers — pure functions extracted from ThemeToggleButton
+ * for testability without a DOM environment.
+ *
+ * The ThemeToggleButton component delegates initial-theme resolution and
+ * apply-side-effects to these helpers. Tests in `theme-utils.test.ts` cover
+ * the persistence + prefers-color-scheme priority paths via injected stubs
+ * for the Storage and Document interfaces.
+ *
+ * Story: F-REGISTER-001a (visual divergence fix #145, Codex round-1 P3)
+ */
+
+export type Theme = "light" | "dark";
+
+export const THEME_STORAGE_KEY = "tadaify.theme";
+
+/**
+ * Minimal Storage shape we depend on — narrower than the full DOM Storage
+ * interface so tests can pass a plain object stub.
+ */
+export interface ThemeStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+/**
+ * Minimal media-query matcher shape.
+ */
+export interface MediaQueryMatcher {
+  matches: boolean;
+}
+
+/**
+ * Resolve the initial theme on first paint:
+ *   1. Stored value in `THEME_STORAGE_KEY` if it's a valid Theme,
+ *   2. otherwise `prefers-color-scheme: dark` if the matcher matches,
+ *   3. otherwise default to "light".
+ *
+ * Pure function — does NOT touch globals. Both inputs are nullable so the
+ * caller can safely pass through unavailable browser APIs (private mode
+ * blocks localStorage; old browsers lack matchMedia).
+ */
+export function readInitialTheme(
+  storage: ThemeStorage | null,
+  prefersDark: MediaQueryMatcher | null
+): Theme {
+  if (storage) {
+    try {
+      const stored = storage.getItem(THEME_STORAGE_KEY);
+      if (stored === "light" || stored === "dark") return stored;
+    } catch {
+      // Storage may throw in private mode — fall through.
+    }
+  }
+  if (prefersDark?.matches) return "dark";
+  return "light";
+}
+
+/**
+ * Minimal class-list shape (DOMTokenList subset).
+ */
+export interface ClassList {
+  toggle(token: string, force?: boolean): boolean;
+}
+
+/**
+ * Apply a theme decision: toggle the `dark-mode` class on the given
+ * class-list and persist the choice via the storage stub. Both side effects
+ * are injected so tests can assert them in isolation.
+ *
+ * Returns the theme so chained callers can read the value back.
+ */
+export function applyTheme(
+  theme: Theme,
+  bodyClassList: ClassList | null,
+  storage: ThemeStorage | null
+): Theme {
+  if (bodyClassList) {
+    bodyClassList.toggle("dark-mode", theme === "dark");
+  }
+  if (storage) {
+    try {
+      storage.setItem(THEME_STORAGE_KEY, theme);
+    } catch {
+      // Storage may throw in private mode — toggle still works in-memory.
+    }
+  }
+  return theme;
+}
+
+/**
+ * Flip a theme decision.
+ */
+export function nextTheme(current: Theme): Theme {
+  return current === "light" ? "dark" : "light";
+}

--- a/app/routes/register.tsx
+++ b/app/routes/register.tsx
@@ -47,6 +47,7 @@ import {
   type OtpState,
 } from "~/lib/otp-state";
 import { MotionLogo } from "~/components/landing/MotionLogo";
+import { ThemeToggleButton } from "~/components/ThemeToggleButton";
 
 // ─── Meta ─────────────────────────────────────────────────────────────────────
 
@@ -443,6 +444,7 @@ export default function RegisterPage({ loaderData }: Route.ComponentProps) {
           Already have an account?{" "}
           <strong style={{ color: "var(--brand-primary)" }}>Sign in</strong>
         </a>
+        <ThemeToggleButton />
       </nav>
 
       {/* Main register grid */}
@@ -569,6 +571,19 @@ export default function RegisterPage({ loaderData }: Route.ComponentProps) {
             minHeight: 400,
           }}
         >
+          {/* logo-corner — matches mockups/tadaify-mvp/register.html line 795 */}
+          <div
+            style={{
+              position: "absolute",
+              top: 24,
+              right: 24,
+              opacity: 0.9,
+              zIndex: 2,
+            }}
+            aria-hidden="true"
+          >
+            <MotionLogo size="nav" />
+          </div>
           <div
             style={{ position: "relative", textAlign: "center", maxWidth: 420, zIndex: 1 }}
           >
@@ -627,16 +642,30 @@ export default function RegisterPage({ loaderData }: Route.ComponentProps) {
               </span>
             </div>
 
-            <p
+            {/* preview-thumb skeleton — matches mockups/tadaify-mvp/register.html
+                lines 811-819 (3 dots + 5 lines: short / full / pill / pill / short). */}
+            <div
               style={{
-                marginTop: 28,
-                opacity: 0.85,
-                fontSize: 13,
-                lineHeight: 1.6,
+                marginTop: 32,
+                background: "rgba(255,255,255,0.08)",
+                border: "1px solid rgba(255,255,255,0.15)",
+                borderRadius: 14,
+                padding: 18,
+                textAlign: "left",
               }}
+              aria-hidden="true"
             >
-              This is how your brand shows up on every page, share card, and email receipt.
-            </p>
+              <div style={{ display: "flex", gap: 6, marginBottom: 12 }}>
+                <span style={{ width: 10, height: 10, borderRadius: "50%", background: "rgba(255,255,255,0.3)" }} />
+                <span style={{ width: 10, height: 10, borderRadius: "50%", background: "rgba(255,255,255,0.3)" }} />
+                <span style={{ width: 10, height: 10, borderRadius: "50%", background: "rgba(255,255,255,0.3)" }} />
+              </div>
+              <div style={{ height: 8, width: "60%", borderRadius: 4, background: "rgba(255,255,255,0.25)", marginTop: 10 }} />
+              <div style={{ height: 8, borderRadius: 4, background: "rgba(255,255,255,0.25)", marginTop: 10 }} />
+              <div style={{ height: 28, borderRadius: 4, background: "rgba(253,230,138,0.35)", marginTop: 10 }} />
+              <div style={{ height: 28, borderRadius: 4, background: "rgba(253,230,138,0.35)", marginTop: 10 }} />
+              <div style={{ height: 8, width: "60%", borderRadius: 4, background: "rgba(255,255,255,0.25)", marginTop: 10 }} />
+            </div>
           </div>
         </aside>
       </div>


### PR DESCRIPTION
## Summary

Restores 3 visual elements that PR #133 (Slice B email-OTP impl) dropped during HTML→React transposition vs `mockups/tadaify-mvp/register.html`. Locked memory rule `feedback_mockup_full_feature_vision.md` mandates that mockup IS the complete design contract — these elements should have shipped with #133 but weren't surfaced by review.

Closes #145.

## Business requirements implemented

n/a — this is a visual-fidelity fix to PR #133. No new BR; the underlying behavior (DEC-291 / DEC-294 / DEC-295 / DEC-296 / DEC-305 / DEC-306 / DEC-308) is unchanged.

## Technical requirements introduced or relied on

n/a — relies on existing TR-AUTH-* envelope. New `ThemeToggleButton` component lands in `app/components/` per existing convention.

## Acceptance criteria (from issue #145)

- [x] Theme toggle button (sun/moon SVG) widoczny w auth-bar `/register`
- [x] Toggle persistuje wybór do `localStorage.tadaify.theme`; respektuje `prefers-color-scheme: dark` jako default
- [x] MotionLogo widoczny w prawym górnym rogu preview-col na desktop (≥960px)
- [x] Preview-thumb skeleton renderuje 3 dots + 5 lines (1 short, 1 full, 2 pill-row, 1 short) zgodnie z mockup linie 811-819
- [x] Wszystkie 186 unit tests passing
- [x] Lokalny smoke: `supabase start` + walk register flow → wszystkie 5 sekcji renderują z brakującymi elementami

Deferred (out of scope, per issue #145 + memory rule):
- [ ] Visual regression Playwright spec → tracked w issue #140 (DEC-313=C follow-up)
- [ ] Full token-level dark mode (palette overrides w `tokens.css`) → osobny feature, nie blokuje tej fix-up
- [ ] mockup-enforcer skill extension dla visual fidelity → tracked w issue orch#181 (DEC-319=A part 2)

## Test plan

**Unit (186/186 passing):**
- 17 existing register flow tests (handle-validator, auth-validator, otp-state)
- No NEW unit tests — `ThemeToggleButton` testing is ulokowane w manualnej weryfikacji + sprawdzaniu localStorage persistence (in-memory toggle covered by integration). Adding a React Testing Library wrapper just to assert `body.classList.toggle` is over-engineering for a 32px button.

**Local smoke (verified):**
1. Fresh worktree off `origin/main` z PR applied
2. `cp .env.example .env` + generate secret
3. `supabase start && npm run dev`
4. Browser localhost:5173/register
5. Side-by-side z `python3 -m http.server 8089` w mockups/tadaify-mvp + http://localhost:8089/register.html
6. Verify: theme toggle visible w auth-bar (klik przełącza body.dark-mode + ikonę), MotionLogo widoczny w prawym górnym rogu preview-col na desktop ≥960px, skeleton 3 dots + 5 lines vs descriptive text na poprzedniej main

**Playwright:** deferred per locked memory rule `feedback_plan_then_tests.md` + DEC-313=C. Issue #140 tracks the executable spec for the auth flow; visual regression dla register should land tam jako sub-test po Phase 2 mockup-enforcer extension (issue orch#181).

## Mockup

📎 Reference mockup: https://github.com/graspsoftwarepw/tadaify-app/blob/main/mockups/tadaify-mvp/register.html

Specific lines this PR restores:
- 65-76 (`.theme-toggle-btn` CSS) → `app/app.css` + `ThemeToggleButton.tsx`
- 498 (theme toggle button DOM) → `register.tsx` line ~447
- 795 (`<span class="logo-mark logo-corner" data-logo>`) → `register.tsx` preview-col absolute positioning
- 811-819 (preview-thumb skeleton DOM) → `register.tsx` skeleton replaces descriptive text

## Rollback

`git revert <merge-commit-sha>` after merge — single commit `1f7cdcf`. No DB / no infra / no schema. Reverting just removes the 3 elements (theme toggle button, logo-corner, skeleton) and restores descriptive text. ThemeToggleButton component file gets removed atomically.

## Context + background (for reviewer)

- **Surfaced by user feedback** 2026-05-02 ~07:00 UTC podczas local visual review po merge PR #133.
- **Why these were missed in PR #133 review:** Codex review focused on backend/auth correctness (handle TOCTOU race, OTP flow, password endpoint). My own review focused on classifier-correct DEC contracts. Visual side-by-side z mockup-em **nie był wymaganym checkpointem** — dokumentowane jako process gap w issue orch#181 (`extend mockup-enforcer to verify visual fidelity, not just URL presence`).
- **Theme toggle scope clarification:** mockup contract is **icon-only swap** (sun ↔ moon SVG). `tokens.css` doesn't ship a dark-mode palette override block, so `body.dark-mode` doesn't currently flip page colors. Full token-level dark mode is intentionally OUT of scope here — adding it now would be scope expansion. ThemeToggleButton ships the affordance the mockup designs; full repaint is a separate feature.
- **Per-test-authorization:** no Playwright specs added per locked memory rule + DEC-313=C deferral. Specs land later via `test-spec-generator` skill or as part of issue #140.
