### PR TITLE
Email mockups Phase 1 — signup + login OTP per #150

### DIFF
--- a/mockups/tadaify-mvp/emails/_email-tokens-preview.html
+++ b/mockups/tadaify-mvp/emails/_email-tokens-preview.html
@@ -1,0 +1,283 @@
+<!DOCTYPE html>
+<!--
+type: mockup
+project: tadaify
+title: Email mockup — Side-by-side OTP token compare (signup vs login)
+created_at: 2026-05-02T17:11:00Z
+-->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>tadaify — Email tokens compare (signup vs login)</title>
+  <link rel="stylesheet" href="../shared/tokens.css">
+  <style>
+    body { background: var(--bg-muted); padding: 32px 16px 96px; }
+    .preview-page { max-width: 1320px; margin: 0 auto; }
+    .preview-back {
+      display: inline-flex; align-items: center; gap: 8px;
+      font-size: 13px; font-weight: 600; color: var(--fg-muted);
+      text-decoration: none; padding: 8px 14px; border-radius: var(--radius-full);
+      background: var(--bg-elevated); border: 1px solid var(--border-strong);
+      margin-bottom: 20px;
+      transition: border 120ms, color 120ms;
+    }
+    .preview-back:hover { border-color: var(--brand-primary); color: var(--brand-primary); }
+    h1.preview-title {
+      font-family: var(--font-display); font-weight: 600;
+      font-size: 32px; letter-spacing: -0.02em; margin-bottom: 6px;
+    }
+    .preview-sub { color: var(--fg-muted); font-size: 15px; margin-bottom: 28px; max-width: 820px; }
+
+    .compare-grid {
+      display: grid; gap: 24px;
+      grid-template-columns: repeat(auto-fit, minmax(440px, 1fr));
+    }
+    .compare-cell {
+      background: var(--bg-elevated);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-lg);
+      box-shadow: var(--shadow);
+      overflow: hidden;
+    }
+    .compare-cell h2 {
+      padding: 18px 24px;
+      font-family: var(--font-sans); font-size: 13px;
+      font-weight: 700; letter-spacing: 0.08em;
+      text-transform: uppercase; color: var(--fg-muted);
+      margin: 0;
+      background: var(--bg-muted);
+      border-bottom: 1px solid var(--border);
+      display: flex; align-items: center; justify-content: space-between;
+      gap: 12px;
+    }
+    .compare-cell h2 .pill { font-size: 11px; padding: 3px 10px; }
+
+    .frame { padding: 28px 24px; background: #F8FAFC; }
+
+    /* Inline copy of email body styles, scoped via .ebody to keep
+       this preview file standalone. */
+    .ebody {
+      max-width: 560px; margin: 0 auto;
+      background: #FFFFFF;
+      border-radius: 12px; overflow: hidden;
+      box-shadow: 0 1px 3px rgba(17,24,39,0.06), 0 8px 24px rgba(17,24,39,0.04);
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+      color: #111827; line-height: 1.55;
+    }
+    .ebody-hero {
+      padding: 28px 32px 4px;
+      background:
+        radial-gradient(600px 200px at 100% 0%, rgba(139,92,246,0.10), transparent 60%),
+        radial-gradient(400px 200px at 0% 0%, rgba(245,158,11,0.08), transparent 60%),
+        #FFFFFF;
+    }
+    .ebody-wm {
+      font-family: 'Crimson Pro', Georgia, serif;
+      font-weight: 600; font-size: 28px; letter-spacing: -0.02em;
+      line-height: 1; display: inline-block; margin-bottom: 16px;
+    }
+    .ebody-wm .ta { color: #6366F1; } .ebody-wm .hyp { color: rgba(17,24,39,0.30); margin: 0 1px; }
+    .ebody-wm .da { color: #F59E0B; } .ebody-wm .ify { color: #111827; }
+    .ebody-greet {
+      font-family: 'Crimson Pro', Georgia, serif;
+      font-weight: 600; font-size: 24px; letter-spacing: -0.02em;
+      color: #111827; margin: 0 0 4px;
+    }
+    .ebody-sub { font-size: 14px; color: #6B7280; margin: 0; }
+
+    .ebody-token-block { padding: 24px 32px; text-align: center; }
+    .ebody-token-label {
+      font-size: 11px; font-weight: 700; letter-spacing: 0.10em;
+      text-transform: uppercase; color: #6366F1; margin-bottom: 10px;
+    }
+    .ebody-token {
+      font-family: 'Crimson Pro', Georgia, serif;
+      font-weight: 600; font-size: 48px; letter-spacing: 0.16em;
+      color: #111827; line-height: 1; padding: 18px 0;
+      display: inline-block; min-width: 280px;
+      background: linear-gradient(135deg, rgba(99,102,241,0.06), rgba(245,158,11,0.05));
+      border: 1.5px solid rgba(99,102,241,0.18);
+      border-radius: 12px;
+      font-feature-settings: "tnum","lnum";
+    }
+    .ebody-expiry { font-size: 12px; color: #9CA3AF; margin-top: 12px; font-weight: 500; }
+
+    .ebody-copy { padding: 4px 32px 22px; font-size: 14px; color: #374151; }
+    .ebody-copy p { margin: 0 0 12px; }
+
+    .ebody-trust {
+      padding: 14px 22px; background: #F9FAFB;
+      border-top: 1px solid #F3F4F6; border-bottom: 1px solid #F3F4F6;
+      display: flex; flex-wrap: wrap; justify-content: center; gap: 4px 14px;
+      font-size: 11px; font-weight: 600; color: #4B5563;
+    }
+    .ebody-foot {
+      padding: 18px 32px 26px;
+      font-size: 11px; color: #9CA3AF; line-height: 1.6;
+    }
+    .ebody-foot .disc {
+      padding: 10px 12px; background: #FAFAFA;
+      border-left: 3px solid #E5E7EB; border-radius: 4px;
+      color: #6B7280; margin-bottom: 12px; font-size: 12px;
+    }
+
+    /* Diff annotations row */
+    .diff-table {
+      max-width: 1280px; margin: 48px auto 0;
+      background: var(--bg-elevated); border: 1px solid var(--border);
+      border-radius: var(--radius-lg); overflow: hidden; box-shadow: var(--shadow-sm);
+    }
+    .diff-table h3 {
+      padding: 18px 24px; margin: 0;
+      font-family: var(--font-sans); font-size: 13px; font-weight: 700;
+      letter-spacing: 0.08em; text-transform: uppercase; color: var(--fg-muted);
+      background: var(--bg-muted); border-bottom: 1px solid var(--border);
+    }
+    .diff-table table { width: 100%; border-collapse: collapse; }
+    .diff-table th, .diff-table td {
+      text-align: left; padding: 12px 18px;
+      border-bottom: 1px solid var(--border);
+      font-size: 14px; vertical-align: top;
+    }
+    .diff-table th {
+      font-weight: 700; color: var(--fg);
+      background: var(--bg);
+      font-size: 12px; letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+    .diff-table td.label { font-weight: 600; width: 200px; color: var(--fg); }
+    .diff-table td code {
+      font-family: var(--font-mono); font-size: 12px;
+      background: var(--bg-muted); padding: 1px 6px; border-radius: 4px;
+    }
+
+    @media (max-width: 940px) {
+      .compare-grid { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <div class="preview-page">
+    <a href="./index.html" class="preview-back">← Back to email mockups</a>
+
+    <h1 class="preview-title">Email tokens — signup vs login compare</h1>
+    <p class="preview-sub">Side-by-side render of both Phase 1 OTP emails so the differences can be spotted at a glance: greeting, subject line, contextual copy, optional device card. Trust strip and disclaimer copy are identical between the two by design.</p>
+
+    <div class="compare-grid">
+
+      <!-- SIGNUP -->
+      <div class="compare-cell">
+        <h2>otp-signup.html <span class="pill pill-primary">new user</span></h2>
+        <div class="frame">
+          <article class="ebody">
+            <header class="ebody-hero">
+              <span class="ebody-wm"><span class="ta">ta</span><span class="hyp">-</span><span class="da">da!</span><span class="ify">ify</span></span>
+              <h1 class="ebody-greet">Hey @waserek 👋</h1>
+              <p class="ebody-sub">welcome to tadaify — let's verify your email.</p>
+            </header>
+            <div class="ebody-token-block">
+              <div class="ebody-token-label">Your verification code</div>
+              <div class="ebody-token">184629</div>
+              <div class="ebody-expiry">Code expires in 10 minutes</div>
+            </div>
+            <div class="ebody-copy">
+              <p>Type these <strong>6 digits</strong> back into the tadaify signup form to finish creating your account.</p>
+            </div>
+            <div class="ebody-trust">
+              <span>🔒 Price locked for life</span><span>💸 30-day money-back</span><span>🛡 GDPR-compliant</span>
+            </div>
+            <div class="ebody-foot">
+              <div class="disc">If you didn't sign up for tadaify, you can safely ignore this email.</div>
+            </div>
+          </article>
+        </div>
+      </div>
+
+      <!-- LOGIN -->
+      <div class="compare-cell">
+        <h2>otp-login.html <span class="pill pill-warm">returning user</span></h2>
+        <div class="frame">
+          <article class="ebody">
+            <header class="ebody-hero">
+              <span class="ebody-wm"><span class="ta">ta</span><span class="hyp">-</span><span class="da">da!</span><span class="ify">ify</span></span>
+              <h1 class="ebody-greet">Welcome back, @waserek</h1>
+              <p class="ebody-sub">signing you in to tadaify.</p>
+            </header>
+            <div class="ebody-token-block">
+              <div class="ebody-token-label">Your sign-in code</div>
+              <div class="ebody-token">502718</div>
+              <div class="ebody-expiry">Code expires in 10 minutes</div>
+            </div>
+            <div class="ebody-copy">
+              <p>Type these <strong>6 digits</strong> back into the tadaify sign-in form to finish logging in.</p>
+            </div>
+            <div class="ebody-trust">
+              <span>🔒 Price locked for life</span><span>💸 30-day money-back</span><span>🛡 GDPR-compliant</span>
+            </div>
+            <div class="ebody-foot">
+              <div class="disc">If you didn't try to sign in to tadaify, you can safely ignore — your account is unchanged.</div>
+            </div>
+          </article>
+        </div>
+      </div>
+    </div>
+
+    <!-- Diff annotations -->
+    <div class="diff-table">
+      <h3>What differs between the two templates</h3>
+      <table>
+        <thead>
+          <tr><th>Element</th><th>Signup OTP</th><th>Login OTP</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="label">Subject</td>
+            <td><code>Your tadaify code: {{ .Token }}</code></td>
+            <td><code>Sign in to tadaify: {{ .Token }}</code></td>
+          </tr>
+          <tr>
+            <td class="label"><code>config.toml</code> slot</td>
+            <td><code>[auth.email.template.signup]</code></td>
+            <td><code>[auth.email.template.magic_link]</code></td>
+          </tr>
+          <tr>
+            <td class="label">Greeting</td>
+            <td><code>Hey @&lt;handle&gt; 👋</code> · fallback <code>Hey there 👋</code> if handle not yet bound</td>
+            <td><code>Welcome back, @&lt;handle&gt;</code> · handle always known on this path (DEC-307)</td>
+          </tr>
+          <tr>
+            <td class="label">Sub-line</td>
+            <td><code>welcome to tadaify — let's verify your email.</code></td>
+            <td><code>signing you in to tadaify.</code></td>
+          </tr>
+          <tr>
+            <td class="label">Token label</td>
+            <td><code>Your verification code</code></td>
+            <td><code>Your sign-in code</code></td>
+          </tr>
+          <tr>
+            <td class="label">Body copy</td>
+            <td>Type these 6 digits back into the tadaify <strong>signup</strong> form to finish creating your account.</td>
+            <td>Type these 6 digits back into the tadaify <strong>sign-in</strong> form to finish logging in.</td>
+          </tr>
+          <tr>
+            <td class="label">Device card</td>
+            <td>—</td>
+            <td>Browser · OS · city · UTC time. Informational only — not clickable.</td>
+          </tr>
+          <tr>
+            <td class="label">Disclaimer copy</td>
+            <td>If you didn't sign up for tadaify, you can safely ignore this email.</td>
+            <td>If you didn't try to sign in to tadaify, you can safely ignore — your account is unchanged.</td>
+          </tr>
+          <tr>
+            <td class="label">Identical between the two</td>
+            <td colspan="2">Wordmark · token visual + sizing · expiry copy · trust strip · footer meta · plain-text fallback structure · dark-mode treatment.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</body>
+</html>

--- a/mockups/tadaify-mvp/emails/index.html
+++ b/mockups/tadaify-mvp/emails/index.html
@@ -1,480 +1,373 @@
 <!DOCTYPE html>
+<!--
+type: mockup
+project: tadaify
+title: Email mockups — landing (Phase 1 + Phase 2 placeholders)
+created_at: 2026-05-02T17:14:00Z
+-->
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>tadaify — Email templates gallery</title>
+  <title>tadaify — Email mockups</title>
+  <link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@500;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../shared/tokens.css">
   <style>
-    /* --- Page chrome --- */
-    body { background: var(--bg-muted); }
-    .gallery-header {
-      position: sticky; top: 0; z-index: 100;
-      background: rgba(249,250,251,0.92);
-      backdrop-filter: saturate(180%) blur(12px);
-      border-bottom: 1px solid var(--border);
-      padding: 14px clamp(16px,4vw,32px);
-      display: flex; align-items: center; gap: 16px; flex-wrap: wrap;
+    body { background: var(--bg); }
+    .header {
+      padding: 64px 24px 24px;
+      max-width: 1080px; margin: 0 auto;
     }
-    .gallery-header .brand { display: inline-flex; align-items: baseline; gap: 8px; font-family: var(--font-display); font-weight: 600; font-size: 22px; letter-spacing: -0.02em; }
-    .gallery-header .brand .ta { color: var(--brand-primary); }
-    .gallery-header .brand .hyp { color: var(--wm-hyphen); margin: 0 1px; }
-    .gallery-header .brand .da { color: var(--brand-warm); }
-    .gallery-header .brand .ify { color: var(--fg); }
-    .gallery-header h1 {
-      font-family: var(--font-sans); font-size: 14px; font-weight: 600;
-      letter-spacing: 0.06em; text-transform: uppercase; color: var(--fg-muted);
-      margin-left: 4px;
+    .header .pill { margin-bottom: 16px; }
+    .header h1 { font-family: var(--font-display); font-weight: 600; font-size: clamp(36px, 5vw, 56px); margin-bottom: 12px; letter-spacing: -0.02em; }
+    .header h1 .wm { display: inline-flex; align-items: baseline; line-height: 1; }
+    .header h1 .wm .ta  { color: var(--brand-primary); }
+    .header h1 .wm .hyp { color: var(--wm-hyphen); margin: 0 0.05em; }
+    .header h1 .wm .da  { color: var(--brand-warm); }
+    .header h1 .wm .ify { color: var(--fg); }
+    .header p.lead { color: var(--fg-muted); font-size: 18px; max-width: 720px; line-height: 1.6; margin-top: 8px; }
+    .header .meta-row {
+      display: flex; flex-wrap: wrap; gap: 12px;
+      margin-top: 24px; align-items: center;
     }
-    .gallery-toolbar { margin-left: auto; display: inline-flex; gap: 8px; align-items: center; flex-wrap: wrap; }
-    .toggle-group { display: inline-flex; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: var(--radius-full); padding: 3px; gap: 0; }
-    .toggle-group button {
-      border: 0; background: transparent; padding: 6px 14px;
-      font-size: 13px; font-weight: 600; color: var(--fg-muted);
-      border-radius: var(--radius-full); cursor: pointer;
-      transition: background 140ms, color 140ms;
+    .meta-row .pill-muted {
+      background: var(--bg-muted); color: var(--fg-muted);
+      font-family: var(--font-mono); font-size: 12px;
+      padding: 4px 12px;
     }
-    .toggle-group button.active { background: var(--brand-primary); color: #FFF; }
-    .toggle-group button:hover:not(.active) { background: var(--bg-muted); color: var(--fg); }
 
-    .gallery-intro {
-      max-width: 880px; margin: 32px auto 16px;
-      padding: 0 clamp(16px,4vw,32px);
+    .section { padding: 24px 0 64px; }
+    .section-inner { max-width: 1080px; margin: 0 auto; padding: 0 24px; }
+    .section h2 {
+      font-family: var(--font-display); font-weight: 600;
+      font-size: 28px; letter-spacing: -0.02em;
+      margin-bottom: 6px;
     }
-    .gallery-intro h2 { font-size: 32px; margin-bottom: 8px; }
-    .gallery-intro p { color: var(--fg-muted); font-size: 16px; line-height: 1.6; }
-    .gallery-intro .meta-pills { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 16px; }
+    .section .section-sub {
+      color: var(--fg-muted); font-size: 15px; margin-bottom: 28px;
+      max-width: 720px;
+    }
 
-    .toc {
-      max-width: 880px; margin: 0 auto 32px;
-      padding: 0 clamp(16px,4vw,32px);
+    .tile-grid {
+      display: grid; gap: 20px;
+      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
     }
-    .toc-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px,1fr)); gap: 8px; }
-    .toc-link {
-      display: block; padding: 10px 14px; background: var(--bg-elevated);
-      border: 1px solid var(--border); border-radius: var(--radius);
-      font-size: 13px; color: var(--fg); text-decoration: none;
-      transition: border 120ms, transform 120ms;
-    }
-    .toc-link:hover { border-color: var(--brand-primary); transform: translateY(-1px); }
-    .toc-link .num { color: var(--fg-subtle); font-family: var(--font-mono); font-size: 11px; margin-right: 8px; }
-    .toc-link .stack { display: inline-block; margin-left: 8px; padding: 1px 6px; font-size: 10px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; border-radius: 4px; }
-    .toc-link .stack.sb { background: rgba(99,102,241,0.12); color: var(--brand-primary); }
-    .toc-link .stack.rs { background: rgba(245,158,11,0.15); color: #92400E; }
-
-    /* --- Email card --- */
-    .email-card {
-      max-width: 880px; margin: 32px auto;
+    .tile {
       background: var(--bg-elevated);
       border: 1px solid var(--border);
       border-radius: var(--radius-lg);
-      box-shadow: var(--shadow);
       overflow: hidden;
+      box-shadow: var(--shadow-sm);
+      display: flex; flex-direction: column;
+      transition: border 160ms, transform 160ms, box-shadow 160ms;
+      text-decoration: none; color: inherit;
     }
-    .email-card-header {
-      padding: 20px 28px;
-      border-bottom: 1px solid var(--border);
-      background: var(--bg-muted);
-    }
-    .email-meta-row { display: flex; flex-wrap: wrap; gap: 12px 24px; align-items: baseline; margin-bottom: 6px; }
-    .email-num { font-family: var(--font-mono); font-size: 12px; color: var(--fg-subtle); }
-    .email-stack-pill { font-size: 10px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; padding: 2px 8px; border-radius: 4px; }
-    .email-stack-pill.sb { background: rgba(99,102,241,0.12); color: var(--brand-primary); }
-    .email-stack-pill.rs { background: rgba(245,158,11,0.15); color: #92400E; }
-    .email-filename { font-family: var(--font-mono); font-size: 12px; color: var(--fg-muted); }
-
-    .email-subject { font-family: var(--font-display); font-size: 22px; font-weight: 600; color: var(--fg); letter-spacing: -0.01em; margin-top: 6px; }
-    .email-preheader { font-size: 13px; color: var(--fg-subtle); margin-top: 4px; font-style: italic; }
-
-    .email-card-toolbar {
-      display: flex; flex-wrap: wrap; gap: 8px;
-      padding: 12px 28px; background: var(--bg);
-      border-bottom: 1px solid var(--border);
-    }
-    .email-card-toolbar .small-toggle {
-      font-size: 12px; font-weight: 600; padding: 5px 11px;
-      background: var(--bg-elevated); border: 1px solid var(--border-strong);
-      border-radius: var(--radius-full); color: var(--fg-muted);
-      cursor: pointer; transition: background 120ms, color 120ms, border-color 120ms;
-    }
-    .email-card-toolbar .small-toggle.active {
-      background: var(--brand-primary); color: #FFF; border-color: var(--brand-primary);
-    }
-    .email-card-toolbar .small-toggle:hover:not(.active) { background: var(--bg-muted); color: var(--fg); }
-    .email-card-toolbar .copy-btn {
-      margin-left: auto; font-size: 12px; font-weight: 600;
-      background: var(--fg); color: var(--fg-inverse);
-      border: 0; padding: 6px 14px; border-radius: var(--radius-full); cursor: pointer;
-      display: inline-flex; align-items: center; gap: 6px;
-    }
-    .email-card-toolbar .copy-btn:hover { background: var(--brand-primary); }
-    .email-card-toolbar .copy-btn.ok { background: var(--success); }
-
-    /* Iframe stage */
-    .email-stage {
-      padding: 24px;
-      background: repeating-linear-gradient(45deg, transparent 0, transparent 12px, rgba(17,24,39,0.02) 12px, rgba(17,24,39,0.02) 13px), var(--bg-muted);
-      display: flex; justify-content: center;
-      transition: background 200ms;
-    }
-    .email-stage.dark { background: var(--bg-dark); }
-    .email-iframe {
-      border: 1px solid var(--border-strong);
-      background: #FFF;
-      width: 100%;
-      max-width: 640px;
-      min-height: 600px;
-      transition: max-width 220ms ease, min-height 220ms ease;
+    .tile:hover {
+      border-color: var(--brand-primary);
+      transform: translateY(-3px);
       box-shadow: var(--shadow-lg);
-      border-radius: 6px;
     }
-    .email-iframe.mobile { max-width: 375px; }
-    .email-stage.dark .email-iframe { border-color: #1F2937; box-shadow: 0 12px 32px rgba(0,0,0,0.5); }
 
-    /* Source view */
-    details.email-source {
-      margin: 0; padding: 0;
-      border-top: 1px solid var(--border);
+    .tile-preview {
+      height: 220px;
+      padding: 24px 22px;
+      background:
+        radial-gradient(400px 160px at 100% 0%, rgba(139,92,246,0.10), transparent 60%),
+        radial-gradient(300px 160px at 0% 0%, rgba(245,158,11,0.08), transparent 60%),
+        #FFFFFF;
+      display: flex; flex-direction: column; justify-content: center; align-items: center;
+      gap: 10px;
+      border-bottom: 1px solid var(--border);
+      position: relative;
     }
-    details.email-source > summary {
-      cursor: pointer; padding: 12px 28px;
-      font-family: var(--font-mono); font-size: 12px; color: var(--fg-muted);
-      list-style: none; display: flex; align-items: center; gap: 8px;
-      background: var(--bg);
+    .tile-preview .tile-wm {
+      font-family: var(--font-display); font-weight: 600;
+      font-size: 22px; letter-spacing: -0.02em; line-height: 1;
     }
-    details.email-source > summary::-webkit-details-marker { display: none; }
-    details.email-source > summary::before {
-      content: "▸"; transition: transform 140ms; color: var(--fg-subtle);
+    .tile-preview .tile-wm .ta  { color: #6366F1; }
+    .tile-preview .tile-wm .hyp { color: rgba(17,24,39,0.30); margin: 0 1px; }
+    .tile-preview .tile-wm .da  { color: #F59E0B; }
+    .tile-preview .tile-wm .ify { color: #111827; }
+    .tile-preview .tile-token {
+      font-family: var(--font-display); font-weight: 600;
+      font-size: 32px; letter-spacing: 0.16em; color: #111827;
+      padding: 10px 18px;
+      background: linear-gradient(135deg, rgba(99,102,241,0.06), rgba(245,158,11,0.05));
+      border: 1.5px solid rgba(99,102,241,0.18);
+      border-radius: 10px;
+      font-feature-settings: "tnum","lnum";
     }
-    details.email-source[open] > summary::before { transform: rotate(90deg); }
-    details.email-source > summary:hover { background: var(--bg-muted); color: var(--fg); }
-    .source-tabs { display: flex; gap: 0; border-top: 1px solid var(--border); background: var(--bg-muted); padding: 0 28px; }
-    .source-tabs button {
-      background: transparent; border: 0; padding: 10px 14px;
-      font-family: var(--font-mono); font-size: 12px; color: var(--fg-muted);
-      cursor: pointer; border-bottom: 2px solid transparent;
+    .tile-preview .tile-caption {
+      font-size: 11px; color: var(--fg-muted); font-weight: 500;
+      letter-spacing: 0.04em; text-transform: uppercase;
     }
-    .source-tabs button.active { color: var(--brand-primary); border-bottom-color: var(--brand-primary); }
-    .source-pre {
-      margin: 0; padding: 16px 28px 20px;
-      background: #0B0F1E; color: #E5E7EB;
-      font-family: var(--font-mono); font-size: 11px; line-height: 1.55;
-      overflow-x: auto; max-height: 480px; overflow-y: auto;
-      white-space: pre; tab-size: 2;
+
+    .tile-info {
+      padding: 18px 22px 22px;
+      flex: 1; display: flex; flex-direction: column; gap: 6px;
     }
+    .tile-info .filename {
+      font-family: var(--font-mono); font-size: 12px;
+      color: var(--fg-subtle); margin-bottom: 4px;
+    }
+    .tile-info h3 {
+      font-family: var(--font-display); font-weight: 600;
+      font-size: 20px; letter-spacing: -0.02em; margin: 0;
+    }
+    .tile-info p { color: var(--fg-muted); font-size: 13px; line-height: 1.55; margin: 4px 0 0; }
+    .tile-info .badge-row { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 10px; }
+    .tile-info .badge-row .pill { font-size: 11px; padding: 3px 9px; }
+
+    /* Phase 2 placeholder */
+    .tile.disabled {
+      opacity: 0.6;
+      pointer-events: none;
+      background:
+        repeating-linear-gradient(135deg, var(--bg-elevated) 0 12px, var(--bg-muted) 12px 14px);
+      border-style: dashed;
+    }
+    .tile.disabled .tile-preview {
+      background: var(--bg-muted);
+      color: var(--fg-subtle);
+      font-family: var(--font-display); font-size: 18px;
+      padding: 24px;
+    }
+    .tile.disabled .tile-preview .tile-wm { opacity: 0.4; }
+    .tile.disabled .tile-preview .tile-token {
+      background: var(--bg-elevated); border-color: var(--border-strong);
+      color: var(--fg-subtle); font-size: 22px; letter-spacing: 0.10em;
+    }
+    .tile.disabled .tile-info h3 { color: var(--fg-muted); }
 
     /* Footer */
-    .gallery-footer {
-      max-width: 880px; margin: 48px auto 32px;
-      padding: 0 clamp(16px,4vw,32px);
-      text-align: center; font-size: 13px; color: var(--fg-subtle);
+    .ref-strip {
+      max-width: 1080px; margin: 32px auto 0; padding: 0 24px;
+    }
+    .ref-card {
+      padding: 22px 26px;
+      background: var(--bg-elevated);
+      border: 1px solid var(--border);
+      border-left: 4px solid var(--brand-warm);
+      border-radius: var(--radius-md);
+      box-shadow: var(--shadow-sm);
+    }
+    .ref-card h3 {
+      font-family: var(--font-sans); font-size: 12px; font-weight: 700;
+      letter-spacing: 0.08em; text-transform: uppercase;
+      color: var(--brand-warm-dark); margin: 0 0 10px;
+    }
+    .ref-card ul { margin: 0; padding-left: 20px; }
+    .ref-card li { font-size: 14px; color: var(--fg); padding: 2px 0; }
+    .ref-card li code {
+      font-family: var(--font-mono); font-size: 12px;
+      background: var(--bg-muted); padding: 1px 6px; border-radius: 4px;
     }
 
-    /* Mobile */
-    @media (max-width: 720px) {
-      .email-card-toolbar { padding: 10px 16px; }
-      .email-card-header { padding: 16px 20px; }
-      .email-stage { padding: 16px 8px; }
-      .source-tabs, .source-pre { padding-left: 16px; padding-right: 16px; }
+    .legacy-note {
+      max-width: 1080px; margin: 24px auto 0; padding: 0 24px;
+      font-size: 13px; color: var(--fg-muted);
+    }
+    .legacy-note a { color: var(--brand-primary); }
+
+    .footer-meta {
+      max-width: 1080px; margin: 48px auto 0; padding: 32px 24px 0;
+      border-top: 1px solid var(--border);
+      font-size: 12px; color: var(--fg-subtle);
+      font-family: var(--font-mono);
     }
   </style>
 </head>
 <body>
+  <header class="header">
+    <span class="pill pill-primary">Phase 1 · auth email templates</span>
+    <h1>
+      <span class="wm">
+        <span class="ta">ta</span><span class="hyp">-</span><span class="da">da!</span><span class="ify">ify</span>
+      </span>
+      <br/>email mockups
+    </h1>
+    <p class="lead">Branded HTML emails sent by Supabase Auth in local dev (Inbucket on <code>localhost:54354</code>) and by Resend in production. Phase 1 ships the two OTP-only templates needed by the locked Slice B register + login flow.</p>
 
-  <header class="gallery-header">
-    <span class="brand"><span class="ta">ta</span><span class="hyp">!</span><span class="da">da</span><span class="ify">ify</span></span>
-    <h1>Email gallery · 10 templates</h1>
-    <div class="gallery-toolbar">
-      <span style="font-size:12px;font-weight:600;color:var(--fg-muted);text-transform:uppercase;letter-spacing:0.06em;">All previews:</span>
-      <div class="toggle-group" id="globalThemeToggle" role="tablist" aria-label="Theme preview">
-        <button data-mode="light" class="active" type="button">☀ Light</button>
-        <button data-mode="dark" type="button">☾ Dark</button>
-      </div>
-      <div class="toggle-group" id="globalSizeToggle" role="tablist" aria-label="Size preview">
-        <button data-size="desktop" class="active" type="button">🖥 Desktop</button>
-        <button data-size="mobile" type="button">📱 Mobile</button>
-      </div>
+    <div class="meta-row">
+      <span class="pill-muted pill">issue #150</span>
+      <span class="pill-muted pill">DEC-291 / DEC-294 / DEC-295 / DEC-306 / DEC-307</span>
+      <span class="pill-muted pill">TR-tadaify-002</span>
+      <span class="pill-muted pill">brand: indigo serif</span>
     </div>
   </header>
 
-  <section class="gallery-intro">
-    <h2>tadaify in inboxes</h2>
-    <p>
-      10 transactional email templates &mdash; the only place tadaify reaches users outside the app. Each card below shows the rendered preview, lets you toggle light/dark and desktop/mobile, view the production HTML, and copy it for direct paste into the prod codebase.
-    </p>
-    <div class="meta-pills">
-      <span class="pill pill-primary">4 Supabase Auth</span>
-      <span class="pill pill-warm">6 Resend custom</span>
-      <span class="pill">All have plain-text twin (.txt)</span>
-      <span class="pill">Inline CSS · Outlook-safe · WCAG AA</span>
+  <!-- ===================================================================
+       PHASE 1 — ships now
+       =================================================================== -->
+  <section class="section">
+    <div class="section-inner">
+      <h2>Phase 1 — OTP-only (this PR)</h2>
+      <p class="section-sub">Two templates wired into <code>supabase/config.toml</code>: the signup slot and the magic_link slot (which Supabase reuses for OTP-only login). Single CTA in each: a 6-digit code. No <code>{{ .ConfirmationURL }}</code> button. No password setup link.</p>
+
+      <div class="tile-grid">
+
+        <a class="tile" href="./otp-signup.html">
+          <div class="tile-preview">
+            <span class="tile-wm">
+              <span class="ta">ta</span><span class="hyp">-</span><span class="da">da!</span><span class="ify">ify</span>
+            </span>
+            <div class="tile-token">184629</div>
+            <span class="tile-caption">code expires in 10 min</span>
+          </div>
+          <div class="tile-info">
+            <span class="filename">otp-signup.html</span>
+            <h3>Signup OTP</h3>
+            <p>Sent immediately after a new user submits the register form. Greeting: <code>Hey @handle 👋</code>. Subject: <code>Your tadaify code: {{ .Token }}</code>.</p>
+            <div class="badge-row">
+              <span class="pill pill-primary">new user</span>
+              <span class="pill pill-success">light + dark client</span>
+              <span class="pill">multipart</span>
+            </div>
+          </div>
+        </a>
+
+        <a class="tile" href="./otp-login.html">
+          <div class="tile-preview">
+            <span class="tile-wm">
+              <span class="ta">ta</span><span class="hyp">-</span><span class="da">da!</span><span class="ify">ify</span>
+            </span>
+            <div class="tile-token">502718</div>
+            <span class="tile-caption">code expires in 10 min</span>
+          </div>
+          <div class="tile-info">
+            <span class="filename">otp-login.html</span>
+            <h3>Login OTP</h3>
+            <p>Sent on returning-user sign-in (DEC-307 path). Greeting: <code>Welcome back, @handle</code>. Subject: <code>Sign in to tadaify: {{ .Token }}</code>. Adds a non-clickable device card.</p>
+            <div class="badge-row">
+              <span class="pill pill-warm">returning user</span>
+              <span class="pill pill-success">light + dark client</span>
+              <span class="pill">multipart</span>
+            </div>
+          </div>
+        </a>
+
+        <a class="tile" href="./_email-tokens-preview.html">
+          <div class="tile-preview">
+            <span class="tile-wm">
+              <span class="ta">ta</span><span class="hyp">-</span><span class="da">da!</span><span class="ify">ify</span>
+            </span>
+            <div class="tile-token" style="font-size:24px;">A | B</div>
+            <span class="tile-caption">side-by-side compare</span>
+          </div>
+          <div class="tile-info">
+            <span class="filename">_email-tokens-preview.html</span>
+            <h3>Side-by-side compare</h3>
+            <p>Both templates rendered next to each other plus a diff table — what differs (subject, greeting, copy, device card) and what stays identical (token, trust strip, dark-mode treatment).</p>
+            <div class="badge-row">
+              <span class="pill">helper view</span>
+              <span class="pill pill-primary">diff annotations</span>
+            </div>
+          </div>
+        </a>
+      </div>
     </div>
   </section>
 
-  <nav class="toc" aria-label="Templates">
-    <div class="toc-grid">
-      <a class="toc-link" href="#email-1"><span class="num">01</span>Confirm signup<span class="stack sb">Supabase</span></a>
-      <a class="toc-link" href="#email-2"><span class="num">02</span>Magic link<span class="stack sb">Supabase</span></a>
-      <a class="toc-link" href="#email-3"><span class="num">03</span>Reset password<span class="stack sb">Supabase</span></a>
-      <a class="toc-link" href="#email-4"><span class="num">04</span>Change email<span class="stack sb">Supabase</span></a>
-      <a class="toc-link" href="#email-5"><span class="num">05</span>Team invite<span class="stack rs">Resend</span></a>
-      <a class="toc-link" href="#email-6"><span class="num">06</span>GDPR export ready<span class="stack rs">Resend</span></a>
-      <a class="toc-link" href="#email-7"><span class="num">07</span>Subscription cancelled<span class="stack rs">Resend</span></a>
-      <a class="toc-link" href="#email-8"><span class="num">08</span>Payment failed<span class="stack rs">Resend</span></a>
-      <a class="toc-link" href="#email-9"><span class="num">09</span>Handle change confirm<span class="stack rs">Resend</span></a>
-      <a class="toc-link" href="#email-10"><span class="num">10</span>Waitlist promote<span class="stack rs">Resend</span></a>
+  <!-- ===================================================================
+       PHASE 2 — placeholder tiles
+       =================================================================== -->
+  <section class="section">
+    <div class="section-inner">
+      <h2>Phase 2 — coming as features ship</h2>
+      <p class="section-sub">Mockups for these arrive when the feature each one supports lands on the board. Not blocking the Phase 1 wiring.</p>
+
+      <div class="tile-grid">
+
+        <div class="tile disabled" aria-disabled="true">
+          <div class="tile-preview">
+            <span class="tile-wm">
+              <span class="ta">ta</span><span class="hyp">-</span><span class="da">da!</span><span class="ify">ify</span>
+            </span>
+            <div class="tile-token">— — — — — —</div>
+            <span class="tile-caption">phase 2 · not yet drafted</span>
+          </div>
+          <div class="tile-info">
+            <span class="filename">password-reset.html</span>
+            <h3>Password reset</h3>
+            <p>Sent when a user requests a password-reset code. Lands with F-AUTH-PASSWORD-RESET (post-MVP per DEC-295=A).</p>
+            <div class="badge-row"><span class="pill">phase 2</span></div>
+          </div>
+        </div>
+
+        <div class="tile disabled" aria-disabled="true">
+          <div class="tile-preview">
+            <span class="tile-wm">
+              <span class="ta">ta</span><span class="hyp">-</span><span class="da">da!</span><span class="ify">ify</span>
+            </span>
+            <div class="tile-token">— — — — — —</div>
+            <span class="tile-caption">phase 2 · not yet drafted</span>
+          </div>
+          <div class="tile-info">
+            <span class="filename">email-change-confirm.html</span>
+            <h3>Email change confirm</h3>
+            <p>Sent to the new address when a user updates their account email. Lands with the Settings → email-change feature.</p>
+            <div class="badge-row"><span class="pill">phase 2</span></div>
+          </div>
+        </div>
+
+        <div class="tile disabled" aria-disabled="true">
+          <div class="tile-preview">
+            <span class="tile-wm">
+              <span class="ta">ta</span><span class="hyp">-</span><span class="da">da!</span><span class="ify">ify</span>
+            </span>
+            <div class="tile-token" style="font-size:18px;">linked ✓</div>
+            <span class="tile-caption">phase 2 · not yet drafted</span>
+          </div>
+          <div class="tile-info">
+            <span class="filename">identity-linked.html</span>
+            <h3>Identity linked</h3>
+            <p>Confirmation email when a third-party identity (X / Google / Apple) is auto-linked per DEC-293. Ships with OAuth Slice.</p>
+            <div class="badge-row"><span class="pill">phase 2</span></div>
+          </div>
+        </div>
+
+        <div class="tile disabled" aria-disabled="true">
+          <div class="tile-preview">
+            <span class="tile-wm">
+              <span class="ta">ta</span><span class="hyp">-</span><span class="da">da!</span><span class="ify">ify</span>
+            </span>
+            <div class="tile-token" style="font-size:18px;">welcome 🎉</div>
+            <span class="tile-caption">phase 2 · not yet drafted</span>
+          </div>
+          <div class="tile-info">
+            <span class="filename">welcome.html</span>
+            <h3>Welcome</h3>
+            <p>Sent on first login after onboarding completion. Surfaces handle + profile URL. Ships with Slice C (#136-#139).</p>
+            <div class="badge-row"><span class="pill">phase 2</span></div>
+          </div>
+        </div>
+
+      </div>
     </div>
-  </nav>
+  </section>
 
-  <!-- Template card factory: rendered via JS at bottom -->
-  <main id="emails"></main>
+  <p class="legacy-note">
+    Older transactional email gallery (10 templates: signup verify, magic link, reset, invite, payment-failed, etc.) lives at
+    <a href="./legacy-gallery.html">legacy-gallery.html</a> — predates the Slice B OTP-only contract and is being superseded as each Phase 1/2 mockup lands.
+  </p>
 
-  <footer class="gallery-footer">
-    <p>tadaify email templates · brand canon: Indigo Serif (locked 2026-04-24)</p>
-    <p style="margin-top:8px;">
-      Files: <code style="font-family:var(--font-mono);">supabase-auth/*.html</code> &middot;
-      <code style="font-family:var(--font-mono);">resend/*.html</code> &middot;
-      see <a href="./README.md">README.md</a> for integration.
-    </p>
-  </footer>
+  <div class="ref-strip">
+    <div class="ref-card">
+      <h3>Slice B contract these mockups demonstrate</h3>
+      <ul>
+        <li><strong>OTP-only:</strong> exactly one CTA per email — the 6-digit code. No magic link, no <code>{{ .ConfirmationURL }}</code> button (DEC-294).</li>
+        <li><strong>Multipart MIME:</strong> every template ships <code>text/html</code> + <code>text/plain</code> alternative parts (TR-tadaify-002).</li>
+        <li><strong>No external assets:</strong> wordmark is styled text; trust strip is unicode emoji + text. Email body fetches no font / no image CDN (ECN-150-02).</li>
+        <li><strong>Dark-mode parity:</strong> Apple Mail dark / Gmail dark render kept readable via the dark variant block in each template (ECN-150-03).</li>
+        <li><strong>Token disambiguation:</strong> Crimson Pro display + <code>font-feature-settings: "tnum","lnum"</code> so 0/O and 1/l/I read cleanly (ECN-150-06).</li>
+        <li><strong>config.toml wiring:</strong> signup → <code>[auth.email.template.signup]</code>; login OTP → <code>[auth.email.template.magic_link]</code> (Supabase reuses that slot for OTP-only login).</li>
+        <li><strong>Trust strip:</strong> 🔒 Price locked for life · 💸 30-day money-back · 🛡 GDPR-compliant — same chips that appear under the register form on <a href="../register.html">register.html</a>.</li>
+      </ul>
+    </div>
+  </div>
 
-  <script>
-    // --- Template registry --------------------------------------------------
-    const TEMPLATES = [
-      {
-        id: 1, stack: "supabase",
-        slug: "verify-signup",
-        path: "./supabase-auth/verify-signup.html",
-        textPath: "./supabase-auth/verify-signup.txt",
-        subject: "Confirm your tadaify account",
-        preheader: "Tap once to confirm your email and start building your tadaify page. Link expires in 24 hours.",
-        from: "tadaify <noreply@tadaify.com>",
-      },
-      {
-        id: 2, stack: "supabase",
-        slug: "magic-link",
-        path: "./supabase-auth/magic-link.html",
-        textPath: "./supabase-auth/magic-link.txt",
-        subject: "Your tadaify magic login link",
-        preheader: "Tap once to sign in to tadaify. Or paste this 6-digit code. Expires in 1 hour.",
-        from: "tadaify <noreply@tadaify.com>",
-      },
-      {
-        id: 3, stack: "supabase",
-        slug: "reset-password",
-        path: "./supabase-auth/reset-password.html",
-        textPath: "./supabase-auth/reset-password.txt",
-        subject: "Reset your tadaify password",
-        preheader: "Reset your tadaify password. Link expires in 1 hour. Didn't request this? You can safely ignore this email.",
-        from: "tadaify <security@tadaify.com>",
-      },
-      {
-        id: 4, stack: "supabase",
-        slug: "change-email",
-        path: "./supabase-auth/change-email.html",
-        textPath: "./supabase-auth/change-email.txt",
-        subject: "Confirm your new email address",
-        preheader: "Confirm the email change. Both addresses must confirm. Link expires in 24 hours.",
-        from: "tadaify <security@tadaify.com>",
-      },
-      {
-        id: 5, stack: "resend",
-        slug: "team-invite",
-        path: "./resend/team-invite.html",
-        textPath: "./resend/team-invite.txt",
-        subject: "Sarah invited you to join Acme Studio on tadaify",
-        preheader: "Sarah invited you to join Acme Studio as Editor on tadaify. Accept by May 3.",
-        from: "tadaify <invites@tadaify.com>",
-      },
-      {
-        id: 6, stack: "resend",
-        slug: "gdpr-export-ready",
-        path: "./resend/gdpr-export-ready.html",
-        textPath: "./resend/gdpr-export-ready.txt",
-        subject: "Your tadaify data export is ready",
-        preheader: "Your data export is ready. Download within 7 days. Size: 2.4 MB.",
-        from: "tadaify <privacy@tadaify.com>",
-      },
-      {
-        id: 7, stack: "resend",
-        slug: "subscription-cancelled",
-        path: "./resend/subscription-cancelled.html",
-        textPath: "./resend/subscription-cancelled.txt",
-        subject: "Your tadaify subscription is cancelled (until May 27)",
-        preheader: "Your subscription is cancelled but @yourhandle stays live until May 27. Reactivate anytime to keep your locked-for-life price.",
-        from: "tadaify <billing@tadaify.com>",
-      },
-      {
-        id: 8, stack: "resend",
-        slug: "payment-failed",
-        path: "./resend/payment-failed.html",
-        textPath: "./resend/payment-failed.txt",
-        subject: "Payment for tadaify failed — please update your card",
-        preheader: "Payment for $5.00 didn't go through. Update your card before May 27 to keep your page live.",
-        from: "tadaify <billing@tadaify.com>",
-      },
-      {
-        id: 9, stack: "resend",
-        slug: "handle-change-confirm",
-        path: "./resend/handle-change-confirm.html",
-        textPath: "./resend/handle-change-confirm.txt",
-        subject: "You changed your tadaify handle: oldhandle → newhandle",
-        preheader: "Your handle changed: @oldhandle → @newhandle. Old links redirect for 30 days. Undo within 1h if this wasn't you.",
-        from: "tadaify <security@tadaify.com>",
-      },
-      {
-        id: 10, stack: "resend",
-        slug: "waitlist-promote",
-        path: "./resend/waitlist-promote.html",
-        textPath: "./resend/waitlist-promote.txt",
-        subject: "Your tadaify spot is ready! 🎉",
-        preheader: "Your tadaify handle @yourhandle is reserved. Finalize within 7 days to claim it.",
-        from: "tadaify <hello@tadaify.com>",
-      },
-    ];
-
-    const stackLabel = (s) => s === "supabase" ? "Supabase Auth" : "Resend";
-    const stackPillCls = (s) => s === "supabase" ? "sb" : "rs";
-
-    // --- Render -------------------------------------------------------------
-    const root = document.getElementById("emails");
-    TEMPLATES.forEach((t) => {
-      const card = document.createElement("section");
-      card.className = "email-card";
-      card.id = `email-${t.id}`;
-      card.dataset.slug = t.slug;
-      card.innerHTML = `
-        <header class="email-card-header">
-          <div class="email-meta-row">
-            <span class="email-num">#${String(t.id).padStart(2,'0')}</span>
-            <span class="email-stack-pill ${stackPillCls(t.stack)}">${stackLabel(t.stack)}</span>
-            <span class="email-filename">${t.path}</span>
-            <span class="email-filename" style="color:var(--fg-subtle);">From: ${t.from}</span>
-          </div>
-          <div class="email-subject">${t.subject}</div>
-          <div class="email-preheader">${t.preheader}</div>
-        </header>
-
-        <div class="email-card-toolbar">
-          <button class="small-toggle theme active" type="button" data-mode="light">☀ Light</button>
-          <button class="small-toggle theme" type="button" data-mode="dark">☾ Dark</button>
-          <span style="width:8px;"></span>
-          <button class="small-toggle size active" type="button" data-size="desktop">🖥 Desktop</button>
-          <button class="small-toggle size" type="button" data-size="mobile">📱 Mobile (375px)</button>
-          <button class="copy-btn" type="button" data-copy="html">📋 Copy HTML</button>
-          <button class="copy-btn" type="button" data-copy="text" style="background:var(--brand-warm);color:#1F2937;">📋 Copy .txt</button>
-        </div>
-
-        <div class="email-stage">
-          <iframe class="email-iframe" src="${t.path}" title="${t.subject} preview" loading="lazy"></iframe>
-        </div>
-
-        <details class="email-source">
-          <summary>View source · HTML + plain-text twin</summary>
-          <div class="source-tabs">
-            <button class="active" data-tab="html" type="button">${t.slug}.html</button>
-            <button data-tab="text" type="button">${t.slug}.txt</button>
-          </div>
-          <pre class="source-pre" data-pane="html">Loading ${t.path} …</pre>
-          <pre class="source-pre" data-pane="text" hidden>Loading ${t.textPath} …</pre>
-        </details>
-      `;
-      root.appendChild(card);
-
-      // --- Wire toolbar within this card -------------------------------------
-      const stage = card.querySelector(".email-stage");
-      const iframe = card.querySelector(".email-iframe");
-      const themeBtns = card.querySelectorAll(".small-toggle.theme");
-      const sizeBtns = card.querySelectorAll(".small-toggle.size");
-
-      themeBtns.forEach((b) => b.addEventListener("click", () => {
-        themeBtns.forEach((x) => x.classList.remove("active"));
-        b.classList.add("active");
-        const mode = b.dataset.mode;
-        stage.classList.toggle("dark", mode === "dark");
-        // Force re-render iframe with prefers-color-scheme via colorScheme attr fallback
-        try {
-          const doc = iframe.contentDocument;
-          if (doc && doc.documentElement) {
-            doc.documentElement.style.colorScheme = mode;
-            // Add a marker so @media (prefers-color-scheme: dark) approximation visible:
-            // Simulate by toggling a class — emails use prefers-color-scheme so we paint stage bg only.
-          }
-        } catch (e) { /* cross-origin or not loaded yet */ }
-      }));
-
-      sizeBtns.forEach((b) => b.addEventListener("click", () => {
-        sizeBtns.forEach((x) => x.classList.remove("active"));
-        b.classList.add("active");
-        iframe.classList.toggle("mobile", b.dataset.size === "mobile");
-      }));
-
-      // --- Source loading + tabs --------------------------------------------
-      const tabBtns = card.querySelectorAll(".source-tabs button");
-      const htmlPane = card.querySelector('.source-pre[data-pane="html"]');
-      const textPane = card.querySelector('.source-pre[data-pane="text"]');
-      let htmlSrc = null, textSrc = null;
-      const loadOnce = () => {
-        if (htmlSrc !== null) return;
-        fetch(t.path).then(r => r.text()).then(s => {
-          htmlSrc = s;
-          htmlPane.textContent = s;
-        }).catch(e => { htmlPane.textContent = `[Could not load ${t.path}]\n${e}\n\nIf running over file://, your browser may block fetch — open via a local server (e.g. \`python3 -m http.server\` from the mockups dir) to view source.`; });
-        fetch(t.textPath).then(r => r.text()).then(s => {
-          textSrc = s;
-          textPane.textContent = s;
-        }).catch(e => { textPane.textContent = `[Could not load ${t.textPath}]\n${e}`; });
-      };
-      card.querySelector("details.email-source").addEventListener("toggle", (e) => { if (e.target.open) loadOnce(); });
-
-      tabBtns.forEach((b) => b.addEventListener("click", () => {
-        tabBtns.forEach((x) => x.classList.remove("active"));
-        b.classList.add("active");
-        const which = b.dataset.tab;
-        htmlPane.hidden = which !== "html";
-        textPane.hidden = which !== "text";
-      }));
-
-      // --- Copy buttons ------------------------------------------------------
-      card.querySelectorAll(".copy-btn").forEach((b) => b.addEventListener("click", async () => {
-        const which = b.dataset.copy;
-        const url = which === "html" ? t.path : t.textPath;
-        try {
-          const res = await fetch(url);
-          const text = await res.text();
-          await navigator.clipboard.writeText(text);
-          const orig = b.textContent;
-          b.classList.add("ok");
-          b.textContent = "✓ Copied";
-          setTimeout(() => { b.classList.remove("ok"); b.textContent = orig; }, 1600);
-        } catch (e) {
-          alert(`Could not copy ${url}.\nIf running on file://, browsers may block fetch + clipboard. Open this gallery via \`python3 -m http.server\` for full functionality, or copy from disk: ${url}`);
-        }
-      }));
-    });
-
-    // --- Global toggles drive every card -----------------------------------
-    document.querySelectorAll("#globalThemeToggle button").forEach((b) => {
-      b.addEventListener("click", () => {
-        document.querySelectorAll("#globalThemeToggle button").forEach((x) => x.classList.remove("active"));
-        b.classList.add("active");
-        const mode = b.dataset.mode;
-        document.querySelectorAll(".email-card").forEach((card) => {
-          const target = card.querySelector(`.small-toggle.theme[data-mode="${mode}"]`);
-          if (target && !target.classList.contains("active")) target.click();
-        });
-      });
-    });
-    document.querySelectorAll("#globalSizeToggle button").forEach((b) => {
-      b.addEventListener("click", () => {
-        document.querySelectorAll("#globalSizeToggle button").forEach((x) => x.classList.remove("active"));
-        b.classList.add("active");
-        const size = b.dataset.size;
-        document.querySelectorAll(".email-card").forEach((card) => {
-          const target = card.querySelector(`.small-toggle.size[data-size="${size}"]`);
-          if (target && !target.classList.contains("active")) target.click();
-        });
-      });
-    });
-  </script>
+  <p class="footer-meta">
+    Mockup-only PR · status:needs-work · awaiting user accept before implementation kicks in on supabase/templates/auth/.
+  </p>
 </body>
 </html>

--- a/mockups/tadaify-mvp/emails/legacy-gallery.html
+++ b/mockups/tadaify-mvp/emails/legacy-gallery.html
@@ -1,0 +1,480 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>tadaify — Email templates gallery</title>
+  <link rel="stylesheet" href="../shared/tokens.css">
+  <style>
+    /* --- Page chrome --- */
+    body { background: var(--bg-muted); }
+    .gallery-header {
+      position: sticky; top: 0; z-index: 100;
+      background: rgba(249,250,251,0.92);
+      backdrop-filter: saturate(180%) blur(12px);
+      border-bottom: 1px solid var(--border);
+      padding: 14px clamp(16px,4vw,32px);
+      display: flex; align-items: center; gap: 16px; flex-wrap: wrap;
+    }
+    .gallery-header .brand { display: inline-flex; align-items: baseline; gap: 8px; font-family: var(--font-display); font-weight: 600; font-size: 22px; letter-spacing: -0.02em; }
+    .gallery-header .brand .ta { color: var(--brand-primary); }
+    .gallery-header .brand .hyp { color: var(--wm-hyphen); margin: 0 1px; }
+    .gallery-header .brand .da { color: var(--brand-warm); }
+    .gallery-header .brand .ify { color: var(--fg); }
+    .gallery-header h1 {
+      font-family: var(--font-sans); font-size: 14px; font-weight: 600;
+      letter-spacing: 0.06em; text-transform: uppercase; color: var(--fg-muted);
+      margin-left: 4px;
+    }
+    .gallery-toolbar { margin-left: auto; display: inline-flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+    .toggle-group { display: inline-flex; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: var(--radius-full); padding: 3px; gap: 0; }
+    .toggle-group button {
+      border: 0; background: transparent; padding: 6px 14px;
+      font-size: 13px; font-weight: 600; color: var(--fg-muted);
+      border-radius: var(--radius-full); cursor: pointer;
+      transition: background 140ms, color 140ms;
+    }
+    .toggle-group button.active { background: var(--brand-primary); color: #FFF; }
+    .toggle-group button:hover:not(.active) { background: var(--bg-muted); color: var(--fg); }
+
+    .gallery-intro {
+      max-width: 880px; margin: 32px auto 16px;
+      padding: 0 clamp(16px,4vw,32px);
+    }
+    .gallery-intro h2 { font-size: 32px; margin-bottom: 8px; }
+    .gallery-intro p { color: var(--fg-muted); font-size: 16px; line-height: 1.6; }
+    .gallery-intro .meta-pills { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 16px; }
+
+    .toc {
+      max-width: 880px; margin: 0 auto 32px;
+      padding: 0 clamp(16px,4vw,32px);
+    }
+    .toc-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px,1fr)); gap: 8px; }
+    .toc-link {
+      display: block; padding: 10px 14px; background: var(--bg-elevated);
+      border: 1px solid var(--border); border-radius: var(--radius);
+      font-size: 13px; color: var(--fg); text-decoration: none;
+      transition: border 120ms, transform 120ms;
+    }
+    .toc-link:hover { border-color: var(--brand-primary); transform: translateY(-1px); }
+    .toc-link .num { color: var(--fg-subtle); font-family: var(--font-mono); font-size: 11px; margin-right: 8px; }
+    .toc-link .stack { display: inline-block; margin-left: 8px; padding: 1px 6px; font-size: 10px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; border-radius: 4px; }
+    .toc-link .stack.sb { background: rgba(99,102,241,0.12); color: var(--brand-primary); }
+    .toc-link .stack.rs { background: rgba(245,158,11,0.15); color: #92400E; }
+
+    /* --- Email card --- */
+    .email-card {
+      max-width: 880px; margin: 32px auto;
+      background: var(--bg-elevated);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-lg);
+      box-shadow: var(--shadow);
+      overflow: hidden;
+    }
+    .email-card-header {
+      padding: 20px 28px;
+      border-bottom: 1px solid var(--border);
+      background: var(--bg-muted);
+    }
+    .email-meta-row { display: flex; flex-wrap: wrap; gap: 12px 24px; align-items: baseline; margin-bottom: 6px; }
+    .email-num { font-family: var(--font-mono); font-size: 12px; color: var(--fg-subtle); }
+    .email-stack-pill { font-size: 10px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; padding: 2px 8px; border-radius: 4px; }
+    .email-stack-pill.sb { background: rgba(99,102,241,0.12); color: var(--brand-primary); }
+    .email-stack-pill.rs { background: rgba(245,158,11,0.15); color: #92400E; }
+    .email-filename { font-family: var(--font-mono); font-size: 12px; color: var(--fg-muted); }
+
+    .email-subject { font-family: var(--font-display); font-size: 22px; font-weight: 600; color: var(--fg); letter-spacing: -0.01em; margin-top: 6px; }
+    .email-preheader { font-size: 13px; color: var(--fg-subtle); margin-top: 4px; font-style: italic; }
+
+    .email-card-toolbar {
+      display: flex; flex-wrap: wrap; gap: 8px;
+      padding: 12px 28px; background: var(--bg);
+      border-bottom: 1px solid var(--border);
+    }
+    .email-card-toolbar .small-toggle {
+      font-size: 12px; font-weight: 600; padding: 5px 11px;
+      background: var(--bg-elevated); border: 1px solid var(--border-strong);
+      border-radius: var(--radius-full); color: var(--fg-muted);
+      cursor: pointer; transition: background 120ms, color 120ms, border-color 120ms;
+    }
+    .email-card-toolbar .small-toggle.active {
+      background: var(--brand-primary); color: #FFF; border-color: var(--brand-primary);
+    }
+    .email-card-toolbar .small-toggle:hover:not(.active) { background: var(--bg-muted); color: var(--fg); }
+    .email-card-toolbar .copy-btn {
+      margin-left: auto; font-size: 12px; font-weight: 600;
+      background: var(--fg); color: var(--fg-inverse);
+      border: 0; padding: 6px 14px; border-radius: var(--radius-full); cursor: pointer;
+      display: inline-flex; align-items: center; gap: 6px;
+    }
+    .email-card-toolbar .copy-btn:hover { background: var(--brand-primary); }
+    .email-card-toolbar .copy-btn.ok { background: var(--success); }
+
+    /* Iframe stage */
+    .email-stage {
+      padding: 24px;
+      background: repeating-linear-gradient(45deg, transparent 0, transparent 12px, rgba(17,24,39,0.02) 12px, rgba(17,24,39,0.02) 13px), var(--bg-muted);
+      display: flex; justify-content: center;
+      transition: background 200ms;
+    }
+    .email-stage.dark { background: var(--bg-dark); }
+    .email-iframe {
+      border: 1px solid var(--border-strong);
+      background: #FFF;
+      width: 100%;
+      max-width: 640px;
+      min-height: 600px;
+      transition: max-width 220ms ease, min-height 220ms ease;
+      box-shadow: var(--shadow-lg);
+      border-radius: 6px;
+    }
+    .email-iframe.mobile { max-width: 375px; }
+    .email-stage.dark .email-iframe { border-color: #1F2937; box-shadow: 0 12px 32px rgba(0,0,0,0.5); }
+
+    /* Source view */
+    details.email-source {
+      margin: 0; padding: 0;
+      border-top: 1px solid var(--border);
+    }
+    details.email-source > summary {
+      cursor: pointer; padding: 12px 28px;
+      font-family: var(--font-mono); font-size: 12px; color: var(--fg-muted);
+      list-style: none; display: flex; align-items: center; gap: 8px;
+      background: var(--bg);
+    }
+    details.email-source > summary::-webkit-details-marker { display: none; }
+    details.email-source > summary::before {
+      content: "▸"; transition: transform 140ms; color: var(--fg-subtle);
+    }
+    details.email-source[open] > summary::before { transform: rotate(90deg); }
+    details.email-source > summary:hover { background: var(--bg-muted); color: var(--fg); }
+    .source-tabs { display: flex; gap: 0; border-top: 1px solid var(--border); background: var(--bg-muted); padding: 0 28px; }
+    .source-tabs button {
+      background: transparent; border: 0; padding: 10px 14px;
+      font-family: var(--font-mono); font-size: 12px; color: var(--fg-muted);
+      cursor: pointer; border-bottom: 2px solid transparent;
+    }
+    .source-tabs button.active { color: var(--brand-primary); border-bottom-color: var(--brand-primary); }
+    .source-pre {
+      margin: 0; padding: 16px 28px 20px;
+      background: #0B0F1E; color: #E5E7EB;
+      font-family: var(--font-mono); font-size: 11px; line-height: 1.55;
+      overflow-x: auto; max-height: 480px; overflow-y: auto;
+      white-space: pre; tab-size: 2;
+    }
+
+    /* Footer */
+    .gallery-footer {
+      max-width: 880px; margin: 48px auto 32px;
+      padding: 0 clamp(16px,4vw,32px);
+      text-align: center; font-size: 13px; color: var(--fg-subtle);
+    }
+
+    /* Mobile */
+    @media (max-width: 720px) {
+      .email-card-toolbar { padding: 10px 16px; }
+      .email-card-header { padding: 16px 20px; }
+      .email-stage { padding: 16px 8px; }
+      .source-tabs, .source-pre { padding-left: 16px; padding-right: 16px; }
+    }
+  </style>
+</head>
+<body>
+
+  <header class="gallery-header">
+    <span class="brand"><span class="ta">ta</span><span class="hyp">!</span><span class="da">da</span><span class="ify">ify</span></span>
+    <h1>Email gallery · 10 templates</h1>
+    <div class="gallery-toolbar">
+      <span style="font-size:12px;font-weight:600;color:var(--fg-muted);text-transform:uppercase;letter-spacing:0.06em;">All previews:</span>
+      <div class="toggle-group" id="globalThemeToggle" role="tablist" aria-label="Theme preview">
+        <button data-mode="light" class="active" type="button">☀ Light</button>
+        <button data-mode="dark" type="button">☾ Dark</button>
+      </div>
+      <div class="toggle-group" id="globalSizeToggle" role="tablist" aria-label="Size preview">
+        <button data-size="desktop" class="active" type="button">🖥 Desktop</button>
+        <button data-size="mobile" type="button">📱 Mobile</button>
+      </div>
+    </div>
+  </header>
+
+  <section class="gallery-intro">
+    <h2>tadaify in inboxes</h2>
+    <p>
+      10 transactional email templates &mdash; the only place tadaify reaches users outside the app. Each card below shows the rendered preview, lets you toggle light/dark and desktop/mobile, view the production HTML, and copy it for direct paste into the prod codebase.
+    </p>
+    <div class="meta-pills">
+      <span class="pill pill-primary">4 Supabase Auth</span>
+      <span class="pill pill-warm">6 Resend custom</span>
+      <span class="pill">All have plain-text twin (.txt)</span>
+      <span class="pill">Inline CSS · Outlook-safe · WCAG AA</span>
+    </div>
+  </section>
+
+  <nav class="toc" aria-label="Templates">
+    <div class="toc-grid">
+      <a class="toc-link" href="#email-1"><span class="num">01</span>Confirm signup<span class="stack sb">Supabase</span></a>
+      <a class="toc-link" href="#email-2"><span class="num">02</span>Magic link<span class="stack sb">Supabase</span></a>
+      <a class="toc-link" href="#email-3"><span class="num">03</span>Reset password<span class="stack sb">Supabase</span></a>
+      <a class="toc-link" href="#email-4"><span class="num">04</span>Change email<span class="stack sb">Supabase</span></a>
+      <a class="toc-link" href="#email-5"><span class="num">05</span>Team invite<span class="stack rs">Resend</span></a>
+      <a class="toc-link" href="#email-6"><span class="num">06</span>GDPR export ready<span class="stack rs">Resend</span></a>
+      <a class="toc-link" href="#email-7"><span class="num">07</span>Subscription cancelled<span class="stack rs">Resend</span></a>
+      <a class="toc-link" href="#email-8"><span class="num">08</span>Payment failed<span class="stack rs">Resend</span></a>
+      <a class="toc-link" href="#email-9"><span class="num">09</span>Handle change confirm<span class="stack rs">Resend</span></a>
+      <a class="toc-link" href="#email-10"><span class="num">10</span>Waitlist promote<span class="stack rs">Resend</span></a>
+    </div>
+  </nav>
+
+  <!-- Template card factory: rendered via JS at bottom -->
+  <main id="emails"></main>
+
+  <footer class="gallery-footer">
+    <p>tadaify email templates · brand canon: Indigo Serif (locked 2026-04-24)</p>
+    <p style="margin-top:8px;">
+      Files: <code style="font-family:var(--font-mono);">supabase-auth/*.html</code> &middot;
+      <code style="font-family:var(--font-mono);">resend/*.html</code> &middot;
+      see <a href="./README.md">README.md</a> for integration.
+    </p>
+  </footer>
+
+  <script>
+    // --- Template registry --------------------------------------------------
+    const TEMPLATES = [
+      {
+        id: 1, stack: "supabase",
+        slug: "verify-signup",
+        path: "./supabase-auth/verify-signup.html",
+        textPath: "./supabase-auth/verify-signup.txt",
+        subject: "Confirm your tadaify account",
+        preheader: "Tap once to confirm your email and start building your tadaify page. Link expires in 24 hours.",
+        from: "tadaify <noreply@tadaify.com>",
+      },
+      {
+        id: 2, stack: "supabase",
+        slug: "magic-link",
+        path: "./supabase-auth/magic-link.html",
+        textPath: "./supabase-auth/magic-link.txt",
+        subject: "Your tadaify magic login link",
+        preheader: "Tap once to sign in to tadaify. Or paste this 6-digit code. Expires in 1 hour.",
+        from: "tadaify <noreply@tadaify.com>",
+      },
+      {
+        id: 3, stack: "supabase",
+        slug: "reset-password",
+        path: "./supabase-auth/reset-password.html",
+        textPath: "./supabase-auth/reset-password.txt",
+        subject: "Reset your tadaify password",
+        preheader: "Reset your tadaify password. Link expires in 1 hour. Didn't request this? You can safely ignore this email.",
+        from: "tadaify <security@tadaify.com>",
+      },
+      {
+        id: 4, stack: "supabase",
+        slug: "change-email",
+        path: "./supabase-auth/change-email.html",
+        textPath: "./supabase-auth/change-email.txt",
+        subject: "Confirm your new email address",
+        preheader: "Confirm the email change. Both addresses must confirm. Link expires in 24 hours.",
+        from: "tadaify <security@tadaify.com>",
+      },
+      {
+        id: 5, stack: "resend",
+        slug: "team-invite",
+        path: "./resend/team-invite.html",
+        textPath: "./resend/team-invite.txt",
+        subject: "Sarah invited you to join Acme Studio on tadaify",
+        preheader: "Sarah invited you to join Acme Studio as Editor on tadaify. Accept by May 3.",
+        from: "tadaify <invites@tadaify.com>",
+      },
+      {
+        id: 6, stack: "resend",
+        slug: "gdpr-export-ready",
+        path: "./resend/gdpr-export-ready.html",
+        textPath: "./resend/gdpr-export-ready.txt",
+        subject: "Your tadaify data export is ready",
+        preheader: "Your data export is ready. Download within 7 days. Size: 2.4 MB.",
+        from: "tadaify <privacy@tadaify.com>",
+      },
+      {
+        id: 7, stack: "resend",
+        slug: "subscription-cancelled",
+        path: "./resend/subscription-cancelled.html",
+        textPath: "./resend/subscription-cancelled.txt",
+        subject: "Your tadaify subscription is cancelled (until May 27)",
+        preheader: "Your subscription is cancelled but @yourhandle stays live until May 27. Reactivate anytime to keep your locked-for-life price.",
+        from: "tadaify <billing@tadaify.com>",
+      },
+      {
+        id: 8, stack: "resend",
+        slug: "payment-failed",
+        path: "./resend/payment-failed.html",
+        textPath: "./resend/payment-failed.txt",
+        subject: "Payment for tadaify failed — please update your card",
+        preheader: "Payment for $5.00 didn't go through. Update your card before May 27 to keep your page live.",
+        from: "tadaify <billing@tadaify.com>",
+      },
+      {
+        id: 9, stack: "resend",
+        slug: "handle-change-confirm",
+        path: "./resend/handle-change-confirm.html",
+        textPath: "./resend/handle-change-confirm.txt",
+        subject: "You changed your tadaify handle: oldhandle → newhandle",
+        preheader: "Your handle changed: @oldhandle → @newhandle. Old links redirect for 30 days. Undo within 1h if this wasn't you.",
+        from: "tadaify <security@tadaify.com>",
+      },
+      {
+        id: 10, stack: "resend",
+        slug: "waitlist-promote",
+        path: "./resend/waitlist-promote.html",
+        textPath: "./resend/waitlist-promote.txt",
+        subject: "Your tadaify spot is ready! 🎉",
+        preheader: "Your tadaify handle @yourhandle is reserved. Finalize within 7 days to claim it.",
+        from: "tadaify <hello@tadaify.com>",
+      },
+    ];
+
+    const stackLabel = (s) => s === "supabase" ? "Supabase Auth" : "Resend";
+    const stackPillCls = (s) => s === "supabase" ? "sb" : "rs";
+
+    // --- Render -------------------------------------------------------------
+    const root = document.getElementById("emails");
+    TEMPLATES.forEach((t) => {
+      const card = document.createElement("section");
+      card.className = "email-card";
+      card.id = `email-${t.id}`;
+      card.dataset.slug = t.slug;
+      card.innerHTML = `
+        <header class="email-card-header">
+          <div class="email-meta-row">
+            <span class="email-num">#${String(t.id).padStart(2,'0')}</span>
+            <span class="email-stack-pill ${stackPillCls(t.stack)}">${stackLabel(t.stack)}</span>
+            <span class="email-filename">${t.path}</span>
+            <span class="email-filename" style="color:var(--fg-subtle);">From: ${t.from}</span>
+          </div>
+          <div class="email-subject">${t.subject}</div>
+          <div class="email-preheader">${t.preheader}</div>
+        </header>
+
+        <div class="email-card-toolbar">
+          <button class="small-toggle theme active" type="button" data-mode="light">☀ Light</button>
+          <button class="small-toggle theme" type="button" data-mode="dark">☾ Dark</button>
+          <span style="width:8px;"></span>
+          <button class="small-toggle size active" type="button" data-size="desktop">🖥 Desktop</button>
+          <button class="small-toggle size" type="button" data-size="mobile">📱 Mobile (375px)</button>
+          <button class="copy-btn" type="button" data-copy="html">📋 Copy HTML</button>
+          <button class="copy-btn" type="button" data-copy="text" style="background:var(--brand-warm);color:#1F2937;">📋 Copy .txt</button>
+        </div>
+
+        <div class="email-stage">
+          <iframe class="email-iframe" src="${t.path}" title="${t.subject} preview" loading="lazy"></iframe>
+        </div>
+
+        <details class="email-source">
+          <summary>View source · HTML + plain-text twin</summary>
+          <div class="source-tabs">
+            <button class="active" data-tab="html" type="button">${t.slug}.html</button>
+            <button data-tab="text" type="button">${t.slug}.txt</button>
+          </div>
+          <pre class="source-pre" data-pane="html">Loading ${t.path} …</pre>
+          <pre class="source-pre" data-pane="text" hidden>Loading ${t.textPath} …</pre>
+        </details>
+      `;
+      root.appendChild(card);
+
+      // --- Wire toolbar within this card -------------------------------------
+      const stage = card.querySelector(".email-stage");
+      const iframe = card.querySelector(".email-iframe");
+      const themeBtns = card.querySelectorAll(".small-toggle.theme");
+      const sizeBtns = card.querySelectorAll(".small-toggle.size");
+
+      themeBtns.forEach((b) => b.addEventListener("click", () => {
+        themeBtns.forEach((x) => x.classList.remove("active"));
+        b.classList.add("active");
+        const mode = b.dataset.mode;
+        stage.classList.toggle("dark", mode === "dark");
+        // Force re-render iframe with prefers-color-scheme via colorScheme attr fallback
+        try {
+          const doc = iframe.contentDocument;
+          if (doc && doc.documentElement) {
+            doc.documentElement.style.colorScheme = mode;
+            // Add a marker so @media (prefers-color-scheme: dark) approximation visible:
+            // Simulate by toggling a class — emails use prefers-color-scheme so we paint stage bg only.
+          }
+        } catch (e) { /* cross-origin or not loaded yet */ }
+      }));
+
+      sizeBtns.forEach((b) => b.addEventListener("click", () => {
+        sizeBtns.forEach((x) => x.classList.remove("active"));
+        b.classList.add("active");
+        iframe.classList.toggle("mobile", b.dataset.size === "mobile");
+      }));
+
+      // --- Source loading + tabs --------------------------------------------
+      const tabBtns = card.querySelectorAll(".source-tabs button");
+      const htmlPane = card.querySelector('.source-pre[data-pane="html"]');
+      const textPane = card.querySelector('.source-pre[data-pane="text"]');
+      let htmlSrc = null, textSrc = null;
+      const loadOnce = () => {
+        if (htmlSrc !== null) return;
+        fetch(t.path).then(r => r.text()).then(s => {
+          htmlSrc = s;
+          htmlPane.textContent = s;
+        }).catch(e => { htmlPane.textContent = `[Could not load ${t.path}]\n${e}\n\nIf running over file://, your browser may block fetch — open via a local server (e.g. \`python3 -m http.server\` from the mockups dir) to view source.`; });
+        fetch(t.textPath).then(r => r.text()).then(s => {
+          textSrc = s;
+          textPane.textContent = s;
+        }).catch(e => { textPane.textContent = `[Could not load ${t.textPath}]\n${e}`; });
+      };
+      card.querySelector("details.email-source").addEventListener("toggle", (e) => { if (e.target.open) loadOnce(); });
+
+      tabBtns.forEach((b) => b.addEventListener("click", () => {
+        tabBtns.forEach((x) => x.classList.remove("active"));
+        b.classList.add("active");
+        const which = b.dataset.tab;
+        htmlPane.hidden = which !== "html";
+        textPane.hidden = which !== "text";
+      }));
+
+      // --- Copy buttons ------------------------------------------------------
+      card.querySelectorAll(".copy-btn").forEach((b) => b.addEventListener("click", async () => {
+        const which = b.dataset.copy;
+        const url = which === "html" ? t.path : t.textPath;
+        try {
+          const res = await fetch(url);
+          const text = await res.text();
+          await navigator.clipboard.writeText(text);
+          const orig = b.textContent;
+          b.classList.add("ok");
+          b.textContent = "✓ Copied";
+          setTimeout(() => { b.classList.remove("ok"); b.textContent = orig; }, 1600);
+        } catch (e) {
+          alert(`Could not copy ${url}.\nIf running on file://, browsers may block fetch + clipboard. Open this gallery via \`python3 -m http.server\` for full functionality, or copy from disk: ${url}`);
+        }
+      }));
+    });
+
+    // --- Global toggles drive every card -----------------------------------
+    document.querySelectorAll("#globalThemeToggle button").forEach((b) => {
+      b.addEventListener("click", () => {
+        document.querySelectorAll("#globalThemeToggle button").forEach((x) => x.classList.remove("active"));
+        b.classList.add("active");
+        const mode = b.dataset.mode;
+        document.querySelectorAll(".email-card").forEach((card) => {
+          const target = card.querySelector(`.small-toggle.theme[data-mode="${mode}"]`);
+          if (target && !target.classList.contains("active")) target.click();
+        });
+      });
+    });
+    document.querySelectorAll("#globalSizeToggle button").forEach((b) => {
+      b.addEventListener("click", () => {
+        document.querySelectorAll("#globalSizeToggle button").forEach((x) => x.classList.remove("active"));
+        b.classList.add("active");
+        const size = b.dataset.size;
+        document.querySelectorAll(".email-card").forEach((card) => {
+          const target = card.querySelector(`.small-toggle.size[data-size="${size}"]`);
+          if (target && !target.classList.contains("active")) target.click();
+        });
+      });
+    });
+  </script>
+</body>
+</html>

--- a/mockups/tadaify-mvp/emails/otp-login.html
+++ b/mockups/tadaify-mvp/emails/otp-login.html
@@ -1,0 +1,511 @@
+<!DOCTYPE html>
+<!--
+type: mockup
+project: tadaify
+title: Email mockup — Login OTP (Phase 1, DEC-307 returning-user path)
+created_at: 2026-05-02T17:08:00Z
+-->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>tadaify — Email mockup — Login OTP (Phase 1)</title>
+  <link rel="stylesheet" href="../shared/tokens.css">
+  <style>
+    /* Page chrome shared with otp-signup.html — kept inline so the file is
+       openable standalone without a chained CSS partial. If we extract a
+       shared `_email-frame.css` later, this block moves there verbatim. */
+    body { background: var(--bg-muted); padding: 32px 16px 96px; }
+
+    .preview-page { max-width: 1080px; margin: 0 auto; }
+    .preview-back {
+      display: inline-flex; align-items: center; gap: 8px;
+      font-size: 13px; font-weight: 600; color: var(--fg-muted);
+      text-decoration: none; padding: 8px 14px; border-radius: var(--radius-full);
+      background: var(--bg-elevated); border: 1px solid var(--border-strong);
+      margin-bottom: 20px;
+      transition: border 120ms, color 120ms;
+    }
+    .preview-back:hover { border-color: var(--brand-primary); color: var(--brand-primary); }
+    .preview-title {
+      font-family: var(--font-display); font-weight: 600;
+      font-size: 32px; letter-spacing: -0.02em; margin-bottom: 6px;
+    }
+    .preview-sub { color: var(--fg-muted); font-size: 15px; margin-bottom: 4px; }
+    .preview-decs {
+      font-size: 12px; color: var(--fg-subtle); font-family: var(--font-mono);
+      margin-bottom: 28px;
+    }
+
+    .clients-grid {
+      display: grid; gap: 24px;
+      grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
+    }
+
+    .inbucket {
+      border-radius: var(--radius-lg); overflow: hidden;
+      box-shadow: var(--shadow-lg); background: #fff;
+      border: 1px solid var(--border);
+    }
+    .inbucket.dark { background: #0F172A; border-color: #1E293B; }
+
+    .inbucket-chrome {
+      display: flex; align-items: center; gap: 8px;
+      padding: 10px 16px; border-bottom: 1px solid var(--border);
+      background: #F1F5F9; font-size: 12px; color: #475569;
+    }
+    .inbucket.dark .inbucket-chrome {
+      background: #1E293B; border-bottom-color: #334155; color: #94A3B8;
+    }
+    .inbucket-chrome .dot { width: 11px; height: 11px; border-radius: 50%; }
+    .inbucket-chrome .dot.r { background: #FB7185; }
+    .inbucket-chrome .dot.y { background: #FBBF24; }
+    .inbucket-chrome .dot.g { background: #34D399; }
+    .inbucket-chrome .url {
+      margin-left: 8px; font-family: var(--font-mono); font-size: 11px;
+      padding: 3px 10px; background: #fff; border-radius: var(--radius-full);
+      color: #475569; border: 1px solid #CBD5E1;
+    }
+    .inbucket.dark .inbucket-chrome .url {
+      background: #0F172A; color: #CBD5E1; border-color: #334155;
+    }
+    .inbucket-chrome .badge {
+      margin-left: auto; font-size: 10px; font-weight: 700;
+      letter-spacing: 0.08em; text-transform: uppercase;
+      padding: 3px 8px; border-radius: 4px;
+      background: rgba(99,102,241,0.12); color: var(--brand-primary);
+    }
+    .inbucket.dark .inbucket-chrome .badge {
+      background: rgba(99,102,241,0.22); color: #C7D2FE;
+    }
+
+    .inbucket-headers {
+      padding: 16px 24px; border-bottom: 1px solid var(--border);
+      background: #FAFAFA; font-size: 13px;
+    }
+    .inbucket.dark .inbucket-headers {
+      background: #0B1220; border-bottom-color: #1E293B; color: #CBD5E1;
+    }
+    .inbucket-headers .row {
+      display: grid; grid-template-columns: 64px 1fr; gap: 8px; padding: 3px 0;
+    }
+    .inbucket-headers .key {
+      font-weight: 600; color: var(--fg-subtle);
+      letter-spacing: 0.04em; text-transform: uppercase; font-size: 11px;
+      padding-top: 2px;
+    }
+    .inbucket.dark .inbucket-headers .key { color: #64748B; }
+    .inbucket-headers .val { color: var(--fg); font-family: var(--font-mono); font-size: 12px; }
+    .inbucket.dark .inbucket-headers .val { color: #E2E8F0; }
+    .inbucket-headers .val .from-name { font-family: var(--font-sans); font-weight: 600; }
+
+    .inbucket-tab-strip {
+      display: flex; gap: 0; border-bottom: 1px solid var(--border);
+      background: #fff;
+    }
+    .inbucket.dark .inbucket-tab-strip {
+      background: #0F172A; border-bottom-color: #1E293B;
+    }
+    .inbucket-tab {
+      padding: 10px 18px; font-size: 12px; font-weight: 600;
+      color: var(--fg-muted); border-bottom: 2px solid transparent;
+      cursor: default;
+    }
+    .inbucket-tab.active {
+      color: var(--brand-primary); border-bottom-color: var(--brand-primary);
+    }
+    .inbucket.dark .inbucket-tab { color: #94A3B8; }
+    .inbucket.dark .inbucket-tab.active { color: #C7D2FE; border-bottom-color: #C7D2FE; }
+
+    .inbucket-body-wrap { padding: 32px 24px 24px; background: #F8FAFC; }
+    .inbucket.dark .inbucket-body-wrap { background: #020617; }
+
+    /* ---------- email body ---------- */
+    .email-body {
+      max-width: 600px; margin: 0 auto;
+      background: #FFFFFF;
+      border-radius: 12px; overflow: hidden;
+      box-shadow: 0 1px 3px rgba(17,24,39,0.06), 0 8px 24px rgba(17,24,39,0.04);
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      color: #111827; line-height: 1.55;
+    }
+    .email-body__hero {
+      padding: 36px 40px 8px;
+      background:
+        radial-gradient(600px 200px at 100% 0%, rgba(139,92,246,0.10), transparent 60%),
+        radial-gradient(400px 200px at 0% 0%, rgba(245,158,11,0.08), transparent 60%),
+        #FFFFFF;
+    }
+    .email-body__wordmark {
+      font-family: 'Crimson Pro', Georgia, serif;
+      font-weight: 600; font-size: 32px;
+      letter-spacing: -0.02em; line-height: 1;
+      display: inline-block; margin-bottom: 24px;
+    }
+    .email-body__wordmark .ta  { color: #6366F1; }
+    .email-body__wordmark .hyp { color: rgba(17,24,39,0.30); margin: 0 1px; }
+    .email-body__wordmark .da  { color: #F59E0B; }
+    .email-body__wordmark .ify { color: #111827; }
+
+    .email-body__greeting {
+      font-family: 'Crimson Pro', Georgia, serif;
+      font-weight: 600; font-size: 28px; letter-spacing: -0.02em;
+      color: #111827; margin: 0 0 6px;
+    }
+    .email-body__sub { font-size: 15px; color: #6B7280; margin: 0; }
+
+    .email-body__token-block { padding: 32px 40px; text-align: center; }
+    .email-body__token-label {
+      font-size: 12px; font-weight: 700; letter-spacing: 0.10em;
+      text-transform: uppercase; color: #6366F1; margin-bottom: 12px;
+    }
+    .email-body__token {
+      font-family: 'Crimson Pro', Georgia, serif;
+      font-weight: 600; font-size: 56px; letter-spacing: 0.16em;
+      color: #111827; line-height: 1; padding: 22px 0;
+      display: inline-block; min-width: 320px;
+      background: linear-gradient(135deg, rgba(99,102,241,0.06), rgba(245,158,11,0.05));
+      border: 1.5px solid rgba(99,102,241,0.18);
+      border-radius: 14px;
+      font-feature-settings: "tnum", "lnum";
+    }
+    .email-body__token-expiry {
+      font-size: 13px; color: #9CA3AF; margin-top: 14px; font-weight: 500;
+    }
+
+    .email-body__copy {
+      padding: 8px 40px 28px; font-size: 15px; color: #374151;
+    }
+    .email-body__copy p { margin: 0 0 14px; }
+    .email-body__copy p.lead { font-size: 16px; }
+    .email-body__copy strong { color: #111827; }
+
+    .email-body__device-card {
+      margin: 0 40px 24px;
+      padding: 14px 16px;
+      background: #F9FAFB;
+      border: 1px solid #E5E7EB;
+      border-radius: 10px;
+      font-size: 13px;
+      color: #4B5563;
+      display: flex; align-items: flex-start; gap: 10px;
+    }
+    .email-body__device-card .icn {
+      width: 28px; height: 28px; border-radius: 8px;
+      background: rgba(99,102,241,0.12); color: #6366F1;
+      display: inline-flex; align-items: center; justify-content: center;
+      font-size: 14px; flex-shrink: 0;
+    }
+    .email-body__device-card strong { display: block; color: #111827; font-weight: 600; margin-bottom: 2px; }
+
+    .email-body__trust-strip {
+      padding: 18px 28px; background: #F9FAFB;
+      border-top: 1px solid #F3F4F6; border-bottom: 1px solid #F3F4F6;
+      display: flex; flex-wrap: wrap; justify-content: center; gap: 6px 18px;
+      font-size: 12px; font-weight: 600; color: #4B5563;
+    }
+    .email-body__trust-strip span { white-space: nowrap; display: inline-flex; align-items: center; gap: 6px; }
+
+    .email-body__footer {
+      padding: 24px 40px 36px;
+      font-size: 12px; color: #9CA3AF; line-height: 1.6;
+    }
+    .email-body__footer .disclaimer {
+      padding: 12px 14px; background: #FAFAFA;
+      border-left: 3px solid #E5E7EB; border-radius: 4px;
+      color: #6B7280; margin-bottom: 16px;
+    }
+    .email-body__footer .meta {
+      font-family: 'JetBrains Mono', 'SF Mono', monospace;
+      font-size: 11px; color: #9CA3AF;
+    }
+    .email-body__footer a { color: #6366F1; text-decoration: none; }
+
+    /* dark-mode email body — Apple Mail dark / Gmail dark, ECN-150-03 */
+    .inbucket.dark .email-body {
+      background: #1F2937; color: #E5E7EB;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.4), 0 8px 24px rgba(0,0,0,0.3);
+    }
+    .inbucket.dark .email-body__hero {
+      background:
+        radial-gradient(600px 200px at 100% 0%, rgba(139,92,246,0.18), transparent 60%),
+        radial-gradient(400px 200px at 0% 0%, rgba(245,158,11,0.12), transparent 60%),
+        #1F2937;
+    }
+    .inbucket.dark .email-body__wordmark .ta  { color: #A5B4FC; }
+    .inbucket.dark .email-body__wordmark .hyp { color: rgba(229,231,235,0.40); }
+    .inbucket.dark .email-body__wordmark .da  { color: #FCD34D; }
+    .inbucket.dark .email-body__wordmark .ify { color: #F9FAFB; }
+    .inbucket.dark .email-body__greeting { color: #F9FAFB; }
+    .inbucket.dark .email-body__sub      { color: #9CA3AF; }
+    .inbucket.dark .email-body__token-label { color: #A5B4FC; }
+    .inbucket.dark .email-body__token {
+      color: #F9FAFB;
+      background: linear-gradient(135deg, rgba(99,102,241,0.18), rgba(245,158,11,0.10));
+      border-color: rgba(165,180,252,0.30);
+    }
+    .inbucket.dark .email-body__token-expiry { color: #9CA3AF; }
+    .inbucket.dark .email-body__copy { color: #D1D5DB; }
+    .inbucket.dark .email-body__copy strong { color: #F9FAFB; }
+    .inbucket.dark .email-body__device-card {
+      background: #111827; border-color: #374151; color: #D1D5DB;
+    }
+    .inbucket.dark .email-body__device-card strong { color: #F9FAFB; }
+    .inbucket.dark .email-body__device-card .icn {
+      background: rgba(165,180,252,0.15); color: #A5B4FC;
+    }
+    .inbucket.dark .email-body__trust-strip {
+      background: #111827; border-color: #374151; color: #D1D5DB;
+    }
+    .inbucket.dark .email-body__footer { color: #6B7280; }
+    .inbucket.dark .email-body__footer .disclaimer {
+      background: #111827; border-left-color: #374151; color: #9CA3AF;
+    }
+    .inbucket.dark .email-body__footer .meta { color: #6B7280; }
+    .inbucket.dark .email-body__footer a { color: #A5B4FC; }
+
+    .plaintext-section { max-width: 880px; margin: 48px auto 0; padding: 0 16px; }
+    .plaintext-section h3 {
+      font-family: var(--font-sans);
+      font-size: 13px; font-weight: 700;
+      letter-spacing: 0.08em; text-transform: uppercase;
+      color: var(--fg-muted); margin: 0 0 12px;
+    }
+    .plaintext-section pre {
+      background: var(--bg-elevated); border: 1px solid var(--border);
+      border-radius: var(--radius-md);
+      padding: 22px 26px;
+      font-family: var(--font-mono); font-size: 13px;
+      color: var(--fg); line-height: 1.7;
+      white-space: pre-wrap; word-break: break-word;
+      box-shadow: var(--shadow-sm);
+    }
+
+    .spec-notes { max-width: 880px; margin: 32px auto 0; padding: 0 16px; }
+    .spec-notes-card {
+      padding: 24px 28px; background: var(--bg-elevated);
+      border: 1px solid var(--border);
+      border-left: 4px solid var(--brand-warm);
+      border-radius: var(--radius-md);
+      box-shadow: var(--shadow-sm);
+    }
+    .spec-notes-card h3 {
+      font-family: var(--font-sans); font-size: 13px; font-weight: 700;
+      letter-spacing: 0.08em; text-transform: uppercase;
+      color: var(--brand-warm-dark); margin: 0 0 12px;
+    }
+    .spec-notes-card ul { margin: 0; padding-left: 18px; }
+    .spec-notes-card li { font-size: 14px; color: var(--fg); padding: 3px 0; }
+    .spec-notes-card li code {
+      font-family: var(--font-mono); font-size: 12px;
+      background: var(--bg-muted); padding: 1px 6px; border-radius: 4px;
+    }
+
+    @media (max-width: 720px) {
+      .clients-grid { grid-template-columns: 1fr; }
+      .email-body__hero, .email-body__token-block,
+      .email-body__copy, .email-body__footer { padding-left: 24px; padding-right: 24px; }
+      .email-body__device-card { margin-left: 24px; margin-right: 24px; }
+      .email-body__token { font-size: 44px; min-width: 0; padding: 18px 12px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="preview-page">
+    <a href="./index.html" class="preview-back">← Back to email mockups</a>
+
+    <h1 class="preview-title">Login OTP — Phase 1</h1>
+    <p class="preview-sub">Sent when a returning user requests sign-in (DEC-307 returning-user path). Same OTP-only contract as signup, recognising the user is already known.</p>
+    <p class="preview-decs">DEC-291 / DEC-294 / DEC-295 / DEC-306 / DEC-307 · TR-tadaify-002 · ECN-150-02 / -03 / -06</p>
+
+    <div class="clients-grid">
+
+      <!-- LIGHT MODE EMAIL CLIENT -->
+      <div class="inbucket">
+        <div class="inbucket-chrome">
+          <span class="dot r"></span>
+          <span class="dot y"></span>
+          <span class="dot g"></span>
+          <span class="url">localhost:54354 · Inbucket</span>
+          <span class="badge">light client</span>
+        </div>
+        <div class="inbucket-headers">
+          <div class="row"><span class="key">From</span><span class="val"><span class="from-name">tadaify</span> &lt;noreply@tadaify.com&gt;</span></div>
+          <div class="row"><span class="key">To</span><span class="val">waserek@local.test</span></div>
+          <div class="row"><span class="key">Subject</span><span class="val">Sign in to tadaify: 502718</span></div>
+          <div class="row"><span class="key">Date</span><span class="val">2026-05-02 13:21:42 UTC</span></div>
+          <div class="row"><span class="key">Type</span><span class="val">multipart/alternative · text/html + text/plain</span></div>
+        </div>
+        <div class="inbucket-tab-strip">
+          <div class="inbucket-tab active">HTML</div>
+          <div class="inbucket-tab">Plain text</div>
+          <div class="inbucket-tab">Raw source</div>
+        </div>
+        <div class="inbucket-body-wrap">
+          <article class="email-body" role="article" aria-label="Login OTP email">
+            <header class="email-body__hero">
+              <span class="email-body__wordmark" aria-label="tadaify">
+                <span class="ta">ta</span><span class="hyp">-</span><span class="da">da!</span><span class="ify">ify</span>
+              </span>
+              <h1 class="email-body__greeting">Welcome back, @waserek</h1>
+              <p class="email-body__sub">signing you in to tadaify.</p>
+            </header>
+
+            <div class="email-body__token-block">
+              <div class="email-body__token-label">Your sign-in code</div>
+              <div class="email-body__token">502718</div>
+              <div class="email-body__token-expiry">Code expires in 10 minutes</div>
+            </div>
+
+            <div class="email-body__copy">
+              <p class="lead">Type these <strong>6 digits</strong> back into the tadaify sign-in form to finish logging in.</p>
+              <p>No password, no link to click — just the code, then you're in.</p>
+            </div>
+
+            <div class="email-body__device-card">
+              <span class="icn">🖥</span>
+              <span>
+                <strong>Sign-in attempt detected</strong>
+                Chrome on macOS · Warsaw, PL · 2026-05-02 13:21 UTC<br/>
+                Didn't request this? Ignore this email — no action will be taken without the code above.
+              </span>
+            </div>
+
+            <div class="email-body__trust-strip">
+              <span>🔒 Price locked for life</span>
+              <span>💸 30-day money-back</span>
+              <span>🛡 GDPR-compliant</span>
+            </div>
+
+            <footer class="email-body__footer">
+              <div class="disclaimer">
+                If you didn't try to sign in to tadaify, you can safely ignore this email — your account is unchanged. We never share your address.
+              </div>
+              <div class="meta">
+                tadaify · sent via Supabase Auth · <a href="https://tadaify.com">tadaify.com</a><br/>
+                Need help? Reply to this email — a human reads every reply.
+              </div>
+            </footer>
+          </article>
+        </div>
+      </div>
+
+      <!-- DARK MODE EMAIL CLIENT -->
+      <div class="inbucket dark">
+        <div class="inbucket-chrome">
+          <span class="dot r"></span>
+          <span class="dot y"></span>
+          <span class="dot g"></span>
+          <span class="url">Apple Mail (dark)</span>
+          <span class="badge">dark client</span>
+        </div>
+        <div class="inbucket-headers">
+          <div class="row"><span class="key">From</span><span class="val"><span class="from-name">tadaify</span> &lt;noreply@tadaify.com&gt;</span></div>
+          <div class="row"><span class="key">To</span><span class="val">waserek@local.test</span></div>
+          <div class="row"><span class="key">Subject</span><span class="val">Sign in to tadaify: 502718</span></div>
+          <div class="row"><span class="key">Date</span><span class="val">2026-05-02 13:21:42 UTC</span></div>
+          <div class="row"><span class="key">Type</span><span class="val">multipart/alternative</span></div>
+        </div>
+        <div class="inbucket-tab-strip">
+          <div class="inbucket-tab active">HTML</div>
+          <div class="inbucket-tab">Plain text</div>
+          <div class="inbucket-tab">Raw source</div>
+        </div>
+        <div class="inbucket-body-wrap">
+          <article class="email-body" role="article" aria-label="Login OTP email (dark client)">
+            <header class="email-body__hero">
+              <span class="email-body__wordmark" aria-label="tadaify">
+                <span class="ta">ta</span><span class="hyp">-</span><span class="da">da!</span><span class="ify">ify</span>
+              </span>
+              <h1 class="email-body__greeting">Welcome back, @waserek</h1>
+              <p class="email-body__sub">signing you in to tadaify.</p>
+            </header>
+
+            <div class="email-body__token-block">
+              <div class="email-body__token-label">Your sign-in code</div>
+              <div class="email-body__token">502718</div>
+              <div class="email-body__token-expiry">Code expires in 10 minutes</div>
+            </div>
+
+            <div class="email-body__copy">
+              <p class="lead">Type these <strong>6 digits</strong> back into the tadaify sign-in form to finish logging in.</p>
+              <p>No password, no link to click — just the code, then you're in.</p>
+            </div>
+
+            <div class="email-body__device-card">
+              <span class="icn">🖥</span>
+              <span>
+                <strong>Sign-in attempt detected</strong>
+                Chrome on macOS · Warsaw, PL · 2026-05-02 13:21 UTC<br/>
+                Didn't request this? Ignore this email — no action will be taken without the code above.
+              </span>
+            </div>
+
+            <div class="email-body__trust-strip">
+              <span>🔒 Price locked for life</span>
+              <span>💸 30-day money-back</span>
+              <span>🛡 GDPR-compliant</span>
+            </div>
+
+            <footer class="email-body__footer">
+              <div class="disclaimer">
+                If you didn't try to sign in to tadaify, you can safely ignore this email — your account is unchanged. We never share your address.
+              </div>
+              <div class="meta">
+                tadaify · sent via Supabase Auth · <a href="https://tadaify.com">tadaify.com</a><br/>
+                Need help? Reply to this email — a human reads every reply.
+              </div>
+            </footer>
+          </article>
+        </div>
+      </div>
+    </div>
+
+    <section class="plaintext-section">
+      <h3>What plain-text-only clients see (multipart/alternative — text/plain part)</h3>
+<pre>tadaify
+
+Welcome back, @waserek.
+
+Type these 6 digits back into the tadaify sign-in form to finish
+logging in:
+
+    502718
+
+Code expires in 10 minutes.
+
+No password, no link to click — just the code, then you're in.
+
+Sign-in attempt detected:
+  Chrome on macOS · Warsaw, PL · 2026-05-02 13:21 UTC
+  Didn't request this? Ignore this email — no action will be taken
+  without the code above.
+
+  Price locked for life · 30-day money-back · GDPR-compliant
+
+If you didn't try to sign in to tadaify, you can safely ignore this
+email — your account is unchanged. We never share your address.
+
+—
+tadaify
+https://tadaify.com
+Need help? Just reply — a human reads every reply.
+</pre>
+    </section>
+
+    <section class="spec-notes">
+      <div class="spec-notes-card">
+        <h3>Spec notes — what differs from signup OTP</h3>
+        <ul>
+          <li><strong>Greeting:</strong> <code>Welcome back, @&lt;handle&gt;</code> — handle is always known on the login path (DEC-307), so no fallback copy needed.</li>
+          <li><strong>Sub-line:</strong> <code>signing you in to tadaify</code> instead of <code>welcome to tadaify</code>.</li>
+          <li><strong>Subject:</strong> <code>Sign in to tadaify: {{ .Token }}</code> — set via <code>config.toml [auth.email.template.magic_link]</code> (Supabase reuses the magic-link slot for OTP-only login).</li>
+          <li><strong>Device card:</strong> shows browser + OS + city + UTC time; helps spot rogue sign-in attempts. Same data Supabase exposes via the auth event payload — values mocked in this preview.</li>
+          <li><strong>No magic link:</strong> still OTP-only — the device card is informational, not clickable.</li>
+          <li><strong>Token rendering, dark-mode parity, plain-text fallback, trust strip:</strong> identical to signup OTP — see <a href="./otp-signup.html">otp-signup.html</a>.</li>
+        </ul>
+      </div>
+    </section>
+  </div>
+</body>
+</html>

--- a/mockups/tadaify-mvp/emails/otp-signup.html
+++ b/mockups/tadaify-mvp/emails/otp-signup.html
@@ -1,0 +1,569 @@
+<!DOCTYPE html>
+<!--
+type: mockup
+project: tadaify
+title: Email mockup — Signup OTP (Phase 1, DEC-291/294/295)
+created_at: 2026-05-02T17:05:00Z
+-->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>tadaify — Email mockup — Signup OTP (Phase 1)</title>
+  <link rel="stylesheet" href="../shared/tokens.css">
+  <style>
+    /* =====================================================================
+       PAGE CHROME — Inbucket-style email-client preview frame.
+       Everything inside .email-body is the literal HTML body Supabase
+       will emit once `supabase/templates/auth/otp-signup.html` is wired
+       per #150. Frame is mockup chrome only — never goes to production.
+       ===================================================================== */
+    body { background: var(--bg-muted); padding: 32px 16px 96px; }
+
+    .preview-page {
+      max-width: 1080px; margin: 0 auto;
+    }
+
+    .preview-back {
+      display: inline-flex; align-items: center; gap: 8px;
+      font-size: 13px; font-weight: 600; color: var(--fg-muted);
+      text-decoration: none; padding: 8px 14px; border-radius: var(--radius-full);
+      background: var(--bg-elevated); border: 1px solid var(--border-strong);
+      margin-bottom: 20px;
+      transition: border 120ms, color 120ms;
+    }
+    .preview-back:hover { border-color: var(--brand-primary); color: var(--brand-primary); }
+
+    .preview-title {
+      font-family: var(--font-display); font-weight: 600;
+      font-size: 32px; letter-spacing: -0.02em; margin-bottom: 6px;
+    }
+    .preview-sub { color: var(--fg-muted); font-size: 15px; margin-bottom: 4px; }
+    .preview-decs {
+      font-size: 12px; color: var(--fg-subtle); font-family: var(--font-mono);
+      margin-bottom: 28px;
+    }
+
+    /* Theme switcher — light / dark email-client preview */
+    .theme-switch {
+      display: inline-flex; gap: 0; background: var(--bg-elevated);
+      border: 1px solid var(--border-strong); border-radius: var(--radius-full);
+      padding: 3px; margin: 0 0 24px 0;
+    }
+    .theme-switch button {
+      border: 0; background: transparent; padding: 6px 16px;
+      font-size: 13px; font-weight: 600; color: var(--fg-muted);
+      border-radius: var(--radius-full); cursor: pointer;
+    }
+    .theme-switch button.active { background: var(--brand-primary); color: #FFF; }
+    .theme-switch button:hover:not(.active) { background: var(--bg-muted); color: var(--fg); }
+
+    /* The two-up grid: light client | dark client */
+    .clients-grid {
+      display: grid; gap: 24px;
+      grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
+    }
+
+    /* =====================================================================
+       INBUCKET FRAME — wraps the rendered email body
+       ===================================================================== */
+    .inbucket {
+      border-radius: var(--radius-lg);
+      overflow: hidden;
+      box-shadow: var(--shadow-lg);
+      background: #fff;
+      border: 1px solid var(--border);
+    }
+    .inbucket.dark {
+      background: #0F172A;
+      border-color: #1E293B;
+    }
+
+    .inbucket-chrome {
+      display: flex; align-items: center; gap: 8px;
+      padding: 10px 16px;
+      border-bottom: 1px solid var(--border);
+      background: #F1F5F9;
+      font-size: 12px; color: #475569;
+    }
+    .inbucket.dark .inbucket-chrome {
+      background: #1E293B; border-bottom-color: #334155; color: #94A3B8;
+    }
+    .inbucket-chrome .dot { width: 11px; height: 11px; border-radius: 50%; }
+    .inbucket-chrome .dot.r { background: #FB7185; }
+    .inbucket-chrome .dot.y { background: #FBBF24; }
+    .inbucket-chrome .dot.g { background: #34D399; }
+    .inbucket-chrome .url {
+      margin-left: 8px; font-family: var(--font-mono); font-size: 11px;
+      padding: 3px 10px; background: #fff; border-radius: var(--radius-full);
+      color: #475569; border: 1px solid #CBD5E1;
+    }
+    .inbucket.dark .inbucket-chrome .url {
+      background: #0F172A; color: #CBD5E1; border-color: #334155;
+    }
+    .inbucket-chrome .badge {
+      margin-left: auto; font-size: 10px; font-weight: 700;
+      letter-spacing: 0.08em; text-transform: uppercase;
+      padding: 3px 8px; border-radius: 4px;
+      background: rgba(99,102,241,0.12); color: var(--brand-primary);
+    }
+    .inbucket.dark .inbucket-chrome .badge {
+      background: rgba(99,102,241,0.22); color: #C7D2FE;
+    }
+
+    .inbucket-headers {
+      padding: 16px 24px;
+      border-bottom: 1px solid var(--border);
+      background: #FAFAFA;
+      font-size: 13px;
+    }
+    .inbucket.dark .inbucket-headers {
+      background: #0B1220; border-bottom-color: #1E293B; color: #CBD5E1;
+    }
+    .inbucket-headers .row {
+      display: grid; grid-template-columns: 64px 1fr; gap: 8px; padding: 3px 0;
+    }
+    .inbucket-headers .key {
+      font-weight: 600; color: var(--fg-subtle);
+      letter-spacing: 0.04em; text-transform: uppercase; font-size: 11px;
+      padding-top: 2px;
+    }
+    .inbucket.dark .inbucket-headers .key { color: #64748B; }
+    .inbucket-headers .val { color: var(--fg); font-family: var(--font-mono); font-size: 12px; }
+    .inbucket.dark .inbucket-headers .val { color: #E2E8F0; }
+    .inbucket-headers .val .from-name { font-family: var(--font-sans); font-weight: 600; }
+
+    .inbucket-tab-strip {
+      display: flex; gap: 0; border-bottom: 1px solid var(--border);
+      background: #fff;
+    }
+    .inbucket.dark .inbucket-tab-strip {
+      background: #0F172A; border-bottom-color: #1E293B;
+    }
+    .inbucket-tab {
+      padding: 10px 18px; font-size: 12px; font-weight: 600;
+      color: var(--fg-muted); border-bottom: 2px solid transparent;
+      cursor: default;
+    }
+    .inbucket-tab.active {
+      color: var(--brand-primary); border-bottom-color: var(--brand-primary);
+    }
+    .inbucket.dark .inbucket-tab { color: #94A3B8; }
+    .inbucket.dark .inbucket-tab.active { color: #C7D2FE; border-bottom-color: #C7D2FE; }
+
+    /* Email body container — the WIDTH the recipient actually sees.
+       Anything inside .email-body is what Supabase emits. */
+    .inbucket-body-wrap {
+      padding: 32px 24px 24px;
+      background: #F8FAFC;
+    }
+    .inbucket.dark .inbucket-body-wrap {
+      background: #020617;
+    }
+
+    /* =====================================================================
+       EMAIL BODY — this is the literal content Supabase will render.
+       ALL CSS inline below would normally live INLINE-STYLE on each tag
+       for max email-client compatibility. Here we use a <style scoped> so
+       the mockup is readable; the template-shipping step will inline.
+       ===================================================================== */
+    .email-body {
+      max-width: 600px; margin: 0 auto;
+      background: #FFFFFF;
+      border-radius: 12px;
+      overflow: hidden;
+      box-shadow: 0 1px 3px rgba(17,24,39,0.06), 0 8px 24px rgba(17,24,39,0.04);
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      color: #111827;
+      line-height: 1.55;
+    }
+    .email-body__hero {
+      padding: 36px 40px 8px;
+      text-align: left;
+      background:
+        radial-gradient(600px 200px at 100% 0%, rgba(139,92,246,0.10), transparent 60%),
+        radial-gradient(400px 200px at 0% 0%, rgba(245,158,11,0.08), transparent 60%),
+        #FFFFFF;
+    }
+    .email-body__wordmark {
+      font-family: 'Crimson Pro', Georgia, serif;
+      font-weight: 600;
+      font-size: 32px;
+      letter-spacing: -0.02em;
+      line-height: 1;
+      display: inline-block;
+      margin-bottom: 24px;
+    }
+    .email-body__wordmark .ta  { color: #6366F1; }
+    .email-body__wordmark .hyp { color: rgba(17,24,39,0.30); margin: 0 1px; }
+    .email-body__wordmark .da  { color: #F59E0B; }
+    .email-body__wordmark .ify { color: #111827; }
+
+    .email-body__greeting {
+      font-family: 'Crimson Pro', Georgia, serif;
+      font-weight: 600; font-size: 28px; letter-spacing: -0.02em;
+      color: #111827; margin: 0 0 6px;
+    }
+    .email-body__sub {
+      font-size: 15px; color: #6B7280; margin: 0;
+    }
+
+    .email-body__token-block {
+      padding: 32px 40px;
+      text-align: center;
+    }
+    .email-body__token-label {
+      font-size: 12px; font-weight: 700; letter-spacing: 0.10em;
+      text-transform: uppercase; color: #6366F1;
+      margin-bottom: 12px;
+    }
+    .email-body__token {
+      font-family: 'Crimson Pro', Georgia, serif;
+      font-weight: 600;
+      font-size: 56px;
+      letter-spacing: 0.16em;
+      color: #111827;
+      line-height: 1;
+      padding: 22px 0;
+      display: inline-block;
+      min-width: 320px;
+      background:
+        linear-gradient(135deg, rgba(99,102,241,0.06), rgba(245,158,11,0.05));
+      border: 1.5px solid rgba(99,102,241,0.18);
+      border-radius: 14px;
+      /* Disambiguating monospace fallback per ECN-150-06. Crimson Pro
+         already separates 0/O and 1/l/I cleanly; if the client falls
+         back to a generic serif we still want clarity. */
+      font-feature-settings: "tnum", "lnum";
+    }
+    .email-body__token-expiry {
+      font-size: 13px; color: #9CA3AF; margin-top: 14px;
+      font-weight: 500;
+    }
+
+    .email-body__copy {
+      padding: 8px 40px 28px;
+      font-size: 15px; color: #374151;
+    }
+    .email-body__copy p { margin: 0 0 14px; }
+    .email-body__copy p.lead { font-size: 16px; }
+    .email-body__copy strong { color: #111827; }
+
+    .email-body__trust-strip {
+      padding: 18px 28px;
+      background: #F9FAFB;
+      border-top: 1px solid #F3F4F6;
+      border-bottom: 1px solid #F3F4F6;
+      display: flex; flex-wrap: wrap; justify-content: center; gap: 6px 18px;
+      font-size: 12px; font-weight: 600; color: #4B5563;
+    }
+    .email-body__trust-strip span { white-space: nowrap; display: inline-flex; align-items: center; gap: 6px; }
+
+    .email-body__footer {
+      padding: 24px 40px 36px;
+      font-size: 12px; color: #9CA3AF;
+      line-height: 1.6;
+    }
+    .email-body__footer .disclaimer {
+      padding: 12px 14px;
+      background: #FAFAFA;
+      border-left: 3px solid #E5E7EB;
+      border-radius: 4px;
+      color: #6B7280;
+      margin-bottom: 16px;
+    }
+    .email-body__footer .meta {
+      font-family: 'JetBrains Mono', 'SF Mono', monospace;
+      font-size: 11px; color: #9CA3AF;
+    }
+    .email-body__footer a { color: #6366F1; text-decoration: none; }
+
+    /* =====================================================================
+       DARK-MODE EMAIL CLIENT (Apple Mail dark / Gmail dark) — ECN-150-03.
+       Per CSS, use prefers-color-scheme; on the right-side preview we
+       force dark via a parent class so user sees both side-by-side
+       without flipping OS theme.
+       ===================================================================== */
+    .inbucket.dark .email-body {
+      background: #1F2937;
+      color: #E5E7EB;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.4), 0 8px 24px rgba(0,0,0,0.3);
+    }
+    .inbucket.dark .email-body__hero {
+      background:
+        radial-gradient(600px 200px at 100% 0%, rgba(139,92,246,0.18), transparent 60%),
+        radial-gradient(400px 200px at 0% 0%, rgba(245,158,11,0.12), transparent 60%),
+        #1F2937;
+    }
+    .inbucket.dark .email-body__wordmark .ta  { color: #A5B4FC; }
+    .inbucket.dark .email-body__wordmark .hyp { color: rgba(229,231,235,0.40); }
+    .inbucket.dark .email-body__wordmark .da  { color: #FCD34D; }
+    .inbucket.dark .email-body__wordmark .ify { color: #F9FAFB; }
+    .inbucket.dark .email-body__greeting { color: #F9FAFB; }
+    .inbucket.dark .email-body__sub      { color: #9CA3AF; }
+    .inbucket.dark .email-body__token-label { color: #A5B4FC; }
+    .inbucket.dark .email-body__token {
+      color: #F9FAFB;
+      background: linear-gradient(135deg, rgba(99,102,241,0.18), rgba(245,158,11,0.10));
+      border-color: rgba(165,180,252,0.30);
+    }
+    .inbucket.dark .email-body__token-expiry { color: #9CA3AF; }
+    .inbucket.dark .email-body__copy { color: #D1D5DB; }
+    .inbucket.dark .email-body__copy strong { color: #F9FAFB; }
+    .inbucket.dark .email-body__trust-strip {
+      background: #111827; border-color: #374151; color: #D1D5DB;
+    }
+    .inbucket.dark .email-body__footer { color: #6B7280; }
+    .inbucket.dark .email-body__footer .disclaimer {
+      background: #111827; border-left-color: #374151; color: #9CA3AF;
+    }
+    .inbucket.dark .email-body__footer .meta { color: #6B7280; }
+    .inbucket.dark .email-body__footer a { color: #A5B4FC; }
+
+    /* =====================================================================
+       PLAIN-TEXT FALLBACK section — what plaintext-only clients receive.
+       Lives OUTSIDE the email body in the mockup chrome.
+       ===================================================================== */
+    .plaintext-section {
+      max-width: 880px; margin: 48px auto 0;
+      padding: 0 16px;
+    }
+    .plaintext-section h3 {
+      font-family: var(--font-sans);
+      font-size: 13px; font-weight: 700;
+      letter-spacing: 0.08em; text-transform: uppercase;
+      color: var(--fg-muted);
+      margin: 0 0 12px;
+    }
+    .plaintext-section pre {
+      background: var(--bg-elevated); border: 1px solid var(--border);
+      border-radius: var(--radius-md);
+      padding: 22px 26px;
+      font-family: var(--font-mono); font-size: 13px;
+      color: var(--fg); line-height: 1.7;
+      white-space: pre-wrap; word-break: break-word;
+      box-shadow: var(--shadow-sm);
+    }
+
+    /* =====================================================================
+       SPEC NOTES SIDEBAR
+       ===================================================================== */
+    .spec-notes {
+      max-width: 880px; margin: 32px auto 0;
+      padding: 0 16px;
+    }
+    .spec-notes-card {
+      padding: 24px 28px;
+      background: var(--bg-elevated);
+      border: 1px solid var(--border);
+      border-left: 4px solid var(--brand-primary);
+      border-radius: var(--radius-md);
+      box-shadow: var(--shadow-sm);
+    }
+    .spec-notes-card h3 {
+      font-family: var(--font-sans); font-size: 13px; font-weight: 700;
+      letter-spacing: 0.08em; text-transform: uppercase;
+      color: var(--brand-primary); margin: 0 0 12px;
+    }
+    .spec-notes-card ul { margin: 0; padding-left: 18px; }
+    .spec-notes-card li { font-size: 14px; color: var(--fg); padding: 3px 0; }
+    .spec-notes-card li code {
+      font-family: var(--font-mono); font-size: 12px;
+      background: var(--bg-muted); padding: 1px 6px; border-radius: 4px;
+    }
+
+    @media (max-width: 720px) {
+      .clients-grid { grid-template-columns: 1fr; }
+      .email-body__hero, .email-body__token-block,
+      .email-body__copy, .email-body__footer { padding-left: 24px; padding-right: 24px; }
+      .email-body__token { font-size: 44px; min-width: 0; padding: 18px 12px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="preview-page">
+    <a href="./index.html" class="preview-back">← Back to email mockups</a>
+
+    <h1 class="preview-title">Signup OTP — Phase 1</h1>
+    <p class="preview-sub">Sent immediately after a new user submits the register form (see <a href="../register.html">register.html</a>). 6-digit code only — no magic link, per locked design.</p>
+    <p class="preview-decs">DEC-291 / DEC-294 / DEC-295 / DEC-306 · TR-tadaify-002 · ECN-150-02 / -03 / -06</p>
+
+    <!-- Side-by-side: light email client | dark email client -->
+    <div class="clients-grid">
+
+      <!-- LIGHT MODE EMAIL CLIENT -->
+      <div class="inbucket">
+        <div class="inbucket-chrome">
+          <span class="dot r"></span>
+          <span class="dot y"></span>
+          <span class="dot g"></span>
+          <span class="url">localhost:54354 · Inbucket</span>
+          <span class="badge">light client</span>
+        </div>
+        <div class="inbucket-headers">
+          <div class="row"><span class="key">From</span><span class="val"><span class="from-name">tadaify</span> &lt;noreply@tadaify.com&gt;</span></div>
+          <div class="row"><span class="key">To</span><span class="val">waserek@local.test</span></div>
+          <div class="row"><span class="key">Subject</span><span class="val">Your tadaify code: 184629</span></div>
+          <div class="row"><span class="key">Date</span><span class="val">2026-05-02 12:34:07 UTC</span></div>
+          <div class="row"><span class="key">Type</span><span class="val">multipart/alternative · text/html + text/plain</span></div>
+        </div>
+        <div class="inbucket-tab-strip">
+          <div class="inbucket-tab active">HTML</div>
+          <div class="inbucket-tab">Plain text</div>
+          <div class="inbucket-tab">Raw source</div>
+        </div>
+        <div class="inbucket-body-wrap">
+          <!-- =================================================================
+               LITERAL EMAIL HTML — this is exactly what Supabase emits.
+               Variables: {{ .Token }} → 184629 (mocked).
+               No external image / font CDN calls (ECN-150-02): all chrome
+               is system fonts + inline SVG (none used here).
+               ================================================================= -->
+          <article class="email-body" role="article" aria-label="Signup OTP email">
+            <header class="email-body__hero">
+              <span class="email-body__wordmark" aria-label="tadaify">
+                <span class="ta">ta</span><span class="hyp">-</span><span class="da">da!</span><span class="ify">ify</span>
+              </span>
+              <h1 class="email-body__greeting">Hey @waserek 👋</h1>
+              <p class="email-body__sub">welcome to tadaify — let's verify your email.</p>
+            </header>
+
+            <div class="email-body__token-block">
+              <div class="email-body__token-label">Your verification code</div>
+              <div class="email-body__token">184629</div>
+              <div class="email-body__token-expiry">Code expires in 10 minutes</div>
+            </div>
+
+            <div class="email-body__copy">
+              <p class="lead">Type these <strong>6 digits</strong> back into the tadaify signup form to finish creating your account.</p>
+              <p>That's the whole step — no link to click, no password to set right now. We'll get you posting your first link in under a minute.</p>
+            </div>
+
+            <div class="email-body__trust-strip">
+              <span>🔒 Price locked for life</span>
+              <span>💸 30-day money-back</span>
+              <span>🛡 GDPR-compliant</span>
+            </div>
+
+            <footer class="email-body__footer">
+              <div class="disclaimer">
+                If you didn't sign up for tadaify, you can safely ignore this email. We never share your address.
+              </div>
+              <div class="meta">
+                tadaify · sent via Supabase Auth · <a href="https://tadaify.com">tadaify.com</a><br/>
+                Need help? Reply to this email — a human reads every reply.
+              </div>
+            </footer>
+          </article>
+        </div>
+      </div>
+
+      <!-- DARK MODE EMAIL CLIENT -->
+      <div class="inbucket dark">
+        <div class="inbucket-chrome">
+          <span class="dot r"></span>
+          <span class="dot y"></span>
+          <span class="dot g"></span>
+          <span class="url">Apple Mail (dark)</span>
+          <span class="badge">dark client</span>
+        </div>
+        <div class="inbucket-headers">
+          <div class="row"><span class="key">From</span><span class="val"><span class="from-name">tadaify</span> &lt;noreply@tadaify.com&gt;</span></div>
+          <div class="row"><span class="key">To</span><span class="val">waserek@local.test</span></div>
+          <div class="row"><span class="key">Subject</span><span class="val">Your tadaify code: 184629</span></div>
+          <div class="row"><span class="key">Date</span><span class="val">2026-05-02 12:34:07 UTC</span></div>
+          <div class="row"><span class="key">Type</span><span class="val">multipart/alternative</span></div>
+        </div>
+        <div class="inbucket-tab-strip">
+          <div class="inbucket-tab active">HTML</div>
+          <div class="inbucket-tab">Plain text</div>
+          <div class="inbucket-tab">Raw source</div>
+        </div>
+        <div class="inbucket-body-wrap">
+          <article class="email-body" role="article" aria-label="Signup OTP email (dark client)">
+            <header class="email-body__hero">
+              <span class="email-body__wordmark" aria-label="tadaify">
+                <span class="ta">ta</span><span class="hyp">-</span><span class="da">da!</span><span class="ify">ify</span>
+              </span>
+              <h1 class="email-body__greeting">Hey @waserek 👋</h1>
+              <p class="email-body__sub">welcome to tadaify — let's verify your email.</p>
+            </header>
+
+            <div class="email-body__token-block">
+              <div class="email-body__token-label">Your verification code</div>
+              <div class="email-body__token">184629</div>
+              <div class="email-body__token-expiry">Code expires in 10 minutes</div>
+            </div>
+
+            <div class="email-body__copy">
+              <p class="lead">Type these <strong>6 digits</strong> back into the tadaify signup form to finish creating your account.</p>
+              <p>That's the whole step — no link to click, no password to set right now. We'll get you posting your first link in under a minute.</p>
+            </div>
+
+            <div class="email-body__trust-strip">
+              <span>🔒 Price locked for life</span>
+              <span>💸 30-day money-back</span>
+              <span>🛡 GDPR-compliant</span>
+            </div>
+
+            <footer class="email-body__footer">
+              <div class="disclaimer">
+                If you didn't sign up for tadaify, you can safely ignore this email. We never share your address.
+              </div>
+              <div class="meta">
+                tadaify · sent via Supabase Auth · <a href="https://tadaify.com">tadaify.com</a><br/>
+                Need help? Reply to this email — a human reads every reply.
+              </div>
+            </footer>
+          </article>
+        </div>
+      </div>
+    </div>
+
+    <!-- Plain-text fallback rendered separately -->
+    <section class="plaintext-section">
+      <h3>What plain-text-only clients see (multipart/alternative — text/plain part)</h3>
+<pre>tadaify
+
+Hey @waserek,
+
+Welcome to tadaify. Type these 6 digits back into the signup form
+to finish creating your account:
+
+    184629
+
+Code expires in 10 minutes.
+
+That's the whole step — no link to click, no password to set right
+now. We'll get you posting your first link in under a minute.
+
+  Price locked for life · 30-day money-back · GDPR-compliant
+
+If you didn't sign up for tadaify, you can safely ignore this email.
+We never share your address.
+
+—
+tadaify
+https://tadaify.com
+Need help? Just reply — a human reads every reply.
+</pre>
+    </section>
+
+    <section class="spec-notes">
+      <div class="spec-notes-card">
+        <h3>Spec notes — what this mockup demonstrates</h3>
+        <ul>
+          <li><strong>Single CTA:</strong> the 6-digit code. No <code>{{ .ConfirmationURL }}</code> button rendered (DEC-294 — OTP-only).</li>
+          <li><strong>Token rendering:</strong> 56px Crimson Pro display, letter-spacing 0.16em, <code>font-feature-settings: "tnum","lnum"</code> for unambiguous digits (ECN-150-06).</li>
+          <li><strong>No external assets:</strong> wordmark is styled text, not an image; no CDN font fetched in the email body itself (ECN-150-02). Page chrome uses `tokens.css` purely for mockup display.</li>
+          <li><strong>Dark-mode parity:</strong> right-side preview shows what Apple Mail dark / Gmail dark renders (ECN-150-03). All chips and disclaimers stay readable; brand hues shift to the indigo-200 / amber-300 family.</li>
+          <li><strong>Trust strip:</strong> 🔒 Price locked for life · 💸 30-day money-back · 🛡 GDPR-compliant — same chips that appear under the register form.</li>
+          <li><strong>Plain-text fallback:</strong> rendered above; `multipart/alternative` is mandatory per TR-tadaify-002.</li>
+          <li><strong>Subject:</strong> <code>Your tadaify code: {{ .Token }}</code> — set via <code>config.toml [auth.email.template.signup]</code>.</li>
+          <li><strong>Greeting:</strong> uses captured handle from the register form (<code>@waserek</code>). If the handle is not yet bound at send-time, fall back to <code>Hey there 👋</code>.</li>
+        </ul>
+      </div>
+    </section>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Branded HTML email mockups for the Phase 1 OTP-only auth flow per issue #150. Two templates rendered inside an Inbucket-style email-client preview frame (light + dark side-by-side) plus a side-by-side compare and a landing index. Mockup-only PR — gates refinement; implementation against `supabase/templates/auth/` does not start until the user accepts.

Files added under `mockups/tadaify-mvp/emails/`:

- `index.html` — Phase 1 + Phase 2 landing with tile previews
- `otp-signup.html` — Inbucket frame, light + dark email client, plain-text fallback, spec notes
- `otp-login.html` — DEC-307 returning-user variant with non-clickable device card
- `_email-tokens-preview.html` — compare grid + diff annotations
- `legacy-gallery.html` — the former `index.html` 10-template gallery, preserved untouched

## Business requirements implemented

- BR-tadaify-AUTH (Slice B) — register and login emails carry the branded indigo-serif design and a single 6-digit code as the only CTA. (BR doc currently lives under the Slice B requirement bundle; mockup demonstrates the visual + content contract.)

## Technical requirements introduced or relied on

- TR-tadaify-002 — every transactional email ships `multipart/alternative` (`text/html` + `text/plain`). The mockups render the HTML body inside an Inbucket frame and surface the plain-text part in a separate `<pre>` block per template.
- ECN-150-02 — email body fetches no external image / no external font CDN. Wordmark is styled text; trust strip is unicode + text. (Page chrome around the frame is allowed to use `tokens.css`; the rendered email body is fully self-contained.)
- ECN-150-03 — dark-mode email client parity. Each Inbucket card has a `light` and a `dark` variant rendered side-by-side so reviewers can verify Apple Mail dark / Gmail dark readability without flipping OS theme.
- ECN-150-06 — token-disambiguation. 56px Crimson Pro + `font-feature-settings: "tnum","lnum"` plus 0.16em letter-spacing keeps 0/O and 1/l/I cleanly distinct.

## Acceptance criteria from issue (verbatim)

This PR addresses the *mockup* surface of #150's Phase 1. The implementation criteria (`supabase/templates/auth/...`, `config.toml` wiring, local Mailpit smoke) remain open for the follow-up implementation PR.

- [ ] `supabase/templates/auth/otp-signup.html` shipped — *not in this PR (mockup gates impl)*
- [ ] `supabase/templates/auth/otp-login.html` shipped — *not in this PR*
- [ ] `config.toml` wires both templates with custom subject lines — *not in this PR*
- [ ] Plain-text alternative present in each template (multipart MIME) — *demonstrated in mockup as a `<pre>` block per template*
- [ ] Local smoke: `supabase start` + register from UI → Mailpit shows branded HTML email — *post-impl smoke*
- [ ] Local smoke for login path — *post-impl smoke*
- [x] Visual check vs `mockups/tadaify-mvp/register.html` aesthetic — colors, typography, trust chips align — *verified in mockup; reviewer confirms before merge*

## Test plan

No automated tests — mockup-only PR. Manual verification:

- Open `mockups/tadaify-mvp/emails/index.html` in Chrome/Safari and click each Phase 1 tile.
- Open `otp-signup.html` and `otp-login.html`. Verify:
  - Light email-client card on the left, dark email-client card on the right.
  - Wordmark uses indigo `ta` + amber `da!` + dark `ify`.
  - Token block reads cleanly at 56px with no ambiguity between 0/O.
  - Trust strip chips match the chips visible under the register form.
  - Plain-text fallback section underneath shows the equivalent text-only content.
- Open `_email-tokens-preview.html` — both templates render side-by-side; the diff table at the bottom lists subject / config slot / greeting / device-card differences.
- Compare visually against `mockups/tadaify-mvp/register.html` — palette, fonts, chips align.

Edge cases worth flagging in the diff table (carried into ECNs):

- ECN-150-02 (no external assets) — confirmed visually: no `<img src="https://...">`, no `<link rel="stylesheet" href="https://fonts...">` inside the email body.
- ECN-150-03 (dark client) — confirmed: side-by-side dark variant renders with adequate contrast.
- ECN-150-06 (token disambiguation) — confirmed: numeric variants 184629 and 502718 are easy to read; recommend the user spot-check 0/O and 1/l/I if they want to commission an alternate token render.

## Mockup

Phase 1 OTP email mockup landing:
https://github.com/graspsoftwarepw/tadaify-app/blob/mockup/email-templates-150/mockups/tadaify-mvp/emails/index.html

(After merge, swap the URL above to `/blob/main/mockups/tadaify-mvp/emails/index.html` per the "Story mockup refs to main, not branch" memory rule.)

## Rollback

Pure additive content-only change in `mockups/tadaify-mvp/emails/`:

```
git revert <merge-sha>
```

The only non-additive operation in the PR is `git mv mockups/tadaify-mvp/emails/index.html → legacy-gallery.html`. Revert restores the original `index.html` and removes the four new files. No DB, no config, no runtime impact.

---

## Context for the reviewer (Codex / human)

- Phase 1 of #150 was always going to be content-only (mockup → review → impl). Implementation against `supabase/templates/auth/` is intentionally NOT in this PR per the project rule that mockups gate refinement.
- The directory already contained a 10-template gallery (`index.html` + `supabase-auth/` + `resend/` subdirs from PR #133-cascade). That gallery predates the locked Slice B OTP-only contract (DEC-294 says register is OTP-only — the legacy `verify-signup.html` ships a magic link, contradicting the lock). I preserved the legacy gallery as `legacy-gallery.html` rather than deleting it; there's a discoverable link from the new landing.
- The new `index.html` is the Phase 1 + Phase 2 landing brief asked for; the legacy 10-template view stays available one click away.

## Codex pairing notes

- Frame HTML uses inline `<style>` blocks for readability. The implementation step that ships `supabase/templates/auth/otp-signup.html` MUST inline every CSS rule onto the matching tag (Outlook + Gmail strip `<style>`). Treat the mockup CSS as the spec, not the shipping CSS.
- Token disambiguation (ECN-150-06) currently rides on Crimson Pro's natural 0/O / 1/l/I separation + `font-feature-settings`. If a reviewer wants a true monospace fallback, that's a separate ECN — flag rather than add silently.
- Device card on `otp-login.html` shows mock data (Chrome / macOS / Warsaw). Real values come from the Supabase auth-event payload; the binding is an impl-step concern, not a mockup concern.
