### PR TITLE
Email mockups Phase 1 v2 — signup + login OTP per #150 (brand-clean)

### DIFF
--- a/mockups/tadaify-mvp/emails/_email-tokens-preview.html
+++ b/mockups/tadaify-mvp/emails/_email-tokens-preview.html
@@ -161,6 +161,9 @@ created_at: 2026-05-02T13:10:00Z
               </div>
             </div>
           </div>
+        </div>
+      </div>
+    </div>
 
     <div>
       <div class="scheme-label">Login OTP — Subject: "Sign in to tadaify: 502718"</div>
@@ -235,30 +238,6 @@ created_at: 2026-05-02T13:10:00Z
         </div>
       </div>
       <div class="token">
-        <div class="swatch" style="background:#FFFBEB"></div>
-        <div class="meta">
-          <span class="name">trust bg</span>
-          <span class="val">#FFFBEB</span>
-          <span class="role">Trust strip — warm tint</span>
-        </div>
-      </div>
-      <div class="token">
-        <div class="swatch" style="background:#FDE68A"></div>
-        <div class="meta">
-          <span class="name">trust border</span>
-          <span class="val">#FDE68A</span>
-          <span class="role">Trust strip border</span>
-        </div>
-      </div>
-      <div class="token">
-        <div class="swatch" style="background:#92400E"></div>
-        <div class="meta">
-          <span class="name">trust fg</span>
-          <span class="val">#92400E</span>
-          <span class="role">Trust strip text</span>
-        </div>
-      </div>
-      <div class="token">
         <div class="swatch" style="background:#4B5563"></div>
         <div class="meta">
           <span class="name">fg-muted</span>
@@ -314,15 +293,11 @@ created_at: 2026-05-02T13:10:00Z
 
   <section class="tokens-section" style="margin-top:32px">
     <h2>Spacing &amp; radius</h2>
-    <p>Email layout uses fixed pixel values (em / rem / clamp() unsupported in many mail clients). Card max-width 600px, padded 28-32px. Radius 14px on email card and OTP container, 12px on trust strip, 10px on plain section.</p>
+    <p>Email layout uses fixed pixel values (em / rem / clamp() unsupported in many mail clients). Card max-width 600px, padded 28-32px. Radius 14px on email card and OTP container, 10px on plain section.</p>
     <div class="token-grid">
       <div class="token">
         <div class="swatch" style="background:#E5E7EB; border-radius:14px"></div>
         <div class="meta"><span class="name">card-radius</span><span class="val">14px</span><span class="role">Email + OTP card</span></div>
-      </div>
-      <div class="token">
-        <div class="swatch" style="background:#E5E7EB; border-radius:12px"></div>
-        <div class="meta"><span class="name">trust-radius</span><span class="val">12px</span><span class="role">Trust strip</span></div>
       </div>
       <div class="token">
         <div class="swatch" style="background:#E5E7EB; width:60px"></div>

--- a/mockups/tadaify-mvp/emails/_email-tokens-preview.html
+++ b/mockups/tadaify-mvp/emails/_email-tokens-preview.html
@@ -1,0 +1,360 @@
+<!--
+type: mockup
+project: tadaify
+title: Auth emails — design tokens compare (signup vs login side-by-side)
+created_at: 2026-05-02T13:10:00Z
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>tadaify — Email tokens preview</title>
+  <link rel="stylesheet" href="../shared/tokens.css">
+  <style>
+    body { background: var(--bg-muted); padding: 32px clamp(16px,4vw,48px); }
+    .page-header { max-width: 1480px; margin: 0 auto 18px; display: flex; align-items: baseline; gap: 16px; flex-wrap: wrap; }
+    .page-header h1 { font-size: 28px; }
+    .page-header .pill { padding: 4px 10px; border-radius: var(--radius-full); font-size: 11px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; background: var(--info-bg); color: var(--info); }
+    .page-header .crumbs { font-size: 13px; color: var(--fg-muted); }
+    .page-header .crumbs a { color: var(--brand-primary); }
+    .page-intro { max-width: 980px; margin: 0 auto 28px; color: var(--fg-muted); font-size: 14px; line-height: 1.6; }
+
+    .compare-grid { max-width: 1480px; margin: 0 auto 32px; display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
+    @media (max-width: 1100px) { .compare-grid { grid-template-columns: 1fr; } }
+    .scheme-label { font-size: 12px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: var(--fg-muted); margin: 0 0 8px 4px; }
+
+    /* compact email card (one-shot, no Inbucket frame here) */
+    .mini-card { background: var(--bg-elevated); border: 1px solid var(--border); border-radius: var(--radius-lg); box-shadow: var(--shadow); overflow: hidden; }
+    .mini-card .head { padding: 14px 22px; border-bottom: 1px solid var(--border); font-family: var(--font-mono); font-size: 12px; color: var(--fg-muted); display: flex; justify-content: space-between; gap: 12px; flex-wrap: wrap; }
+    .mini-card .head .subj { color: var(--fg); font-weight: 600; }
+    .mini-card .canvas { padding: 24px; background: #F3F4F6; }
+
+    .email {
+      max-width: 560px; margin: 0 auto;
+      background: #FFFFFF;
+      border-radius: 14px;
+      overflow: hidden;
+      font-family: 'Inter', system-ui, sans-serif;
+      color: #111827;
+      box-shadow: 0 4px 12px rgba(17,24,39,0.08);
+    }
+    .email-mark { padding: 24px 28px 6px; }
+    .email-mark .wordmark {
+      font-family: 'Crimson Pro', Georgia, serif;
+      font-weight: 600; letter-spacing: -0.02em; font-size: 26px; line-height: 1;
+      display: inline-flex; align-items: baseline;
+    }
+    .email-mark .wm-ta  { color: #6366F1; }
+    .email-mark .wm-da  { color: #F59E0B; }
+    .email-mark .wm-ify { color: #111827; }
+
+    .email-body { padding: 12px 28px 28px; }
+    .greeting { font-family: 'Crimson Pro', Georgia, serif; font-weight: 600; font-size: 24px; line-height: 1.2; margin: 0 0 4px; color: #111827; }
+    .sub { font-size: 14px; color: #4B5563; margin: 0 0 22px; line-height: 1.55; }
+
+    .otp-card { background: #F9FAFB; border: 1px solid #E5E7EB; border-radius: 12px; padding: 22px 18px; text-align: center; margin-bottom: 18px; }
+    .otp-label { font-size: 10px; font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase; color: #6B7280; margin: 0 0 12px; }
+    .otp-code { font-family: 'Crimson Pro', Georgia, serif; font-weight: 600; font-size: 48px; letter-spacing: 0.1em; color: #111827; line-height: 1; font-feature-settings: "tnum" 1, "lnum" 1; margin: 0 0 10px; }
+    .otp-expiry { font-size: 12px; color: #6B7280; margin: 0; }
+    .otp-expiry strong { color: #111827; font-weight: 600; }
+
+    .trust-strip { margin-top: 22px; padding: 14px 16px; background: #FFFBEB; border: 1px solid #FDE68A; border-radius: 10px; display: flex; flex-wrap: wrap; gap: 6px 14px; justify-content: center; font-size: 11px; color: #92400E; font-weight: 500; }
+
+    /* annotation strip */
+    .tokens-section { max-width: 1480px; margin: 0 auto; }
+    .tokens-section h2 { font-size: 22px; margin-bottom: 6px; }
+    .tokens-section p { font-size: 13px; color: var(--fg-muted); margin-bottom: 18px; max-width: 880px; line-height: 1.6; }
+
+    .token-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+      gap: 12px;
+    }
+    .token {
+      background: var(--bg-elevated);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 14px 16px;
+      display: flex; align-items: center; gap: 12px;
+    }
+    .token .swatch {
+      width: 36px; height: 36px; border-radius: 8px; flex-shrink: 0;
+      border: 1px solid var(--border-strong);
+    }
+    .token .meta { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+    .token .name { font-family: var(--font-mono); font-size: 12px; color: var(--fg); font-weight: 600; }
+    .token .val { font-family: var(--font-mono); font-size: 11px; color: var(--fg-muted); }
+    .token .role { font-size: 11px; color: var(--fg-subtle); }
+
+    .typography-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(280px,1fr));
+      gap: 12px;
+      margin-top: 16px;
+    }
+    .typo {
+      background: var(--bg-elevated);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 14px 16px;
+    }
+    .typo .label { font-family: var(--font-mono); font-size: 11px; color: var(--fg-subtle); margin-bottom: 8px; }
+    .typo .specimen { color: var(--fg); }
+    .typo .meta { font-family: var(--font-mono); font-size: 10px; color: var(--fg-muted); margin-top: 6px; }
+
+    .wm-spec { font-family: 'Crimson Pro', Georgia, serif; font-weight: 600; font-size: 28px; letter-spacing: -0.02em; line-height: 1; }
+    .wm-spec .wm-ta  { color: #6366F1; }
+    .wm-spec .wm-da  { color: #F59E0B; }
+    .wm-spec .wm-ify { color: #111827; }
+    .greet-spec { font-family: 'Crimson Pro', Georgia, serif; font-weight: 600; font-size: 22px; letter-spacing: -0.01em; }
+    .otp-spec { font-family: 'Crimson Pro', Georgia, serif; font-weight: 600; font-size: 36px; letter-spacing: 0.1em; font-feature-settings: "tnum" 1, "lnum" 1; }
+    .body-spec { font-family: 'Inter', sans-serif; font-size: 14px; line-height: 1.65; color: #374151; }
+
+    .lock-callout {
+      max-width: 1480px; margin: 32px auto 0;
+      background: rgba(99,102,241,0.08);
+      border: 1px solid rgba(99,102,241,0.32);
+      border-radius: var(--radius);
+      padding: 18px 22px;
+      font-size: 13px;
+      color: var(--fg);
+      line-height: 1.6;
+    }
+    .lock-callout strong { color: var(--brand-primary); }
+
+    .footer-links { max-width: 1480px; margin: 28px auto 0; font-size: 12px; color: var(--fg-subtle); text-align: center; }
+    .footer-links a { color: var(--brand-primary); margin: 0 8px; }
+  </style>
+</head>
+<body>
+
+  <header class="page-header">
+    <span class="pill">Tokens compare</span>
+    <h1>Email auth — design tokens at a glance</h1>
+    <span class="crumbs"><a href="./index.html">← email gallery</a></span>
+  </header>
+
+  <p class="page-intro">
+    Side-by-side reference of both Phase 1 auth emails (signup + login). Below: every CSS token used inside the email body. Email mockups are rendered with inline styles (no external stylesheet, no remote fonts, no remote images) — the values listed here are the source of truth that downstream Supabase GoTrue templates and Resend MJML templates must match exactly.
+  </p>
+
+  <div class="compare-grid">
+
+    <div>
+      <div class="scheme-label">Signup OTP — Subject: "Your tadaify code: 184629"</div>
+      <div class="mini-card">
+        <div class="head">
+          <span><strong>To:</strong> waserek@local.test</span>
+          <span class="subj">Your tadaify code: 184629</span>
+        </div>
+        <div class="canvas">
+          <div class="email">
+            <div class="email-mark">
+              <span class="wordmark"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span></span>
+            </div>
+            <div class="email-body">
+              <h1 class="greeting">Hey @waserek 👋</h1>
+              <p class="sub">welcome to tada!ify — one quick step to confirm your email.</p>
+              <div class="otp-card">
+                <p class="otp-label">Your one-time code</p>
+                <p class="otp-code">184629</p>
+                <p class="otp-expiry">Code expires in <strong>10 minutes</strong></p>
+              </div>
+              <div class="trust-strip">
+                <span>🔒 Price locked for life</span>
+                <span>💸 30-day money-back</span>
+                <span>🛡 GDPR-compliant</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div>
+      <div class="scheme-label">Login OTP — Subject: "Sign in to tadaify: 502718"</div>
+      <div class="mini-card">
+        <div class="head">
+          <span><strong>To:</strong> waserek@local.test</span>
+          <span class="subj">Sign in to tadaify: 502718</span>
+        </div>
+        <div class="canvas">
+          <div class="email">
+            <div class="email-mark">
+              <span class="wordmark"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span></span>
+            </div>
+            <div class="email-body">
+              <h1 class="greeting">Welcome back, @waserek</h1>
+              <p class="sub">signing you in to tada!ify — type the code below to continue.</p>
+              <div class="otp-card">
+                <p class="otp-label">Your sign-in code</p>
+                <p class="otp-code">502718</p>
+                <p class="otp-expiry">Code expires in <strong>10 minutes</strong></p>
+              </div>
+              <div class="trust-strip">
+                <span>🔒 Price locked for life</span>
+                <span>💸 30-day money-back</span>
+                <span>🛡 GDPR-compliant</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <section class="tokens-section">
+    <h2>Color tokens</h2>
+    <p>Hard-coded hex values inside the email body — no CSS custom properties (mail clients drop unsupported features). Mirrors <code>--wm-ta</code>, <code>--wm-da</code>, <code>--wm-ify</code> from <code>shared/tokens.css</code>.</p>
+    <div class="token-grid">
+      <div class="token">
+        <div class="swatch" style="background:#6366F1"></div>
+        <div class="meta">
+          <span class="name">wm-ta</span>
+          <span class="val">#6366F1</span>
+          <span class="role">Wordmark "ta" — indigo</span>
+        </div>
+      </div>
+      <div class="token">
+        <div class="swatch" style="background:#F59E0B"></div>
+        <div class="meta">
+          <span class="name">wm-da</span>
+          <span class="val">#F59E0B</span>
+          <span class="role">Wordmark "da!" — warm yellow (incl. !)</span>
+        </div>
+      </div>
+      <div class="token">
+        <div class="swatch" style="background:#111827"></div>
+        <div class="meta">
+          <span class="name">wm-ify</span>
+          <span class="val">#111827</span>
+          <span class="role">Wordmark "ify" — fg / dark</span>
+        </div>
+      </div>
+      <div class="token">
+        <div class="swatch" style="background:#FFFFFF; border-color:#E5E7EB"></div>
+        <div class="meta">
+          <span class="name">email bg</span>
+          <span class="val">#FFFFFF</span>
+          <span class="role">Email card surface</span>
+        </div>
+      </div>
+      <div class="token">
+        <div class="swatch" style="background:#F9FAFB"></div>
+        <div class="meta">
+          <span class="name">otp-card bg</span>
+          <span class="val">#F9FAFB</span>
+          <span class="role">Code container</span>
+        </div>
+      </div>
+      <div class="token">
+        <div class="swatch" style="background:#FFFBEB"></div>
+        <div class="meta">
+          <span class="name">trust bg</span>
+          <span class="val">#FFFBEB</span>
+          <span class="role">Trust strip — warm tint</span>
+        </div>
+      </div>
+      <div class="token">
+        <div class="swatch" style="background:#FDE68A"></div>
+        <div class="meta">
+          <span class="name">trust border</span>
+          <span class="val">#FDE68A</span>
+          <span class="role">Trust strip border</span>
+        </div>
+      </div>
+      <div class="token">
+        <div class="swatch" style="background:#92400E"></div>
+        <div class="meta">
+          <span class="name">trust fg</span>
+          <span class="val">#92400E</span>
+          <span class="role">Trust strip text</span>
+        </div>
+      </div>
+      <div class="token">
+        <div class="swatch" style="background:#4B5563"></div>
+        <div class="meta">
+          <span class="name">fg-muted</span>
+          <span class="val">#4B5563</span>
+          <span class="role">Sub copy</span>
+        </div>
+      </div>
+      <div class="token">
+        <div class="swatch" style="background:#6B7280"></div>
+        <div class="meta">
+          <span class="name">fg-subtle</span>
+          <span class="val">#6B7280</span>
+          <span class="role">OTP label / disclaimer</span>
+        </div>
+      </div>
+      <div class="token">
+        <div class="swatch" style="background:#E5E7EB"></div>
+        <div class="meta">
+          <span class="name">border</span>
+          <span class="val">#E5E7EB</span>
+          <span class="role">Card + divider strokes</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="tokens-section" style="margin-top:32px">
+    <h2>Typography tokens</h2>
+    <p>Three families only: <code>Crimson Pro</code> (display) → falls back to <code>Georgia</code> → <code>serif</code>. <code>Inter</code> (body) → falls back to system stack. <code>JetBrains Mono</code> never used inside the email body (it's only in the Inbucket chrome around the email). No remote font load — fallbacks must look acceptable in plain Outlook.</p>
+    <div class="typography-grid">
+      <div class="typo">
+        <div class="label">wordmark · Crimson Pro 600 · 28px · -0.02em</div>
+        <div class="specimen wm-spec"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span></div>
+        <div class="meta">font-family: 'Crimson Pro', Georgia, serif</div>
+      </div>
+      <div class="typo">
+        <div class="label">greeting · Crimson Pro 600 · 26px · -0.01em</div>
+        <div class="specimen greet-spec">Hey @waserek 👋</div>
+        <div class="meta">line-height 1.2</div>
+      </div>
+      <div class="typo">
+        <div class="label">otp-code · Crimson Pro 600 · 56px · 0.1em · tnum</div>
+        <div class="specimen otp-spec">184629</div>
+        <div class="meta">font-feature-settings: "tnum" 1, "lnum" 1</div>
+      </div>
+      <div class="typo">
+        <div class="label">body · Inter 400 · 14px · 1.65</div>
+        <div class="specimen body-spec">Type the 6 digits above into the page that's still open in your browser.</div>
+        <div class="meta">font-family: 'Inter', system-ui, sans-serif</div>
+      </div>
+    </div>
+  </section>
+
+  <section class="tokens-section" style="margin-top:32px">
+    <h2>Spacing &amp; radius</h2>
+    <p>Email layout uses fixed pixel values (em / rem / clamp() unsupported in many mail clients). Card max-width 600px, padded 28-32px. Radius 14px on email card and OTP container, 12px on trust strip, 10px on plain section.</p>
+    <div class="token-grid">
+      <div class="token">
+        <div class="swatch" style="background:#E5E7EB; border-radius:14px"></div>
+        <div class="meta"><span class="name">card-radius</span><span class="val">14px</span><span class="role">Email + OTP card</span></div>
+      </div>
+      <div class="token">
+        <div class="swatch" style="background:#E5E7EB; border-radius:12px"></div>
+        <div class="meta"><span class="name">trust-radius</span><span class="val">12px</span><span class="role">Trust strip</span></div>
+      </div>
+      <div class="token">
+        <div class="swatch" style="background:#E5E7EB; width:60px"></div>
+        <div class="meta"><span class="name">card-pad</span><span class="val">28-32px</span><span class="role">Email body padding</span></div>
+      </div>
+      <div class="token">
+        <div class="swatch" style="background:#E5E7EB; width:80px; height:24px"></div>
+        <div class="meta"><span class="name">max-width</span><span class="val">600px</span><span class="role">Email canvas</span></div>
+      </div>
+    </div>
+  </section>
+
+  <div class="lock-callout">
+    <strong>Brand lock — DEC-WORDMARK-01 (2026-04-24).</strong> Wordmark renders as <span class="wm-spec" style="font-size:18px;"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span></span> across every surface — zero separators, zero hyphen, zero middle-dot, zero <code>&lt;span class="hyp"&gt;</code>. The <code>!</code> belongs to the <code>da!</code> partition (warm yellow). No exceptions.
+  </div>
+
+  <p class="footer-links"><a href="./index.html">← back to email gallery</a> · <a href="./otp-signup.html">signup OTP</a> · <a href="./otp-login.html">login OTP</a></p>
+
+</body>
+</html>

--- a/mockups/tadaify-mvp/emails/_email-tokens-preview.html
+++ b/mockups/tadaify-mvp/emails/_email-tokens-preview.html
@@ -59,8 +59,6 @@ created_at: 2026-05-02T13:10:00Z
     .otp-expiry { font-size: 12px; color: #6B7280; margin: 0; }
     .otp-expiry strong { color: #111827; font-weight: 600; }
 
-    .trust-strip { margin-top: 22px; padding: 14px 16px; background: #FFFBEB; border: 1px solid #FDE68A; border-radius: 10px; display: flex; flex-wrap: wrap; gap: 6px 14px; justify-content: center; font-size: 11px; color: #92400E; font-weight: 500; }
-
     /* annotation strip */
     .tokens-section { max-width: 1480px; margin: 0 auto; }
     .tokens-section h2 { font-size: 22px; margin-bottom: 6px; }
@@ -161,11 +159,6 @@ created_at: 2026-05-02T13:10:00Z
                 <p class="otp-code">184629</p>
                 <p class="otp-expiry">Code expires in <strong>10 minutes</strong></p>
               </div>
-              <div class="trust-strip">
-                <span>🔒 Price locked for life</span>
-                <span>💸 30-day money-back</span>
-                <span>🛡 GDPR-compliant</span>
-              </div>
             </div>
           </div>
         </div>
@@ -191,11 +184,6 @@ created_at: 2026-05-02T13:10:00Z
                 <p class="otp-label">Your sign-in code</p>
                 <p class="otp-code">502718</p>
                 <p class="otp-expiry">Code expires in <strong>10 minutes</strong></p>
-              </div>
-              <div class="trust-strip">
-                <span>🔒 Price locked for life</span>
-                <span>💸 30-day money-back</span>
-                <span>🛡 GDPR-compliant</span>
               </div>
             </div>
           </div>

--- a/mockups/tadaify-mvp/emails/_email-tokens-preview.html
+++ b/mockups/tadaify-mvp/emails/_email-tokens-preview.html
@@ -161,9 +161,6 @@ created_at: 2026-05-02T13:10:00Z
               </div>
             </div>
           </div>
-        </div>
-      </div>
-    </div>
 
     <div>
       <div class="scheme-label">Login OTP — Subject: "Sign in to tadaify: 502718"</div>

--- a/mockups/tadaify-mvp/emails/index.html
+++ b/mockups/tadaify-mvp/emails/index.html
@@ -1,479 +1,251 @@
+<!--
+type: mockup
+project: tadaify
+title: Auth email templates Phase 1 index
+created_at: 2026-05-02T13:15:00Z
+-->
 <!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>tadaify — Email templates gallery</title>
+  <title>tadaify — Email mockups · Phase 1</title>
   <link rel="stylesheet" href="../shared/tokens.css">
   <style>
-    /* --- Page chrome --- */
     body { background: var(--bg-muted); }
     .gallery-header {
-      position: sticky; top: 0; z-index: 100;
+      position: sticky; top: 0; z-index: 10;
       background: rgba(249,250,251,0.92);
       backdrop-filter: saturate(180%) blur(12px);
       border-bottom: 1px solid var(--border);
-      padding: 14px clamp(16px,4vw,32px);
-      display: flex; align-items: center; gap: 16px; flex-wrap: wrap;
+      padding: 16px clamp(16px,4vw,40px);
+      display: flex; align-items: baseline; gap: 16px; flex-wrap: wrap;
     }
-    .gallery-header .brand { display: inline-flex; align-items: baseline; font-family: var(--font-display); font-weight: 600; font-size: 22px; letter-spacing: -0.02em; }
-    .gallery-header .brand .ta { color: var(--brand-primary); }
-    .gallery-header .brand .da { color: var(--brand-warm); }
-    .gallery-header .brand .ify { color: var(--fg); }
+    .gallery-header .wordmark {
+      font-family: var(--font-display); font-weight: 600;
+      font-size: 22px; letter-spacing: -0.02em;
+      display: inline-flex; align-items: baseline;
+    }
     .gallery-header h1 {
-      font-family: var(--font-sans); font-size: 14px; font-weight: 600;
-      letter-spacing: 0.06em; text-transform: uppercase; color: var(--fg-muted);
-      margin-left: 4px;
+      font-family: var(--font-sans); font-size: 13px; font-weight: 600;
+      letter-spacing: 0.08em; text-transform: uppercase; color: var(--fg-muted);
     }
-    .gallery-toolbar { margin-left: auto; display: inline-flex; gap: 8px; align-items: center; flex-wrap: wrap; }
-    .toggle-group { display: inline-flex; background: var(--bg-elevated); border: 1px solid var(--border-strong); border-radius: var(--radius-full); padding: 3px; gap: 0; }
-    .toggle-group button {
-      border: 0; background: transparent; padding: 6px 14px;
-      font-size: 13px; font-weight: 600; color: var(--fg-muted);
-      border-radius: var(--radius-full); cursor: pointer;
-      transition: background 140ms, color 140ms;
-    }
-    .toggle-group button.active { background: var(--brand-primary); color: #FFF; }
-    .toggle-group button:hover:not(.active) { background: var(--bg-muted); color: var(--fg); }
+    .gallery-header .crumbs { margin-left: auto; font-size: 13px; color: var(--fg-muted); }
+    .gallery-header .crumbs a { color: var(--brand-primary); }
 
-    .gallery-intro {
-      max-width: 880px; margin: 32px auto 16px;
-      padding: 0 clamp(16px,4vw,32px);
+    .intro { max-width: 880px; margin: 36px auto 24px; padding: 0 clamp(16px,4vw,40px); }
+    .intro h2 { font-size: 32px; margin-bottom: 10px; letter-spacing: -0.02em; }
+    .intro p { color: var(--fg-muted); font-size: 15px; line-height: 1.65; max-width: 720px; }
+    .intro .meta-pills { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 18px; }
+    .pill {
+      padding: 4px 10px; border-radius: var(--radius-full);
+      font-size: 11px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase;
     }
-    .gallery-intro h2 { font-size: 32px; margin-bottom: 8px; }
-    .gallery-intro p { color: var(--fg-muted); font-size: 16px; line-height: 1.6; }
-    .gallery-intro .meta-pills { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 16px; }
+    .pill.info  { background: var(--info-bg);    color: var(--info); }
+    .pill.warm  { background: rgba(245,158,11,0.15); color: #92400E; }
+    .pill.ok    { background: var(--success-bg); color: var(--success); }
+    .pill.muted { background: var(--bg-elevated); color: var(--fg-muted); border: 1px solid var(--border); }
 
-    .toc {
-      max-width: 880px; margin: 0 auto 32px;
-      padding: 0 clamp(16px,4vw,32px);
+    .section-title {
+      max-width: 880px; margin: 32px auto 14px; padding: 0 clamp(16px,4vw,40px);
+      font-size: 13px; font-weight: 700; letter-spacing: 0.1em;
+      text-transform: uppercase; color: var(--fg-muted);
     }
-    .toc-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px,1fr)); gap: 8px; }
-    .toc-link {
-      display: block; padding: 10px 14px; background: var(--bg-elevated);
-      border: 1px solid var(--border); border-radius: var(--radius);
-      font-size: 13px; color: var(--fg); text-decoration: none;
-      transition: border 120ms, transform 120ms;
-    }
-    .toc-link:hover { border-color: var(--brand-primary); transform: translateY(-1px); }
-    .toc-link .num { color: var(--fg-subtle); font-family: var(--font-mono); font-size: 11px; margin-right: 8px; }
-    .toc-link .stack { display: inline-block; margin-left: 8px; padding: 1px 6px; font-size: 10px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; border-radius: 4px; }
-    .toc-link .stack.sb { background: rgba(99,102,241,0.12); color: var(--brand-primary); }
-    .toc-link .stack.rs { background: rgba(245,158,11,0.15); color: #92400E; }
 
-    /* --- Email card --- */
-    .email-card {
-      max-width: 880px; margin: 32px auto;
+    .tile-grid {
+      max-width: 880px; margin: 0 auto;
+      padding: 0 clamp(16px,4vw,40px);
+      display: grid; grid-template-columns: repeat(auto-fill, minmax(260px,1fr));
+      gap: 14px;
+    }
+
+    .tile {
+      display: block;
       background: var(--bg-elevated);
       border: 1px solid var(--border);
       border-radius: var(--radius-lg);
-      box-shadow: var(--shadow);
-      overflow: hidden;
+      padding: 22px 22px 18px;
+      text-decoration: none; color: var(--fg);
+      transition: border-color 140ms, transform 140ms, box-shadow 140ms;
+      position: relative;
     }
-    .email-card-header {
-      padding: 20px 28px;
-      border-bottom: 1px solid var(--border);
+    .tile:hover { border-color: var(--brand-primary); transform: translateY(-2px); box-shadow: var(--shadow); }
+    .tile.disabled {
+      pointer-events: none;
       background: var(--bg-muted);
+      border-style: dashed;
+      color: var(--fg-muted);
     }
-    .email-meta-row { display: flex; flex-wrap: wrap; gap: 12px 24px; align-items: baseline; margin-bottom: 6px; }
-    .email-num { font-family: var(--font-mono); font-size: 12px; color: var(--fg-subtle); }
-    .email-stack-pill { font-size: 10px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; padding: 2px 8px; border-radius: 4px; }
-    .email-stack-pill.sb { background: rgba(99,102,241,0.12); color: var(--brand-primary); }
-    .email-stack-pill.rs { background: rgba(245,158,11,0.15); color: #92400E; }
-    .email-filename { font-family: var(--font-mono); font-size: 12px; color: var(--fg-muted); }
+    .tile.disabled .tile-title { color: var(--fg-muted); }
 
-    .email-subject { font-family: var(--font-display); font-size: 22px; font-weight: 600; color: var(--fg); letter-spacing: -0.01em; margin-top: 6px; }
-    .email-preheader { font-size: 13px; color: var(--fg-subtle); margin-top: 4px; font-style: italic; }
+    .tile-icon {
+      width: 40px; height: 40px;
+      border-radius: 10px;
+      background: rgba(99,102,241,0.10);
+      color: var(--brand-primary);
+      display: inline-flex; align-items: center; justify-content: center;
+      font-family: var(--font-display); font-weight: 600; font-size: 18px;
+      margin-bottom: 14px;
+    }
+    .tile.warm .tile-icon { background: rgba(245,158,11,0.15); color: #B45309; }
+    .tile.disabled .tile-icon { background: var(--bg-sunken); color: var(--fg-subtle); }
 
-    .email-card-toolbar {
-      display: flex; flex-wrap: wrap; gap: 8px;
-      padding: 12px 28px; background: var(--bg);
-      border-bottom: 1px solid var(--border);
-    }
-    .email-card-toolbar .small-toggle {
-      font-size: 12px; font-weight: 600; padding: 5px 11px;
-      background: var(--bg-elevated); border: 1px solid var(--border-strong);
-      border-radius: var(--radius-full); color: var(--fg-muted);
-      cursor: pointer; transition: background 120ms, color 120ms, border-color 120ms;
-    }
-    .email-card-toolbar .small-toggle.active {
-      background: var(--brand-primary); color: #FFF; border-color: var(--brand-primary);
-    }
-    .email-card-toolbar .small-toggle:hover:not(.active) { background: var(--bg-muted); color: var(--fg); }
-    .email-card-toolbar .copy-btn {
-      margin-left: auto; font-size: 12px; font-weight: 600;
-      background: var(--fg); color: var(--fg-inverse);
-      border: 0; padding: 6px 14px; border-radius: var(--radius-full); cursor: pointer;
-      display: inline-flex; align-items: center; gap: 6px;
-    }
-    .email-card-toolbar .copy-btn:hover { background: var(--brand-primary); }
-    .email-card-toolbar .copy-btn.ok { background: var(--success); }
+    .tile-title { font-family: var(--font-display); font-weight: 600; font-size: 18px; margin: 0 0 4px; line-height: 1.25; letter-spacing: -0.01em; }
+    .tile-sub { font-size: 13px; color: var(--fg-muted); line-height: 1.5; margin: 0 0 10px; }
+    .tile-meta { font-family: var(--font-mono); font-size: 11px; color: var(--fg-subtle); }
 
-    /* Iframe stage */
-    .email-stage {
-      padding: 24px;
-      background: repeating-linear-gradient(45deg, transparent 0, transparent 12px, rgba(17,24,39,0.02) 12px, rgba(17,24,39,0.02) 13px), var(--bg-muted);
-      display: flex; justify-content: center;
-      transition: background 200ms;
+    .tile-status {
+      position: absolute; top: 14px; right: 14px;
+      padding: 2px 8px; border-radius: var(--radius-full);
+      font-size: 10px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase;
     }
-    .email-stage.dark { background: var(--bg-dark); }
-    .email-iframe {
-      border: 1px solid var(--border-strong);
-      background: #FFF;
-      width: 100%;
-      max-width: 640px;
-      min-height: 600px;
-      transition: max-width 220ms ease, min-height 220ms ease;
-      box-shadow: var(--shadow-lg);
-      border-radius: 6px;
-    }
-    .email-iframe.mobile { max-width: 375px; }
-    .email-stage.dark .email-iframe { border-color: #1F2937; box-shadow: 0 12px 32px rgba(0,0,0,0.5); }
+    .tile-status.ok { background: var(--success-bg); color: var(--success); }
+    .tile-status.next { background: var(--info-bg); color: var(--info); }
+    .tile-status.later { background: var(--bg-sunken); color: var(--fg-muted); }
 
-    /* Source view */
-    details.email-source {
-      margin: 0; padding: 0;
+    .lock-strip {
+      max-width: 880px; margin: 36px auto 0;
+      padding: 0 clamp(16px,4vw,40px);
+    }
+    .lock-strip .card {
+      background: rgba(99,102,241,0.07);
+      border: 1px solid rgba(99,102,241,0.30);
+      border-radius: var(--radius);
+      padding: 18px 22px;
+      font-size: 13px;
+      line-height: 1.65;
+      color: var(--fg);
+    }
+    .lock-strip .card strong { color: var(--brand-primary); }
+    .lock-strip .card code {
+      background: var(--bg-elevated);
+      border: 1px solid var(--border);
+      padding: 1px 6px;
+      border-radius: 4px;
+      font-family: var(--font-mono);
+      font-size: 12px;
+    }
+
+    .footer-meta {
+      max-width: 880px; margin: 32px auto 48px;
+      padding: 18px clamp(16px,4vw,40px);
+      font-size: 12px; color: var(--fg-subtle);
       border-top: 1px solid var(--border);
+      display: flex; gap: 18px; flex-wrap: wrap; justify-content: space-between;
     }
-    details.email-source > summary {
-      cursor: pointer; padding: 12px 28px;
-      font-family: var(--font-mono); font-size: 12px; color: var(--fg-muted);
-      list-style: none; display: flex; align-items: center; gap: 8px;
-      background: var(--bg);
-    }
-    details.email-source > summary::-webkit-details-marker { display: none; }
-    details.email-source > summary::before {
-      content: "▸"; transition: transform 140ms; color: var(--fg-subtle);
-    }
-    details.email-source[open] > summary::before { transform: rotate(90deg); }
-    details.email-source > summary:hover { background: var(--bg-muted); color: var(--fg); }
-    .source-tabs { display: flex; gap: 0; border-top: 1px solid var(--border); background: var(--bg-muted); padding: 0 28px; }
-    .source-tabs button {
-      background: transparent; border: 0; padding: 10px 14px;
-      font-family: var(--font-mono); font-size: 12px; color: var(--fg-muted);
-      cursor: pointer; border-bottom: 2px solid transparent;
-    }
-    .source-tabs button.active { color: var(--brand-primary); border-bottom-color: var(--brand-primary); }
-    .source-pre {
-      margin: 0; padding: 16px 28px 20px;
-      background: #0B0F1E; color: #E5E7EB;
-      font-family: var(--font-mono); font-size: 11px; line-height: 1.55;
-      overflow-x: auto; max-height: 480px; overflow-y: auto;
-      white-space: pre; tab-size: 2;
-    }
-
-    /* Footer */
-    .gallery-footer {
-      max-width: 880px; margin: 48px auto 32px;
-      padding: 0 clamp(16px,4vw,32px);
-      text-align: center; font-size: 13px; color: var(--fg-subtle);
-    }
-
-    /* Mobile */
-    @media (max-width: 720px) {
-      .email-card-toolbar { padding: 10px 16px; }
-      .email-card-header { padding: 16px 20px; }
-      .email-stage { padding: 16px 8px; }
-      .source-tabs, .source-pre { padding-left: 16px; padding-right: 16px; }
-    }
+    .footer-meta a { color: var(--brand-primary); }
   </style>
 </head>
 <body>
 
   <header class="gallery-header">
-    <span class="brand"><span class="ta">ta</span><span class="da">da!</span><span class="ify">ify</span></span>
-    <h1>Email gallery · 10 templates</h1>
-    <div class="gallery-toolbar">
-      <span style="font-size:12px;font-weight:600;color:var(--fg-muted);text-transform:uppercase;letter-spacing:0.06em;">All previews:</span>
-      <div class="toggle-group" id="globalThemeToggle" role="tablist" aria-label="Theme preview">
-        <button data-mode="light" class="active" type="button">☀ Light</button>
-        <button data-mode="dark" type="button">☾ Dark</button>
-      </div>
-      <div class="toggle-group" id="globalSizeToggle" role="tablist" aria-label="Size preview">
-        <button data-size="desktop" class="active" type="button">🖥 Desktop</button>
-        <button data-size="mobile" type="button">📱 Mobile</button>
-      </div>
-    </div>
+    <span class="wordmark"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span></span>
+    <h1>Email mockups · Phase 1</h1>
+    <span class="crumbs"><a href="../index.html">← all mockups</a></span>
   </header>
 
-  <section class="gallery-intro">
-    <h2>tadaify in inboxes</h2>
+  <section class="intro">
+    <h2>Auth emails — Phase 1</h2>
     <p>
-      10 transactional email templates &mdash; the only place tadaify reaches users outside the app. Each card below shows the rendered preview, lets you toggle light/dark and desktop/mobile, view the production HTML, and copy it for direct paste into the prod codebase.
+      Two transactional emails cover 100% of the Phase 1 auth surface: the OTP sent on signup
+      (new visitor confirms their address) and the OTP sent on every subsequent login
+      (passwordless sign-in is the only login path in tadaify). Token-only delivery per
+      <strong>TR-tadaify-002</strong> — the email body never contains <code>{{ .ConfirmationURL }}</code>
+      or any clickable auth link. The 6-digit code is the entire auth handshake. Each mockup
+      shows the email rendered side-by-side in a light client and a dark client, plus the
+      <code>text/plain</code> multipart fallback below.
     </p>
     <div class="meta-pills">
-      <span class="pill pill-primary">4 Supabase Auth</span>
-      <span class="pill pill-warm">6 Resend custom</span>
-      <span class="pill">All have plain-text twin (.txt)</span>
-      <span class="pill">Inline CSS · Outlook-safe · WCAG AA</span>
+      <span class="pill ok">Phase 1 — ready</span>
+      <span class="pill info">tadaify-app#150</span>
+      <span class="pill warm">Brand lock 2026-04-24</span>
+      <span class="pill muted">DEC-WORDMARK-01</span>
     </div>
   </section>
 
-  <nav class="toc" aria-label="Templates">
-    <div class="toc-grid">
-      <a class="toc-link" href="#email-1"><span class="num">01</span>Confirm signup<span class="stack sb">Supabase</span></a>
-      <a class="toc-link" href="#email-2"><span class="num">02</span>Magic link<span class="stack sb">Supabase</span></a>
-      <a class="toc-link" href="#email-3"><span class="num">03</span>Reset password<span class="stack sb">Supabase</span></a>
-      <a class="toc-link" href="#email-4"><span class="num">04</span>Change email<span class="stack sb">Supabase</span></a>
-      <a class="toc-link" href="#email-5"><span class="num">05</span>Team invite<span class="stack rs">Resend</span></a>
-      <a class="toc-link" href="#email-6"><span class="num">06</span>GDPR export ready<span class="stack rs">Resend</span></a>
-      <a class="toc-link" href="#email-7"><span class="num">07</span>Subscription cancelled<span class="stack rs">Resend</span></a>
-      <a class="toc-link" href="#email-8"><span class="num">08</span>Payment failed<span class="stack rs">Resend</span></a>
-      <a class="toc-link" href="#email-9"><span class="num">09</span>Handle change confirm<span class="stack rs">Resend</span></a>
-      <a class="toc-link" href="#email-10"><span class="num">10</span>Waitlist promote<span class="stack rs">Resend</span></a>
+  <h3 class="section-title">Phase 1 — auth emails (this PR)</h3>
+
+  <div class="tile-grid">
+
+    <a class="tile" href="./otp-signup.html">
+      <span class="tile-status ok">Ready</span>
+      <span class="tile-icon">01</span>
+      <h4 class="tile-title">Signup OTP</h4>
+      <p class="tile-sub">Sent on new-account creation. Confirms email ownership with a 6-digit code. No clickable link.</p>
+      <span class="tile-meta">Subject: "Your tadaify code: 184629" · TTL 10 min</span>
+    </a>
+
+    <a class="tile" href="./otp-login.html">
+      <span class="tile-status ok">Ready</span>
+      <span class="tile-icon">02</span>
+      <h4 class="tile-title">Login OTP</h4>
+      <p class="tile-sub">Sent on every passwordless sign-in. Only auth path for returning users in Phase 1.</p>
+      <span class="tile-meta">Subject: "Sign in to tadaify: 502718" · TTL 10 min</span>
+    </a>
+
+    <a class="tile warm" href="./_email-tokens-preview.html">
+      <span class="tile-status next">Reference</span>
+      <span class="tile-icon">⌘</span>
+      <h4 class="tile-title">Tokens compare</h4>
+      <p class="tile-sub">Side-by-side mini-preview of both emails plus every color, font, and spacing token used in the email body.</p>
+      <span class="tile-meta">internal — design handoff reference</span>
+    </a>
+
+  </div>
+
+  <h3 class="section-title">Phase 2 — coming next</h3>
+
+  <div class="tile-grid">
+
+    <span class="tile disabled" aria-disabled="true">
+      <span class="tile-status later">Phase 2</span>
+      <span class="tile-icon">03</span>
+      <h4 class="tile-title">Password reset OTP</h4>
+      <p class="tile-sub">Optional once we add password sign-in alongside OTP. Same token-only contract.</p>
+      <span class="tile-meta">coming Phase 2</span>
+    </span>
+
+    <span class="tile disabled" aria-disabled="true">
+      <span class="tile-status later">Phase 2</span>
+      <span class="tile-icon">04</span>
+      <h4 class="tile-title">Email change confirm</h4>
+      <p class="tile-sub">Sent to new address when a user updates their primary email. Confirms ownership of the new address.</p>
+      <span class="tile-meta">coming Phase 2</span>
+    </span>
+
+    <span class="tile disabled" aria-disabled="true">
+      <span class="tile-status later">Phase 2</span>
+      <span class="tile-icon">05</span>
+      <h4 class="tile-title">Identity linked</h4>
+      <p class="tile-sub">Notification when a third-party identity (Google, Apple) is linked to an existing tadaify account.</p>
+      <span class="tile-meta">coming Phase 2</span>
+    </span>
+
+    <span class="tile disabled" aria-disabled="true">
+      <span class="tile-status later">Phase 2</span>
+      <span class="tile-icon">06</span>
+      <h4 class="tile-title">Welcome email</h4>
+      <p class="tile-sub">Lifecycle (not auth). Sent ~1 hour after first login with onboarding tips and trust strip.</p>
+      <span class="tile-meta">coming Phase 2</span>
+    </span>
+
+  </div>
+
+  <div class="lock-strip">
+    <div class="card">
+      <strong>Brand lock reminder — DEC-WORDMARK-01 (2026-04-24).</strong>
+      Wordmark renders as <span class="wordmark" style="font-size:14px;"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span></span>
+      across every surface — zero separators, zero hyphen, zero middle-dot, zero <code>&lt;span class="hyp"&gt;</code>.
+      The <code>!</code> belongs to the <code>da!</code> partition (warm yellow). Source of truth:
+      <code>docs/branding/brand-lock.md</code> + <code>shared/tokens.css</code> classes
+      <code>.wm-ta</code> / <code>.wm-da</code> / <code>.wm-ify</code>.
     </div>
-  </nav>
+  </div>
 
-  <!-- Template card factory: rendered via JS at bottom -->
-  <main id="emails"></main>
-
-  <footer class="gallery-footer">
-    <p>tadaify email templates · brand canon: Indigo Serif (locked 2026-04-24)</p>
-    <p style="margin-top:8px;">
-      Files: <code style="font-family:var(--font-mono);">supabase-auth/*.html</code> &middot;
-      <code style="font-family:var(--font-mono);">resend/*.html</code> &middot;
-      see <a href="./README.md">README.md</a> for integration.
-    </p>
+  <footer class="footer-meta">
+    <span>Phase 1 v2 — replaces closed PR #153 (brand-lock violation, fixed post-#155 cleanup).</span>
+    <span><a href="../index.html">all mockups</a> · <a href="https://github.com/graspsoftwarepw/tadaify-app/issues/150">issue #150</a></span>
   </footer>
 
-  <script>
-    // --- Template registry --------------------------------------------------
-    const TEMPLATES = [
-      {
-        id: 1, stack: "supabase",
-        slug: "verify-signup",
-        path: "./supabase-auth/verify-signup.html",
-        textPath: "./supabase-auth/verify-signup.txt",
-        subject: "Confirm your tadaify account",
-        preheader: "Tap once to confirm your email and start building your tadaify page. Link expires in 24 hours.",
-        from: "tadaify <noreply@tadaify.com>",
-      },
-      {
-        id: 2, stack: "supabase",
-        slug: "magic-link",
-        path: "./supabase-auth/magic-link.html",
-        textPath: "./supabase-auth/magic-link.txt",
-        subject: "Your tadaify magic login link",
-        preheader: "Tap once to sign in to tadaify. Or paste this 6-digit code. Expires in 1 hour.",
-        from: "tadaify <noreply@tadaify.com>",
-      },
-      {
-        id: 3, stack: "supabase",
-        slug: "reset-password",
-        path: "./supabase-auth/reset-password.html",
-        textPath: "./supabase-auth/reset-password.txt",
-        subject: "Reset your tadaify password",
-        preheader: "Reset your tadaify password. Link expires in 1 hour. Didn't request this? You can safely ignore this email.",
-        from: "tadaify <security@tadaify.com>",
-      },
-      {
-        id: 4, stack: "supabase",
-        slug: "change-email",
-        path: "./supabase-auth/change-email.html",
-        textPath: "./supabase-auth/change-email.txt",
-        subject: "Confirm your new email address",
-        preheader: "Confirm the email change. Both addresses must confirm. Link expires in 24 hours.",
-        from: "tadaify <security@tadaify.com>",
-      },
-      {
-        id: 5, stack: "resend",
-        slug: "team-invite",
-        path: "./resend/team-invite.html",
-        textPath: "./resend/team-invite.txt",
-        subject: "Sarah invited you to join Acme Studio on tadaify",
-        preheader: "Sarah invited you to join Acme Studio as Editor on tadaify. Accept by May 3.",
-        from: "tadaify <invites@tadaify.com>",
-      },
-      {
-        id: 6, stack: "resend",
-        slug: "gdpr-export-ready",
-        path: "./resend/gdpr-export-ready.html",
-        textPath: "./resend/gdpr-export-ready.txt",
-        subject: "Your tadaify data export is ready",
-        preheader: "Your data export is ready. Download within 7 days. Size: 2.4 MB.",
-        from: "tadaify <privacy@tadaify.com>",
-      },
-      {
-        id: 7, stack: "resend",
-        slug: "subscription-cancelled",
-        path: "./resend/subscription-cancelled.html",
-        textPath: "./resend/subscription-cancelled.txt",
-        subject: "Your tadaify subscription is cancelled (until May 27)",
-        preheader: "Your subscription is cancelled but @yourhandle stays live until May 27. Reactivate anytime to keep your locked-for-life price.",
-        from: "tadaify <billing@tadaify.com>",
-      },
-      {
-        id: 8, stack: "resend",
-        slug: "payment-failed",
-        path: "./resend/payment-failed.html",
-        textPath: "./resend/payment-failed.txt",
-        subject: "Payment for tadaify failed — please update your card",
-        preheader: "Payment for $5.00 didn't go through. Update your card before May 27 to keep your page live.",
-        from: "tadaify <billing@tadaify.com>",
-      },
-      {
-        id: 9, stack: "resend",
-        slug: "handle-change-confirm",
-        path: "./resend/handle-change-confirm.html",
-        textPath: "./resend/handle-change-confirm.txt",
-        subject: "You changed your tadaify handle: oldhandle → newhandle",
-        preheader: "Your handle changed: @oldhandle → @newhandle. Old links redirect for 30 days. Undo within 1h if this wasn't you.",
-        from: "tadaify <security@tadaify.com>",
-      },
-      {
-        id: 10, stack: "resend",
-        slug: "waitlist-promote",
-        path: "./resend/waitlist-promote.html",
-        textPath: "./resend/waitlist-promote.txt",
-        subject: "Your tadaify spot is ready! 🎉",
-        preheader: "Your tadaify handle @yourhandle is reserved. Finalize within 7 days to claim it.",
-        from: "tadaify <hello@tadaify.com>",
-      },
-    ];
-
-    const stackLabel = (s) => s === "supabase" ? "Supabase Auth" : "Resend";
-    const stackPillCls = (s) => s === "supabase" ? "sb" : "rs";
-
-    // --- Render -------------------------------------------------------------
-    const root = document.getElementById("emails");
-    TEMPLATES.forEach((t) => {
-      const card = document.createElement("section");
-      card.className = "email-card";
-      card.id = `email-${t.id}`;
-      card.dataset.slug = t.slug;
-      card.innerHTML = `
-        <header class="email-card-header">
-          <div class="email-meta-row">
-            <span class="email-num">#${String(t.id).padStart(2,'0')}</span>
-            <span class="email-stack-pill ${stackPillCls(t.stack)}">${stackLabel(t.stack)}</span>
-            <span class="email-filename">${t.path}</span>
-            <span class="email-filename" style="color:var(--fg-subtle);">From: ${t.from}</span>
-          </div>
-          <div class="email-subject">${t.subject}</div>
-          <div class="email-preheader">${t.preheader}</div>
-        </header>
-
-        <div class="email-card-toolbar">
-          <button class="small-toggle theme active" type="button" data-mode="light">☀ Light</button>
-          <button class="small-toggle theme" type="button" data-mode="dark">☾ Dark</button>
-          <span style="width:8px;"></span>
-          <button class="small-toggle size active" type="button" data-size="desktop">🖥 Desktop</button>
-          <button class="small-toggle size" type="button" data-size="mobile">📱 Mobile (375px)</button>
-          <button class="copy-btn" type="button" data-copy="html">📋 Copy HTML</button>
-          <button class="copy-btn" type="button" data-copy="text" style="background:var(--brand-warm);color:#1F2937;">📋 Copy .txt</button>
-        </div>
-
-        <div class="email-stage">
-          <iframe class="email-iframe" src="${t.path}" title="${t.subject} preview" loading="lazy"></iframe>
-        </div>
-
-        <details class="email-source">
-          <summary>View source · HTML + plain-text twin</summary>
-          <div class="source-tabs">
-            <button class="active" data-tab="html" type="button">${t.slug}.html</button>
-            <button data-tab="text" type="button">${t.slug}.txt</button>
-          </div>
-          <pre class="source-pre" data-pane="html">Loading ${t.path} …</pre>
-          <pre class="source-pre" data-pane="text" hidden>Loading ${t.textPath} …</pre>
-        </details>
-      `;
-      root.appendChild(card);
-
-      // --- Wire toolbar within this card -------------------------------------
-      const stage = card.querySelector(".email-stage");
-      const iframe = card.querySelector(".email-iframe");
-      const themeBtns = card.querySelectorAll(".small-toggle.theme");
-      const sizeBtns = card.querySelectorAll(".small-toggle.size");
-
-      themeBtns.forEach((b) => b.addEventListener("click", () => {
-        themeBtns.forEach((x) => x.classList.remove("active"));
-        b.classList.add("active");
-        const mode = b.dataset.mode;
-        stage.classList.toggle("dark", mode === "dark");
-        // Force re-render iframe with prefers-color-scheme via colorScheme attr fallback
-        try {
-          const doc = iframe.contentDocument;
-          if (doc && doc.documentElement) {
-            doc.documentElement.style.colorScheme = mode;
-            // Add a marker so @media (prefers-color-scheme: dark) approximation visible:
-            // Simulate by toggling a class — emails use prefers-color-scheme so we paint stage bg only.
-          }
-        } catch (e) { /* cross-origin or not loaded yet */ }
-      }));
-
-      sizeBtns.forEach((b) => b.addEventListener("click", () => {
-        sizeBtns.forEach((x) => x.classList.remove("active"));
-        b.classList.add("active");
-        iframe.classList.toggle("mobile", b.dataset.size === "mobile");
-      }));
-
-      // --- Source loading + tabs --------------------------------------------
-      const tabBtns = card.querySelectorAll(".source-tabs button");
-      const htmlPane = card.querySelector('.source-pre[data-pane="html"]');
-      const textPane = card.querySelector('.source-pre[data-pane="text"]');
-      let htmlSrc = null, textSrc = null;
-      const loadOnce = () => {
-        if (htmlSrc !== null) return;
-        fetch(t.path).then(r => r.text()).then(s => {
-          htmlSrc = s;
-          htmlPane.textContent = s;
-        }).catch(e => { htmlPane.textContent = `[Could not load ${t.path}]\n${e}\n\nIf running over file://, your browser may block fetch — open via a local server (e.g. \`python3 -m http.server\` from the mockups dir) to view source.`; });
-        fetch(t.textPath).then(r => r.text()).then(s => {
-          textSrc = s;
-          textPane.textContent = s;
-        }).catch(e => { textPane.textContent = `[Could not load ${t.textPath}]\n${e}`; });
-      };
-      card.querySelector("details.email-source").addEventListener("toggle", (e) => { if (e.target.open) loadOnce(); });
-
-      tabBtns.forEach((b) => b.addEventListener("click", () => {
-        tabBtns.forEach((x) => x.classList.remove("active"));
-        b.classList.add("active");
-        const which = b.dataset.tab;
-        htmlPane.hidden = which !== "html";
-        textPane.hidden = which !== "text";
-      }));
-
-      // --- Copy buttons ------------------------------------------------------
-      card.querySelectorAll(".copy-btn").forEach((b) => b.addEventListener("click", async () => {
-        const which = b.dataset.copy;
-        const url = which === "html" ? t.path : t.textPath;
-        try {
-          const res = await fetch(url);
-          const text = await res.text();
-          await navigator.clipboard.writeText(text);
-          const orig = b.textContent;
-          b.classList.add("ok");
-          b.textContent = "✓ Copied";
-          setTimeout(() => { b.classList.remove("ok"); b.textContent = orig; }, 1600);
-        } catch (e) {
-          alert(`Could not copy ${url}.\nIf running on file://, browsers may block fetch + clipboard. Open this gallery via \`python3 -m http.server\` for full functionality, or copy from disk: ${url}`);
-        }
-      }));
-    });
-
-    // --- Global toggles drive every card -----------------------------------
-    document.querySelectorAll("#globalThemeToggle button").forEach((b) => {
-      b.addEventListener("click", () => {
-        document.querySelectorAll("#globalThemeToggle button").forEach((x) => x.classList.remove("active"));
-        b.classList.add("active");
-        const mode = b.dataset.mode;
-        document.querySelectorAll(".email-card").forEach((card) => {
-          const target = card.querySelector(`.small-toggle.theme[data-mode="${mode}"]`);
-          if (target && !target.classList.contains("active")) target.click();
-        });
-      });
-    });
-    document.querySelectorAll("#globalSizeToggle button").forEach((b) => {
-      b.addEventListener("click", () => {
-        document.querySelectorAll("#globalSizeToggle button").forEach((x) => x.classList.remove("active"));
-        b.classList.add("active");
-        const size = b.dataset.size;
-        document.querySelectorAll(".email-card").forEach((card) => {
-          const target = card.querySelector(`.small-toggle.size[data-size="${size}"]`);
-          if (target && !target.classList.contains("active")) target.click();
-        });
-      });
-    });
-  </script>
 </body>
 </html>

--- a/mockups/tadaify-mvp/emails/otp-login.html
+++ b/mockups/tadaify-mvp/emails/otp-login.html
@@ -162,23 +162,6 @@ created_at: 2026-05-02T13:05:00Z
     }
     .inbucket.dark-frame .body-copy { color: #CBD5E1; }
 
-    .trust-strip {
-      margin-top: 28px;
-      padding: 18px 20px;
-      background: #FFFBEB;
-      border: 1px solid #FDE68A;
-      border-radius: 12px;
-      display: flex;
-      flex-wrap: wrap;
-      gap: 8px 16px;
-      justify-content: center;
-      font-size: 12px;
-      color: #92400E;
-      font-weight: 500;
-    }
-    .inbucket.dark-frame .trust-strip { background: rgba(245,158,11,0.08); border-color: #92400E; color: #FDE68A; }
-    .trust-strip span { white-space: nowrap; }
-
     .disclaimer {
       margin-top: 22px;
       padding-top: 22px;
@@ -270,12 +253,6 @@ created_at: 2026-05-02T13:05:00Z
 
               <p class="body-copy">Type the 6 digits above into the login page that's still open in your browser. We never email a clickable login link — only this code, only to your inbox.</p>
 
-              <div class="trust-strip">
-                <span>🔒 Price locked for life</span>
-                <span>💸 30-day money-back</span>
-                <span>🛡 GDPR-compliant</span>
-              </div>
-
               <p class="disclaimer">If you didn't request this code, someone may have typed your email by mistake — you can safely ignore this message. If sign-in attempts continue, change your email's password as a precaution.</p>
             </div>
             <div class="email-footer">
@@ -317,12 +294,6 @@ created_at: 2026-05-02T13:05:00Z
               </div>
 
               <p class="body-copy">Type the 6 digits above into the login page that's still open in your browser. We never email a clickable login link — only this code, only to your inbox.</p>
-
-              <div class="trust-strip">
-                <span>🔒 Price locked for life</span>
-                <span>💸 30-day money-back</span>
-                <span>🛡 GDPR-compliant</span>
-              </div>
 
               <p class="disclaimer">If you didn't request this code, someone may have typed your email by mistake — you can safely ignore this message. If sign-in attempts continue, change your email's password as a precaution.</p>
             </div>

--- a/mockups/tadaify-mvp/emails/otp-login.html
+++ b/mockups/tadaify-mvp/emails/otp-login.html
@@ -221,7 +221,7 @@ created_at: 2026-05-02T13:05:00Z
             </div>
             <div class="email-body">
               <h1 class="greeting">Welcome back, @waserek</h1>
-              <p class="sub">signing you in to <span class="wordmark" style="font-size:15px;"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span></span> — type the code below to continue.</p>
+              <p class="sub">signing you in to <span class="wordmark" style="font-size:15px;"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span><span class="wm-ify">.com</span></span> — type the code below to continue.</p>
 
               <div class="otp-card">
                 <p class="otp-label">Your sign-in code</p>
@@ -257,7 +257,7 @@ created_at: 2026-05-02T13:05:00Z
       </div>
 <pre>Welcome back, @waserek,
 
-signing you in to tada!ify - type the code below to continue.
+signing you in to tadaify.com - type the code below to continue.
 
 Your sign-in code:
 

--- a/mockups/tadaify-mvp/emails/otp-login.html
+++ b/mockups/tadaify-mvp/emails/otp-login.html
@@ -240,9 +240,6 @@ created_at: 2026-05-02T13:05:00Z
         </div>
       </div>
     </div>
-        </div>
-      </div>
-    </div>
 
   </div>
 

--- a/mockups/tadaify-mvp/emails/otp-login.html
+++ b/mockups/tadaify-mvp/emails/otp-login.html
@@ -20,8 +20,7 @@ created_at: 2026-05-02T13:05:00Z
     .page-header .pill { padding: 4px 10px; border-radius: var(--radius-full); font-size: 11px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; background: var(--info-bg); color: var(--info); }
     .page-intro { max-width: 1280px; margin: 0 auto 24px; color: var(--fg-muted); font-size: 14px; line-height: 1.6; max-width: 840px; }
 
-    .pair-grid { max-width: 1280px; margin: 0 auto; display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
-    @media (max-width: 1100px) { .pair-grid { grid-template-columns: 1fr; } }
+    .pair-grid { max-width: 720px; margin: 0 auto; }
 
     .scheme-label { font-size: 12px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: var(--fg-muted); margin: 0 0 8px 4px; }
 
@@ -32,7 +31,6 @@ created_at: 2026-05-02T13:05:00Z
       box-shadow: var(--shadow);
       overflow: hidden;
     }
-    .inbucket.dark-frame { background: #0F172A; border-color: #1E293B; }
 
     .inbucket-bar {
       padding: 12px 18px;
@@ -41,15 +39,12 @@ created_at: 2026-05-02T13:05:00Z
       display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
       font-family: var(--font-mono); font-size: 11px; color: var(--fg-muted);
     }
-    .inbucket.dark-frame .inbucket-bar { background: #1E293B; border-bottom-color: #334155; color: #94A3B8; }
     .inbucket-bar .dev-badge {
       background: #FEF3C7; color: #92400E;
       padding: 2px 8px; border-radius: 4px; font-weight: 700;
       font-size: 10px; letter-spacing: 0.04em;
     }
-    .inbucket.dark-frame .inbucket-bar .dev-badge { background: #422006; color: #FDE68A; }
     .inbucket-bar .scheme-mark { margin-left: auto; padding: 2px 8px; border-radius: 4px; background: var(--bg-elevated); border: 1px solid var(--border-strong); }
-    .inbucket.dark-frame .inbucket-bar .scheme-mark { background: #0F172A; border-color: #334155; color: #CBD5E1; }
 
     .inbucket-headers {
       padding: 14px 22px;
@@ -57,15 +52,11 @@ created_at: 2026-05-02T13:05:00Z
       font-family: var(--font-mono); font-size: 12px; color: var(--fg-muted);
       display: grid; grid-template-columns: 70px 1fr; gap: 4px 14px;
     }
-    .inbucket.dark-frame .inbucket-headers { border-bottom-color: #334155; color: #94A3B8; }
     .inbucket-headers .k { color: var(--fg-subtle); text-align: right; }
-    .inbucket.dark-frame .inbucket-headers .k { color: #64748B; }
     .inbucket-headers .v { color: var(--fg); word-break: break-all; }
-    .inbucket.dark-frame .inbucket-headers .v { color: #E2E8F0; }
     .inbucket-headers .v strong { color: var(--fg); font-weight: 600; }
 
     .email-canvas { padding: 32px 18px; background: #F3F4F6; }
-    .inbucket.dark-frame .email-canvas { background: #0B0F1E; }
 
     .email {
       max-width: 600px; margin: 0 auto;
@@ -76,7 +67,6 @@ created_at: 2026-05-02T13:05:00Z
       color: #111827;
       box-shadow: 0 4px 12px rgba(17,24,39,0.08);
     }
-    .inbucket.dark-frame .email { background: #1E293B; color: #E2E8F0; box-shadow: 0 4px 12px rgba(0,0,0,0.4); }
 
     .email-mark { padding: 28px 32px 8px; }
     .email-mark .wordmark {
@@ -91,7 +81,6 @@ created_at: 2026-05-02T13:05:00Z
     .email-mark .wm-ta  { color: #6366F1; }
     .email-mark .wm-da  { color: #F59E0B; }
     .email-mark .wm-ify { color: #111827; }
-    .inbucket.dark-frame .email-mark .wm-ify { color: #F9FAFB; }
 
     .email-body { padding: 16px 32px 32px; }
     .greeting {
@@ -103,14 +92,12 @@ created_at: 2026-05-02T13:05:00Z
       margin: 0 0 6px;
       color: #111827;
     }
-    .inbucket.dark-frame .greeting { color: #F9FAFB; }
     .sub {
       font-size: 15px;
       color: #4B5563;
       margin: 0 0 28px;
       line-height: 1.55;
     }
-    .inbucket.dark-frame .sub { color: #94A3B8; }
 
     .otp-card {
       background: #F9FAFB;
@@ -120,7 +107,6 @@ created_at: 2026-05-02T13:05:00Z
       text-align: center;
       margin-bottom: 24px;
     }
-    .inbucket.dark-frame .otp-card { background: #0F172A; border-color: #334155; }
 
     .otp-label {
       font-size: 11px;
@@ -130,7 +116,6 @@ created_at: 2026-05-02T13:05:00Z
       color: #6B7280;
       margin: 0 0 14px;
     }
-    .inbucket.dark-frame .otp-label { color: #94A3B8; }
 
     .otp-code {
       font-family: 'Crimson Pro', Georgia, serif;
@@ -143,16 +128,13 @@ created_at: 2026-05-02T13:05:00Z
       margin: 0 0 14px;
       user-select: all;
     }
-    .inbucket.dark-frame .otp-code { color: #F9FAFB; }
 
     .otp-expiry {
       font-size: 13px;
       color: #6B7280;
       margin: 0;
     }
-    .inbucket.dark-frame .otp-expiry { color: #94A3B8; }
     .otp-expiry strong { color: #111827; font-weight: 600; }
-    .inbucket.dark-frame .otp-expiry strong { color: #FDE68A; }
 
     .body-copy {
       font-size: 14px;
@@ -160,7 +142,6 @@ created_at: 2026-05-02T13:05:00Z
       color: #374151;
       margin: 0 0 18px;
     }
-    .inbucket.dark-frame .body-copy { color: #CBD5E1; }
 
     .disclaimer {
       margin-top: 22px;
@@ -170,7 +151,6 @@ created_at: 2026-05-02T13:05:00Z
       line-height: 1.6;
       color: #6B7280;
     }
-    .inbucket.dark-frame .disclaimer { border-top-color: #334155; color: #94A3B8; }
 
     .email-footer {
       padding: 18px 32px 22px;
@@ -180,7 +160,6 @@ created_at: 2026-05-02T13:05:00Z
       text-align: center;
       letter-spacing: 0.02em;
     }
-    .inbucket.dark-frame .email-footer { border-top-color: #334155; color: #64748B; }
 
     .plain-section { max-width: 1280px; margin: 36px auto 0; }
     .plain-section h2 { font-size: 18px; margin-bottom: 6px; }
@@ -223,7 +202,6 @@ created_at: 2026-05-02T13:05:00Z
 
     <!-- LIGHT CLIENT -->
     <div>
-      <div class="scheme-label">Light email client (Apple Mail · Gmail web)</div>
       <div class="inbucket">
         <div class="inbucket-bar">
           <span class="dev-badge">🔧 LOCAL DEV</span>
@@ -262,45 +240,6 @@ created_at: 2026-05-02T13:05:00Z
         </div>
       </div>
     </div>
-
-    <!-- DARK CLIENT -->
-    <div>
-      <div class="scheme-label">Dark email client (Apple Mail dark · Outlook dark)</div>
-      <div class="inbucket dark-frame">
-        <div class="inbucket-bar">
-          <span class="dev-badge">🔧 LOCAL DEV</span>
-          <span>Inbucket http://localhost:54354</span>
-          <span class="scheme-mark">dark</span>
-        </div>
-        <div class="inbucket-headers">
-          <span class="k">From:</span><span class="v"><strong>tadaify</strong> &lt;noreply@tadaify.com&gt;</span>
-          <span class="k">To:</span><span class="v">waserek@local.test</span>
-          <span class="k">Subject:</span><span class="v"><strong>Sign in to tadaify: 502718</strong></span>
-          <span class="k">Date:</span><span class="v">2026-05-02 12:41 UTC</span>
-        </div>
-        <div class="email-canvas">
-          <div class="email" role="article" aria-label="Login OTP email (dark)">
-            <div class="email-mark">
-              <span class="wordmark"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span></span>
-            </div>
-            <div class="email-body">
-              <h1 class="greeting">Welcome back, @waserek</h1>
-              <p class="sub">signing you in to <span class="wordmark" style="font-size:15px;"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span></span> — type the code below to continue.</p>
-
-              <div class="otp-card">
-                <p class="otp-label">Your sign-in code</p>
-                <p class="otp-code">502718</p>
-                <p class="otp-expiry">Code expires in <strong>10 minutes</strong></p>
-              </div>
-
-              <p class="body-copy">Type the 6 digits above into the login page that's still open in your browser. We never email a clickable login link — only this code, only to your inbox.</p>
-
-              <p class="disclaimer">If you didn't request this code, someone may have typed your email by mistake — you can safely ignore this message. If sign-in attempts continue, change your email's password as a precaution.</p>
-            </div>
-            <div class="email-footer">
-              tadaify · sent from noreply@tadaify.com · this address doesn't accept replies
-            </div>
-          </div>
         </div>
       </div>
     </div>

--- a/mockups/tadaify-mvp/emails/otp-login.html
+++ b/mockups/tadaify-mvp/emails/otp-login.html
@@ -1,0 +1,377 @@
+<!--
+type: mockup
+project: tadaify
+title: Auth email — login OTP (token-only, multipart preview)
+created_at: 2026-05-02T13:05:00Z
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>tadaify — Email mockup: login OTP</title>
+  <link rel="stylesheet" href="../shared/tokens.css">
+  <style>
+    body { background: var(--bg-muted); padding: 32px clamp(16px,4vw,48px); }
+    .page-header { max-width: 1280px; margin: 0 auto 24px; display: flex; align-items: baseline; gap: 16px; flex-wrap: wrap; }
+    .page-header h1 { font-size: 28px; }
+    .page-header .crumbs { font-size: 13px; color: var(--fg-muted); }
+    .page-header .crumbs a { color: var(--brand-primary); }
+    .page-header .pill { padding: 4px 10px; border-radius: var(--radius-full); font-size: 11px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; background: var(--info-bg); color: var(--info); }
+    .page-intro { max-width: 1280px; margin: 0 auto 24px; color: var(--fg-muted); font-size: 14px; line-height: 1.6; max-width: 840px; }
+
+    .pair-grid { max-width: 1280px; margin: 0 auto; display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
+    @media (max-width: 1100px) { .pair-grid { grid-template-columns: 1fr; } }
+
+    .scheme-label { font-size: 12px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: var(--fg-muted); margin: 0 0 8px 4px; }
+
+    .inbucket {
+      background: var(--bg-elevated);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-lg);
+      box-shadow: var(--shadow);
+      overflow: hidden;
+    }
+    .inbucket.dark-frame { background: #0F172A; border-color: #1E293B; }
+
+    .inbucket-bar {
+      padding: 12px 18px;
+      background: var(--bg-muted);
+      border-bottom: 1px solid var(--border);
+      display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+      font-family: var(--font-mono); font-size: 11px; color: var(--fg-muted);
+    }
+    .inbucket.dark-frame .inbucket-bar { background: #1E293B; border-bottom-color: #334155; color: #94A3B8; }
+    .inbucket-bar .dev-badge {
+      background: #FEF3C7; color: #92400E;
+      padding: 2px 8px; border-radius: 4px; font-weight: 700;
+      font-size: 10px; letter-spacing: 0.04em;
+    }
+    .inbucket.dark-frame .inbucket-bar .dev-badge { background: #422006; color: #FDE68A; }
+    .inbucket-bar .scheme-mark { margin-left: auto; padding: 2px 8px; border-radius: 4px; background: var(--bg-elevated); border: 1px solid var(--border-strong); }
+    .inbucket.dark-frame .inbucket-bar .scheme-mark { background: #0F172A; border-color: #334155; color: #CBD5E1; }
+
+    .inbucket-headers {
+      padding: 14px 22px;
+      border-bottom: 1px solid var(--border);
+      font-family: var(--font-mono); font-size: 12px; color: var(--fg-muted);
+      display: grid; grid-template-columns: 70px 1fr; gap: 4px 14px;
+    }
+    .inbucket.dark-frame .inbucket-headers { border-bottom-color: #334155; color: #94A3B8; }
+    .inbucket-headers .k { color: var(--fg-subtle); text-align: right; }
+    .inbucket.dark-frame .inbucket-headers .k { color: #64748B; }
+    .inbucket-headers .v { color: var(--fg); word-break: break-all; }
+    .inbucket.dark-frame .inbucket-headers .v { color: #E2E8F0; }
+    .inbucket-headers .v strong { color: var(--fg); font-weight: 600; }
+
+    .email-canvas { padding: 32px 18px; background: #F3F4F6; }
+    .inbucket.dark-frame .email-canvas { background: #0B0F1E; }
+
+    .email {
+      max-width: 600px; margin: 0 auto;
+      background: #FFFFFF;
+      border-radius: 14px;
+      overflow: hidden;
+      font-family: 'Inter', system-ui, -apple-system, sans-serif;
+      color: #111827;
+      box-shadow: 0 4px 12px rgba(17,24,39,0.08);
+    }
+    .inbucket.dark-frame .email { background: #1E293B; color: #E2E8F0; box-shadow: 0 4px 12px rgba(0,0,0,0.4); }
+
+    .email-mark { padding: 28px 32px 8px; }
+    .email-mark .wordmark {
+      font-family: 'Crimson Pro', Georgia, serif;
+      font-weight: 600;
+      letter-spacing: -0.02em;
+      font-size: 28px;
+      line-height: 1;
+      display: inline-flex;
+      align-items: baseline;
+    }
+    .email-mark .wm-ta  { color: #6366F1; }
+    .email-mark .wm-da  { color: #F59E0B; }
+    .email-mark .wm-ify { color: #111827; }
+    .inbucket.dark-frame .email-mark .wm-ify { color: #F9FAFB; }
+
+    .email-body { padding: 16px 32px 32px; }
+    .greeting {
+      font-family: 'Crimson Pro', Georgia, serif;
+      font-weight: 600;
+      font-size: 26px;
+      line-height: 1.2;
+      letter-spacing: -0.01em;
+      margin: 0 0 6px;
+      color: #111827;
+    }
+    .inbucket.dark-frame .greeting { color: #F9FAFB; }
+    .sub {
+      font-size: 15px;
+      color: #4B5563;
+      margin: 0 0 28px;
+      line-height: 1.55;
+    }
+    .inbucket.dark-frame .sub { color: #94A3B8; }
+
+    .otp-card {
+      background: #F9FAFB;
+      border: 1px solid #E5E7EB;
+      border-radius: 14px;
+      padding: 28px 24px;
+      text-align: center;
+      margin-bottom: 24px;
+    }
+    .inbucket.dark-frame .otp-card { background: #0F172A; border-color: #334155; }
+
+    .otp-label {
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: #6B7280;
+      margin: 0 0 14px;
+    }
+    .inbucket.dark-frame .otp-label { color: #94A3B8; }
+
+    .otp-code {
+      font-family: 'Crimson Pro', Georgia, serif;
+      font-weight: 600;
+      font-size: 56px;
+      letter-spacing: 0.1em;
+      color: #111827;
+      line-height: 1;
+      font-feature-settings: "tnum" 1, "lnum" 1;
+      margin: 0 0 14px;
+      user-select: all;
+    }
+    .inbucket.dark-frame .otp-code { color: #F9FAFB; }
+
+    .otp-expiry {
+      font-size: 13px;
+      color: #6B7280;
+      margin: 0;
+    }
+    .inbucket.dark-frame .otp-expiry { color: #94A3B8; }
+    .otp-expiry strong { color: #111827; font-weight: 600; }
+    .inbucket.dark-frame .otp-expiry strong { color: #FDE68A; }
+
+    .body-copy {
+      font-size: 14px;
+      line-height: 1.65;
+      color: #374151;
+      margin: 0 0 18px;
+    }
+    .inbucket.dark-frame .body-copy { color: #CBD5E1; }
+
+    .trust-strip {
+      margin-top: 28px;
+      padding: 18px 20px;
+      background: #FFFBEB;
+      border: 1px solid #FDE68A;
+      border-radius: 12px;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px 16px;
+      justify-content: center;
+      font-size: 12px;
+      color: #92400E;
+      font-weight: 500;
+    }
+    .inbucket.dark-frame .trust-strip { background: rgba(245,158,11,0.08); border-color: #92400E; color: #FDE68A; }
+    .trust-strip span { white-space: nowrap; }
+
+    .disclaimer {
+      margin-top: 22px;
+      padding-top: 22px;
+      border-top: 1px solid #E5E7EB;
+      font-size: 12px;
+      line-height: 1.6;
+      color: #6B7280;
+    }
+    .inbucket.dark-frame .disclaimer { border-top-color: #334155; color: #94A3B8; }
+
+    .email-footer {
+      padding: 18px 32px 22px;
+      border-top: 1px solid #F3F4F6;
+      font-size: 11px;
+      color: #9CA3AF;
+      text-align: center;
+      letter-spacing: 0.02em;
+    }
+    .inbucket.dark-frame .email-footer { border-top-color: #334155; color: #64748B; }
+
+    .plain-section { max-width: 1280px; margin: 36px auto 0; }
+    .plain-section h2 { font-size: 18px; margin-bottom: 6px; }
+    .plain-section p { font-size: 13px; color: var(--fg-muted); margin-bottom: 14px; }
+    .plain-frame {
+      background: var(--bg-elevated);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      box-shadow: var(--shadow-sm);
+    }
+    .plain-frame .inbucket-bar { border-radius: var(--radius) var(--radius) 0 0; }
+    .plain-frame pre {
+      margin: 0;
+      padding: 22px 28px;
+      font-family: var(--font-mono);
+      font-size: 13px;
+      line-height: 1.65;
+      color: var(--fg);
+      white-space: pre-wrap;
+      word-wrap: break-word;
+    }
+
+    .footer-links { max-width: 1280px; margin: 32px auto 0; font-size: 12px; color: var(--fg-subtle); text-align: center; }
+    .footer-links a { color: var(--brand-primary); margin: 0 8px; }
+  </style>
+</head>
+<body>
+
+  <header class="page-header">
+    <span class="pill">Email mockup</span>
+    <h1>Login OTP — multipart preview</h1>
+    <span class="crumbs"><a href="./index.html">← email gallery</a></span>
+  </header>
+
+  <p class="page-intro">
+    Sent by Supabase GoTrue when an existing user requests a sign-in code (passwordless OTP, the only login path in tadaify Phase 1). Token-only delivery — no <code>{{ .ConfirmationURL }}</code>, no clickable auth link. Below: the email rendered in light + dark email clients side-by-side, then the plain-text fallback (multipart/alternative).
+  </p>
+
+  <div class="pair-grid">
+
+    <!-- LIGHT CLIENT -->
+    <div>
+      <div class="scheme-label">Light email client (Apple Mail · Gmail web)</div>
+      <div class="inbucket">
+        <div class="inbucket-bar">
+          <span class="dev-badge">🔧 LOCAL DEV</span>
+          <span>Inbucket http://localhost:54354</span>
+          <span class="scheme-mark">light</span>
+        </div>
+        <div class="inbucket-headers">
+          <span class="k">From:</span><span class="v"><strong>tadaify</strong> &lt;noreply@tadaify.com&gt;</span>
+          <span class="k">To:</span><span class="v">waserek@local.test</span>
+          <span class="k">Subject:</span><span class="v"><strong>Sign in to tadaify: 502718</strong></span>
+          <span class="k">Date:</span><span class="v">2026-05-02 12:41 UTC</span>
+        </div>
+        <div class="email-canvas">
+          <div class="email" role="article" aria-label="Login OTP email">
+            <div class="email-mark">
+              <span class="wordmark"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span></span>
+            </div>
+            <div class="email-body">
+              <h1 class="greeting">Welcome back, @waserek</h1>
+              <p class="sub">signing you in to <span class="wordmark" style="font-size:15px;"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span></span> — type the code below to continue.</p>
+
+              <div class="otp-card">
+                <p class="otp-label">Your sign-in code</p>
+                <p class="otp-code">502718</p>
+                <p class="otp-expiry">Code expires in <strong>10 minutes</strong></p>
+              </div>
+
+              <p class="body-copy">Type the 6 digits above into the login page that's still open in your browser. We never email a clickable login link — only this code, only to your inbox.</p>
+
+              <div class="trust-strip">
+                <span>🔒 Price locked for life</span>
+                <span>💸 30-day money-back</span>
+                <span>🛡 GDPR-compliant</span>
+              </div>
+
+              <p class="disclaimer">If you didn't request this code, someone may have typed your email by mistake — you can safely ignore this message. If sign-in attempts continue, change your email's password as a precaution.</p>
+            </div>
+            <div class="email-footer">
+              tadaify · sent from noreply@tadaify.com · this address doesn't accept replies
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- DARK CLIENT -->
+    <div>
+      <div class="scheme-label">Dark email client (Apple Mail dark · Outlook dark)</div>
+      <div class="inbucket dark-frame">
+        <div class="inbucket-bar">
+          <span class="dev-badge">🔧 LOCAL DEV</span>
+          <span>Inbucket http://localhost:54354</span>
+          <span class="scheme-mark">dark</span>
+        </div>
+        <div class="inbucket-headers">
+          <span class="k">From:</span><span class="v"><strong>tadaify</strong> &lt;noreply@tadaify.com&gt;</span>
+          <span class="k">To:</span><span class="v">waserek@local.test</span>
+          <span class="k">Subject:</span><span class="v"><strong>Sign in to tadaify: 502718</strong></span>
+          <span class="k">Date:</span><span class="v">2026-05-02 12:41 UTC</span>
+        </div>
+        <div class="email-canvas">
+          <div class="email" role="article" aria-label="Login OTP email (dark)">
+            <div class="email-mark">
+              <span class="wordmark"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span></span>
+            </div>
+            <div class="email-body">
+              <h1 class="greeting">Welcome back, @waserek</h1>
+              <p class="sub">signing you in to <span class="wordmark" style="font-size:15px;"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span></span> — type the code below to continue.</p>
+
+              <div class="otp-card">
+                <p class="otp-label">Your sign-in code</p>
+                <p class="otp-code">502718</p>
+                <p class="otp-expiry">Code expires in <strong>10 minutes</strong></p>
+              </div>
+
+              <p class="body-copy">Type the 6 digits above into the login page that's still open in your browser. We never email a clickable login link — only this code, only to your inbox.</p>
+
+              <div class="trust-strip">
+                <span>🔒 Price locked for life</span>
+                <span>💸 30-day money-back</span>
+                <span>🛡 GDPR-compliant</span>
+              </div>
+
+              <p class="disclaimer">If you didn't request this code, someone may have typed your email by mistake — you can safely ignore this message. If sign-in attempts continue, change your email's password as a precaution.</p>
+            </div>
+            <div class="email-footer">
+              tadaify · sent from noreply@tadaify.com · this address doesn't accept replies
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <section class="plain-section">
+    <div class="scheme-label">multipart/alternative — text/plain fallback</div>
+    <h2>What plain-text-only clients see</h2>
+    <p>Clients without HTML rendering (terminal mailers, accessibility tools, low-bandwidth previews) get the plain-text part. Code is identical and unchanged.</p>
+    <div class="plain-frame">
+      <div class="inbucket-bar">
+        <span>Content-Type: text/plain; charset=UTF-8</span>
+        <span class="scheme-mark">plain</span>
+      </div>
+<pre>Welcome back, @waserek,
+
+signing you in to tada!ify - type the code below to continue.
+
+Your sign-in code:
+
+    5 0 2 7 1 8
+
+Code expires in 10 minutes.
+
+Type the 6 digits above into the login page that's still open
+in your browser. We never email a clickable login link - only
+this code, only to your inbox.
+
+If you didn't request this code, someone may have typed your
+email by mistake - you can safely ignore this message. If
+sign-in attempts continue, change your email's password as
+a precaution.
+
+--
+tada!ify
+sent from noreply@tadaify.com
+this address doesn't accept replies</pre>
+    </div>
+  </section>
+
+  <p class="footer-links"><a href="./index.html">← back to email gallery</a> · <a href="./otp-signup.html">← signup OTP</a> · <a href="./_email-tokens-preview.html">tokens compare</a></p>
+
+</body>
+</html>

--- a/mockups/tadaify-mvp/emails/otp-signup.html
+++ b/mockups/tadaify-mvp/emails/otp-signup.html
@@ -231,7 +231,6 @@ created_at: 2026-05-02T13:00:00Z
               <div class="otp-card">
                 <p class="otp-label">Your one-time code</p>
                 <p class="otp-code">184629</p>
-                <p class="otp-expiry">Code expires in <strong>10 minutes</strong></p>
                 <p class="otp-handle-note">Your handle <strong>@waserek</strong> is reserved for <strong>10 minutes</strong></p>
               </div>
 
@@ -270,7 +269,6 @@ Your one-time code:
 
     1 8 4 6 2 9
 
-Code expires in 10 minutes.
 Your handle @waserek is reserved for 10 minutes.
 
 Type the 6 digits above into the page that's still open in your

--- a/mockups/tadaify-mvp/emails/otp-signup.html
+++ b/mockups/tadaify-mvp/emails/otp-signup.html
@@ -245,9 +245,6 @@ created_at: 2026-05-02T13:00:00Z
         </div>
       </div>
     </div>
-        </div>
-      </div>
-    </div>
 
   </div>
 

--- a/mockups/tadaify-mvp/emails/otp-signup.html
+++ b/mockups/tadaify-mvp/emails/otp-signup.html
@@ -1,0 +1,380 @@
+<!--
+type: mockup
+project: tadaify
+title: Auth email — signup OTP (token-only, multipart preview)
+created_at: 2026-05-02T13:00:00Z
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>tadaify — Email mockup: signup OTP</title>
+  <link rel="stylesheet" href="../shared/tokens.css">
+  <style>
+    /* --------- Page chrome (around the Inbucket frame, NOT in the email) --------- */
+    body { background: var(--bg-muted); padding: 32px clamp(16px,4vw,48px); }
+    .page-header { max-width: 1280px; margin: 0 auto 24px; display: flex; align-items: baseline; gap: 16px; flex-wrap: wrap; }
+    .page-header h1 { font-size: 28px; }
+    .page-header .crumbs { font-size: 13px; color: var(--fg-muted); }
+    .page-header .crumbs a { color: var(--brand-primary); }
+    .page-header .pill { padding: 4px 10px; border-radius: var(--radius-full); font-size: 11px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; background: var(--info-bg); color: var(--info); }
+    .page-intro { max-width: 1280px; margin: 0 auto 24px; color: var(--fg-muted); font-size: 14px; line-height: 1.6; max-width: 840px; }
+
+    .pair-grid { max-width: 1280px; margin: 0 auto; display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
+    @media (max-width: 1100px) { .pair-grid { grid-template-columns: 1fr; } }
+
+    .scheme-label { font-size: 12px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: var(--fg-muted); margin: 0 0 8px 4px; }
+
+    /* --------- Inbucket frame --------- */
+    .inbucket {
+      background: var(--bg-elevated);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-lg);
+      box-shadow: var(--shadow);
+      overflow: hidden;
+    }
+    .inbucket.dark-frame { background: #0F172A; border-color: #1E293B; }
+
+    .inbucket-bar {
+      padding: 12px 18px;
+      background: var(--bg-muted);
+      border-bottom: 1px solid var(--border);
+      display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+      font-family: var(--font-mono); font-size: 11px; color: var(--fg-muted);
+    }
+    .inbucket.dark-frame .inbucket-bar { background: #1E293B; border-bottom-color: #334155; color: #94A3B8; }
+    .inbucket-bar .dev-badge {
+      background: #FEF3C7; color: #92400E;
+      padding: 2px 8px; border-radius: 4px; font-weight: 700;
+      font-size: 10px; letter-spacing: 0.04em;
+    }
+    .inbucket.dark-frame .inbucket-bar .dev-badge { background: #422006; color: #FDE68A; }
+    .inbucket-bar .scheme-mark { margin-left: auto; padding: 2px 8px; border-radius: 4px; background: var(--bg-elevated); border: 1px solid var(--border-strong); }
+    .inbucket.dark-frame .inbucket-bar .scheme-mark { background: #0F172A; border-color: #334155; color: #CBD5E1; }
+
+    .inbucket-headers {
+      padding: 14px 22px;
+      border-bottom: 1px solid var(--border);
+      font-family: var(--font-mono); font-size: 12px; color: var(--fg-muted);
+      display: grid; grid-template-columns: 70px 1fr; gap: 4px 14px;
+    }
+    .inbucket.dark-frame .inbucket-headers { border-bottom-color: #334155; color: #94A3B8; }
+    .inbucket-headers .k { color: var(--fg-subtle); text-align: right; }
+    .inbucket.dark-frame .inbucket-headers .k { color: #64748B; }
+    .inbucket-headers .v { color: var(--fg); word-break: break-all; }
+    .inbucket.dark-frame .inbucket-headers .v { color: #E2E8F0; }
+    .inbucket-headers .v strong { color: var(--fg); font-weight: 600; }
+
+    /* --------- Email body (INLINE-LIKE — must work standalone in any client) --------- */
+    .email-canvas { padding: 32px 18px; background: #F3F4F6; }
+    .inbucket.dark-frame .email-canvas { background: #0B0F1E; }
+
+    .email {
+      max-width: 600px; margin: 0 auto;
+      background: #FFFFFF;
+      border-radius: 14px;
+      overflow: hidden;
+      font-family: 'Inter', system-ui, -apple-system, sans-serif;
+      color: #111827;
+      box-shadow: 0 4px 12px rgba(17,24,39,0.08);
+    }
+    .inbucket.dark-frame .email { background: #1E293B; color: #E2E8F0; box-shadow: 0 4px 12px rgba(0,0,0,0.4); }
+
+    .email-mark { padding: 28px 32px 8px; }
+    .email-mark .wordmark {
+      font-family: 'Crimson Pro', Georgia, serif;
+      font-weight: 600;
+      letter-spacing: -0.02em;
+      font-size: 28px;
+      line-height: 1;
+      display: inline-flex;
+      align-items: baseline;
+    }
+    .email-mark .wm-ta  { color: #6366F1; }
+    .email-mark .wm-da  { color: #F59E0B; }
+    .email-mark .wm-ify { color: #111827; }
+    .inbucket.dark-frame .email-mark .wm-ify { color: #F9FAFB; }
+
+    .email-body { padding: 16px 32px 32px; }
+    .greeting {
+      font-family: 'Crimson Pro', Georgia, serif;
+      font-weight: 600;
+      font-size: 26px;
+      line-height: 1.2;
+      letter-spacing: -0.01em;
+      margin: 0 0 6px;
+      color: #111827;
+    }
+    .inbucket.dark-frame .greeting { color: #F9FAFB; }
+    .sub {
+      font-size: 15px;
+      color: #4B5563;
+      margin: 0 0 28px;
+      line-height: 1.55;
+    }
+    .inbucket.dark-frame .sub { color: #94A3B8; }
+
+    .otp-card {
+      background: #F9FAFB;
+      border: 1px solid #E5E7EB;
+      border-radius: 14px;
+      padding: 28px 24px;
+      text-align: center;
+      margin-bottom: 24px;
+    }
+    .inbucket.dark-frame .otp-card { background: #0F172A; border-color: #334155; }
+
+    .otp-label {
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: #6B7280;
+      margin: 0 0 14px;
+    }
+    .inbucket.dark-frame .otp-label { color: #94A3B8; }
+
+    .otp-code {
+      font-family: 'Crimson Pro', Georgia, serif;
+      font-weight: 600;
+      font-size: 56px;
+      letter-spacing: 0.1em;
+      color: #111827;
+      line-height: 1;
+      font-feature-settings: "tnum" 1, "lnum" 1;
+      margin: 0 0 14px;
+      user-select: all;
+    }
+    .inbucket.dark-frame .otp-code { color: #F9FAFB; }
+
+    .otp-expiry {
+      font-size: 13px;
+      color: #6B7280;
+      margin: 0;
+    }
+    .inbucket.dark-frame .otp-expiry { color: #94A3B8; }
+    .otp-expiry strong { color: #111827; font-weight: 600; }
+    .inbucket.dark-frame .otp-expiry strong { color: #FDE68A; }
+
+    .body-copy {
+      font-size: 14px;
+      line-height: 1.65;
+      color: #374151;
+      margin: 0 0 18px;
+    }
+    .inbucket.dark-frame .body-copy { color: #CBD5E1; }
+
+    .trust-strip {
+      margin-top: 28px;
+      padding: 18px 20px;
+      background: #FFFBEB;
+      border: 1px solid #FDE68A;
+      border-radius: 12px;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px 16px;
+      justify-content: center;
+      font-size: 12px;
+      color: #92400E;
+      font-weight: 500;
+    }
+    .inbucket.dark-frame .trust-strip { background: rgba(245,158,11,0.08); border-color: #92400E; color: #FDE68A; }
+    .trust-strip span { white-space: nowrap; }
+
+    .disclaimer {
+      margin-top: 22px;
+      padding-top: 22px;
+      border-top: 1px solid #E5E7EB;
+      font-size: 12px;
+      line-height: 1.6;
+      color: #6B7280;
+    }
+    .inbucket.dark-frame .disclaimer { border-top-color: #334155; color: #94A3B8; }
+
+    .email-footer {
+      padding: 18px 32px 22px;
+      border-top: 1px solid #F3F4F6;
+      font-size: 11px;
+      color: #9CA3AF;
+      text-align: center;
+      letter-spacing: 0.02em;
+    }
+    .inbucket.dark-frame .email-footer { border-top-color: #334155; color: #64748B; }
+
+    /* --------- Plain-text fallback section (below the side-by-side) --------- */
+    .plain-section { max-width: 1280px; margin: 36px auto 0; }
+    .plain-section h2 { font-size: 18px; margin-bottom: 6px; }
+    .plain-section p { font-size: 13px; color: var(--fg-muted); margin-bottom: 14px; }
+    .plain-frame {
+      background: var(--bg-elevated);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      box-shadow: var(--shadow-sm);
+    }
+    .plain-frame .inbucket-bar { border-radius: var(--radius) var(--radius) 0 0; }
+    .plain-frame pre {
+      margin: 0;
+      padding: 22px 28px;
+      font-family: var(--font-mono);
+      font-size: 13px;
+      line-height: 1.65;
+      color: var(--fg);
+      white-space: pre-wrap;
+      word-wrap: break-word;
+    }
+
+    .footer-links { max-width: 1280px; margin: 32px auto 0; font-size: 12px; color: var(--fg-subtle); text-align: center; }
+    .footer-links a { color: var(--brand-primary); margin: 0 8px; }
+  </style>
+</head>
+<body>
+
+  <header class="page-header">
+    <span class="pill">Email mockup</span>
+    <h1>Signup OTP — multipart preview</h1>
+    <span class="crumbs"><a href="./index.html">← email gallery</a></span>
+  </header>
+
+  <p class="page-intro">
+    Sent by Supabase GoTrue when a new visitor submits the registration form. Token-only delivery (TR-tadaify-002) — there is no <code>{{ .ConfirmationURL }}</code> placeholder and no clickable auth link. The 6-digit code is the entire auth path. Below: same email rendered side-by-side in a light email client and a dark email client to confirm contrast and dark-mode adaptation. Plain-text fallback (multipart/alternative) at the bottom.
+  </p>
+
+  <div class="pair-grid">
+
+    <!-- LIGHT CLIENT -->
+    <div>
+      <div class="scheme-label">Light email client (Apple Mail · Gmail web)</div>
+      <div class="inbucket">
+        <div class="inbucket-bar">
+          <span class="dev-badge">🔧 LOCAL DEV</span>
+          <span>Inbucket http://localhost:54354</span>
+          <span class="scheme-mark">light</span>
+        </div>
+        <div class="inbucket-headers">
+          <span class="k">From:</span><span class="v"><strong>tadaify</strong> &lt;noreply@tadaify.com&gt;</span>
+          <span class="k">To:</span><span class="v">waserek@local.test</span>
+          <span class="k">Subject:</span><span class="v"><strong>Your tadaify code: 184629</strong></span>
+          <span class="k">Date:</span><span class="v">2026-05-02 12:34 UTC</span>
+        </div>
+        <div class="email-canvas">
+          <div class="email" role="article" aria-label="Signup OTP email">
+            <div class="email-mark">
+              <span class="wordmark"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span></span>
+            </div>
+            <div class="email-body">
+              <h1 class="greeting">Hey @waserek 👋</h1>
+              <p class="sub">welcome to <span class="wordmark" style="font-size:15px;"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span></span> — one quick step to confirm your email.</p>
+
+              <div class="otp-card">
+                <p class="otp-label">Your one-time code</p>
+                <p class="otp-code">184629</p>
+                <p class="otp-expiry">Code expires in <strong>10 minutes</strong></p>
+              </div>
+
+              <p class="body-copy">Type the 6 digits above into the page that's still open in your browser. That's it — no link to click, no password to remember.</p>
+
+              <div class="trust-strip">
+                <span>🔒 Price locked for life</span>
+                <span>💸 30-day money-back</span>
+                <span>🛡 GDPR-compliant</span>
+              </div>
+
+              <p class="disclaimer">If you didn't sign up for tadaify, you can safely ignore this email — your address won't be added to anything. We never share your email with third parties.</p>
+            </div>
+            <div class="email-footer">
+              tadaify · sent from noreply@tadaify.com · this address doesn't accept replies
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- DARK CLIENT -->
+    <div>
+      <div class="scheme-label">Dark email client (Apple Mail dark · Outlook dark)</div>
+      <div class="inbucket dark-frame">
+        <div class="inbucket-bar">
+          <span class="dev-badge">🔧 LOCAL DEV</span>
+          <span>Inbucket http://localhost:54354</span>
+          <span class="scheme-mark">dark</span>
+        </div>
+        <div class="inbucket-headers">
+          <span class="k">From:</span><span class="v"><strong>tadaify</strong> &lt;noreply@tadaify.com&gt;</span>
+          <span class="k">To:</span><span class="v">waserek@local.test</span>
+          <span class="k">Subject:</span><span class="v"><strong>Your tadaify code: 184629</strong></span>
+          <span class="k">Date:</span><span class="v">2026-05-02 12:34 UTC</span>
+        </div>
+        <div class="email-canvas">
+          <div class="email" role="article" aria-label="Signup OTP email (dark)">
+            <div class="email-mark">
+              <span class="wordmark"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span></span>
+            </div>
+            <div class="email-body">
+              <h1 class="greeting">Hey @waserek 👋</h1>
+              <p class="sub">welcome to <span class="wordmark" style="font-size:15px;"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span></span> — one quick step to confirm your email.</p>
+
+              <div class="otp-card">
+                <p class="otp-label">Your one-time code</p>
+                <p class="otp-code">184629</p>
+                <p class="otp-expiry">Code expires in <strong>10 minutes</strong></p>
+              </div>
+
+              <p class="body-copy">Type the 6 digits above into the page that's still open in your browser. That's it — no link to click, no password to remember.</p>
+
+              <div class="trust-strip">
+                <span>🔒 Price locked for life</span>
+                <span>💸 30-day money-back</span>
+                <span>🛡 GDPR-compliant</span>
+              </div>
+
+              <p class="disclaimer">If you didn't sign up for tadaify, you can safely ignore this email — your address won't be added to anything. We never share your email with third parties.</p>
+            </div>
+            <div class="email-footer">
+              tadaify · sent from noreply@tadaify.com · this address doesn't accept replies
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <!-- PLAIN-TEXT FALLBACK (multipart/alternative text part) -->
+  <section class="plain-section">
+    <div class="scheme-label">multipart/alternative — text/plain fallback</div>
+    <h2>What plain-text-only clients see</h2>
+    <p>Some clients (terminal mail readers, accessibility tools, SMS gateways, low-bandwidth previews) render only the <code>text/plain</code> part. The fallback contains the same code in clear ASCII — no markup, no CSS, no images. Token-only path is preserved.</p>
+    <div class="plain-frame">
+      <div class="inbucket-bar">
+        <span>Content-Type: text/plain; charset=UTF-8</span>
+        <span class="scheme-mark">plain</span>
+      </div>
+<pre>Hey @waserek,
+
+welcome to tada!ify - one quick step to confirm your email.
+
+Your one-time code:
+
+    1 8 4 6 2 9
+
+Code expires in 10 minutes.
+
+Type the 6 digits above into the page that's still open in your
+browser. That's it - no link to click, no password to remember.
+
+If you didn't sign up for tada!ify, you can safely ignore this
+email - your address won't be added to anything. We never share
+your email with third parties.
+
+--
+tada!ify
+sent from noreply@tadaify.com
+this address doesn't accept replies</pre>
+    </div>
+  </section>
+
+  <p class="footer-links"><a href="./index.html">← back to email gallery</a> · <a href="./otp-login.html">login OTP →</a> · <a href="./_email-tokens-preview.html">tokens compare</a></p>
+
+</body>
+</html>

--- a/mockups/tadaify-mvp/emails/otp-signup.html
+++ b/mockups/tadaify-mvp/emails/otp-signup.html
@@ -137,7 +137,7 @@ created_at: 2026-05-02T13:00:00Z
       color: #6B7280;
       margin: 0;
     }
-    .otp-handle-note { margin: 8px 0 0 0; text-align: center; font-size: 13px; color: var(--fg-muted); font-family: var(--font-sans); }
+    .otp-handle-note { margin: 8px 0 0 0; text-align: center; font-size: 13px; color: #6B7280; font-family: 'Inter', system-ui, -apple-system, sans-serif; }
     .otp-expiry strong { color: #111827; font-weight: 600; }
 
     .body-copy {

--- a/mockups/tadaify-mvp/emails/otp-signup.html
+++ b/mockups/tadaify-mvp/emails/otp-signup.html
@@ -231,7 +231,7 @@ created_at: 2026-05-02T13:00:00Z
               <div class="otp-card">
                 <p class="otp-label">Your one-time code</p>
                 <p class="otp-code">184629</p>
-                <p class="otp-handle-note">Your handle <strong>@waserek</strong> is reserved for <strong>10 minutes</strong></p>
+                <p class="otp-handle-note">Your handle <strong>@waserek</strong> is reserved for <strong>10 minutes</strong> — enter the code above to claim it for good. After that anyone can grab it.</p>
               </div>
 
               <p class="body-copy">Type the 6 digits above into the page that's still open in your browser. That's it — no link to click, no password to remember.</p>
@@ -269,7 +269,7 @@ Your one-time code:
 
     1 8 4 6 2 9
 
-Your handle @waserek is reserved for 10 minutes.
+Your handle @waserek is reserved for 10 minutes - enter the code above to claim it for good. After that anyone can grab it.
 
 Type the 6 digits above into the page that's still open in your
 browser. That's it - no link to click, no password to remember.

--- a/mockups/tadaify-mvp/emails/otp-signup.html
+++ b/mockups/tadaify-mvp/emails/otp-signup.html
@@ -226,7 +226,7 @@ created_at: 2026-05-02T13:00:00Z
             </div>
             <div class="email-body">
               <h1 class="greeting">Hey @waserek 👋</h1>
-              <p class="sub">welcome to <span class="wordmark" style="font-size:15px;"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span></span> — one quick step to confirm your email.</p>
+              <p class="sub">welcome to <span class="wordmark" style="font-size:15px;"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span><span class="wm-ify">.com</span></span> — one quick step to confirm your email.</p>
 
               <div class="otp-card">
                 <p class="otp-label">Your one-time code</p>
@@ -263,7 +263,7 @@ created_at: 2026-05-02T13:00:00Z
       </div>
 <pre>Hey @waserek,
 
-welcome to tada!ify - one quick step to confirm your email.
+welcome to tadaify.com - one quick step to confirm your email.
 
 Your one-time code:
 

--- a/mockups/tadaify-mvp/emails/otp-signup.html
+++ b/mockups/tadaify-mvp/emails/otp-signup.html
@@ -165,23 +165,6 @@ created_at: 2026-05-02T13:00:00Z
     }
     .inbucket.dark-frame .body-copy { color: #CBD5E1; }
 
-    .trust-strip {
-      margin-top: 28px;
-      padding: 18px 20px;
-      background: #FFFBEB;
-      border: 1px solid #FDE68A;
-      border-radius: 12px;
-      display: flex;
-      flex-wrap: wrap;
-      gap: 8px 16px;
-      justify-content: center;
-      font-size: 12px;
-      color: #92400E;
-      font-weight: 500;
-    }
-    .inbucket.dark-frame .trust-strip { background: rgba(245,158,11,0.08); border-color: #92400E; color: #FDE68A; }
-    .trust-strip span { white-space: nowrap; }
-
     .disclaimer {
       margin-top: 22px;
       padding-top: 22px;
@@ -274,12 +257,6 @@ created_at: 2026-05-02T13:00:00Z
 
               <p class="body-copy">Type the 6 digits above into the page that's still open in your browser. That's it — no link to click, no password to remember.</p>
 
-              <div class="trust-strip">
-                <span>🔒 Price locked for life</span>
-                <span>💸 30-day money-back</span>
-                <span>🛡 GDPR-compliant</span>
-              </div>
-
               <p class="disclaimer">If you didn't sign up for tadaify, you can safely ignore this email — your address won't be added to anything. We never share your email with third parties.</p>
             </div>
             <div class="email-footer">
@@ -321,12 +298,6 @@ created_at: 2026-05-02T13:00:00Z
               </div>
 
               <p class="body-copy">Type the 6 digits above into the page that's still open in your browser. That's it — no link to click, no password to remember.</p>
-
-              <div class="trust-strip">
-                <span>🔒 Price locked for life</span>
-                <span>💸 30-day money-back</span>
-                <span>🛡 GDPR-compliant</span>
-              </div>
 
               <p class="disclaimer">If you didn't sign up for tadaify, you can safely ignore this email — your address won't be added to anything. We never share your email with third parties.</p>
             </div>

--- a/mockups/tadaify-mvp/emails/otp-signup.html
+++ b/mockups/tadaify-mvp/emails/otp-signup.html
@@ -21,8 +21,7 @@ created_at: 2026-05-02T13:00:00Z
     .page-header .pill { padding: 4px 10px; border-radius: var(--radius-full); font-size: 11px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; background: var(--info-bg); color: var(--info); }
     .page-intro { max-width: 1280px; margin: 0 auto 24px; color: var(--fg-muted); font-size: 14px; line-height: 1.6; max-width: 840px; }
 
-    .pair-grid { max-width: 1280px; margin: 0 auto; display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
-    @media (max-width: 1100px) { .pair-grid { grid-template-columns: 1fr; } }
+    .pair-grid { max-width: 720px; margin: 0 auto; }
 
     .scheme-label { font-size: 12px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: var(--fg-muted); margin: 0 0 8px 4px; }
 
@@ -34,7 +33,6 @@ created_at: 2026-05-02T13:00:00Z
       box-shadow: var(--shadow);
       overflow: hidden;
     }
-    .inbucket.dark-frame { background: #0F172A; border-color: #1E293B; }
 
     .inbucket-bar {
       padding: 12px 18px;
@@ -43,15 +41,12 @@ created_at: 2026-05-02T13:00:00Z
       display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
       font-family: var(--font-mono); font-size: 11px; color: var(--fg-muted);
     }
-    .inbucket.dark-frame .inbucket-bar { background: #1E293B; border-bottom-color: #334155; color: #94A3B8; }
     .inbucket-bar .dev-badge {
       background: #FEF3C7; color: #92400E;
       padding: 2px 8px; border-radius: 4px; font-weight: 700;
       font-size: 10px; letter-spacing: 0.04em;
     }
-    .inbucket.dark-frame .inbucket-bar .dev-badge { background: #422006; color: #FDE68A; }
     .inbucket-bar .scheme-mark { margin-left: auto; padding: 2px 8px; border-radius: 4px; background: var(--bg-elevated); border: 1px solid var(--border-strong); }
-    .inbucket.dark-frame .inbucket-bar .scheme-mark { background: #0F172A; border-color: #334155; color: #CBD5E1; }
 
     .inbucket-headers {
       padding: 14px 22px;
@@ -59,16 +54,12 @@ created_at: 2026-05-02T13:00:00Z
       font-family: var(--font-mono); font-size: 12px; color: var(--fg-muted);
       display: grid; grid-template-columns: 70px 1fr; gap: 4px 14px;
     }
-    .inbucket.dark-frame .inbucket-headers { border-bottom-color: #334155; color: #94A3B8; }
     .inbucket-headers .k { color: var(--fg-subtle); text-align: right; }
-    .inbucket.dark-frame .inbucket-headers .k { color: #64748B; }
     .inbucket-headers .v { color: var(--fg); word-break: break-all; }
-    .inbucket.dark-frame .inbucket-headers .v { color: #E2E8F0; }
     .inbucket-headers .v strong { color: var(--fg); font-weight: 600; }
 
     /* --------- Email body (INLINE-LIKE — must work standalone in any client) --------- */
     .email-canvas { padding: 32px 18px; background: #F3F4F6; }
-    .inbucket.dark-frame .email-canvas { background: #0B0F1E; }
 
     .email {
       max-width: 600px; margin: 0 auto;
@@ -79,7 +70,6 @@ created_at: 2026-05-02T13:00:00Z
       color: #111827;
       box-shadow: 0 4px 12px rgba(17,24,39,0.08);
     }
-    .inbucket.dark-frame .email { background: #1E293B; color: #E2E8F0; box-shadow: 0 4px 12px rgba(0,0,0,0.4); }
 
     .email-mark { padding: 28px 32px 8px; }
     .email-mark .wordmark {
@@ -94,7 +84,6 @@ created_at: 2026-05-02T13:00:00Z
     .email-mark .wm-ta  { color: #6366F1; }
     .email-mark .wm-da  { color: #F59E0B; }
     .email-mark .wm-ify { color: #111827; }
-    .inbucket.dark-frame .email-mark .wm-ify { color: #F9FAFB; }
 
     .email-body { padding: 16px 32px 32px; }
     .greeting {
@@ -106,14 +95,12 @@ created_at: 2026-05-02T13:00:00Z
       margin: 0 0 6px;
       color: #111827;
     }
-    .inbucket.dark-frame .greeting { color: #F9FAFB; }
     .sub {
       font-size: 15px;
       color: #4B5563;
       margin: 0 0 28px;
       line-height: 1.55;
     }
-    .inbucket.dark-frame .sub { color: #94A3B8; }
 
     .otp-card {
       background: #F9FAFB;
@@ -123,7 +110,6 @@ created_at: 2026-05-02T13:00:00Z
       text-align: center;
       margin-bottom: 24px;
     }
-    .inbucket.dark-frame .otp-card { background: #0F172A; border-color: #334155; }
 
     .otp-label {
       font-size: 11px;
@@ -133,7 +119,6 @@ created_at: 2026-05-02T13:00:00Z
       color: #6B7280;
       margin: 0 0 14px;
     }
-    .inbucket.dark-frame .otp-label { color: #94A3B8; }
 
     .otp-code {
       font-family: 'Crimson Pro', Georgia, serif;
@@ -146,16 +131,14 @@ created_at: 2026-05-02T13:00:00Z
       margin: 0 0 14px;
       user-select: all;
     }
-    .inbucket.dark-frame .otp-code { color: #F9FAFB; }
 
     .otp-expiry {
       font-size: 13px;
       color: #6B7280;
       margin: 0;
     }
-    .inbucket.dark-frame .otp-expiry { color: #94A3B8; }
+    .otp-handle-note { margin: 8px 0 0 0; text-align: center; font-size: 13px; color: var(--fg-muted); font-family: var(--font-sans); }
     .otp-expiry strong { color: #111827; font-weight: 600; }
-    .inbucket.dark-frame .otp-expiry strong { color: #FDE68A; }
 
     .body-copy {
       font-size: 14px;
@@ -163,7 +146,6 @@ created_at: 2026-05-02T13:00:00Z
       color: #374151;
       margin: 0 0 18px;
     }
-    .inbucket.dark-frame .body-copy { color: #CBD5E1; }
 
     .disclaimer {
       margin-top: 22px;
@@ -173,7 +155,6 @@ created_at: 2026-05-02T13:00:00Z
       line-height: 1.6;
       color: #6B7280;
     }
-    .inbucket.dark-frame .disclaimer { border-top-color: #334155; color: #94A3B8; }
 
     .email-footer {
       padding: 18px 32px 22px;
@@ -183,7 +164,6 @@ created_at: 2026-05-02T13:00:00Z
       text-align: center;
       letter-spacing: 0.02em;
     }
-    .inbucket.dark-frame .email-footer { border-top-color: #334155; color: #64748B; }
 
     /* --------- Plain-text fallback section (below the side-by-side) --------- */
     .plain-section { max-width: 1280px; margin: 36px auto 0; }
@@ -227,7 +207,6 @@ created_at: 2026-05-02T13:00:00Z
 
     <!-- LIGHT CLIENT -->
     <div>
-      <div class="scheme-label">Light email client (Apple Mail · Gmail web)</div>
       <div class="inbucket">
         <div class="inbucket-bar">
           <span class="dev-badge">🔧 LOCAL DEV</span>
@@ -253,6 +232,7 @@ created_at: 2026-05-02T13:00:00Z
                 <p class="otp-label">Your one-time code</p>
                 <p class="otp-code">184629</p>
                 <p class="otp-expiry">Code expires in <strong>10 minutes</strong></p>
+                <p class="otp-handle-note">Your handle <strong>@waserek</strong> is reserved for <strong>10 minutes</strong></p>
               </div>
 
               <p class="body-copy">Type the 6 digits above into the page that's still open in your browser. That's it — no link to click, no password to remember.</p>
@@ -266,45 +246,6 @@ created_at: 2026-05-02T13:00:00Z
         </div>
       </div>
     </div>
-
-    <!-- DARK CLIENT -->
-    <div>
-      <div class="scheme-label">Dark email client (Apple Mail dark · Outlook dark)</div>
-      <div class="inbucket dark-frame">
-        <div class="inbucket-bar">
-          <span class="dev-badge">🔧 LOCAL DEV</span>
-          <span>Inbucket http://localhost:54354</span>
-          <span class="scheme-mark">dark</span>
-        </div>
-        <div class="inbucket-headers">
-          <span class="k">From:</span><span class="v"><strong>tadaify</strong> &lt;noreply@tadaify.com&gt;</span>
-          <span class="k">To:</span><span class="v">waserek@local.test</span>
-          <span class="k">Subject:</span><span class="v"><strong>Your tadaify code: 184629</strong></span>
-          <span class="k">Date:</span><span class="v">2026-05-02 12:34 UTC</span>
-        </div>
-        <div class="email-canvas">
-          <div class="email" role="article" aria-label="Signup OTP email (dark)">
-            <div class="email-mark">
-              <span class="wordmark"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span></span>
-            </div>
-            <div class="email-body">
-              <h1 class="greeting">Hey @waserek 👋</h1>
-              <p class="sub">welcome to <span class="wordmark" style="font-size:15px;"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span></span> — one quick step to confirm your email.</p>
-
-              <div class="otp-card">
-                <p class="otp-label">Your one-time code</p>
-                <p class="otp-code">184629</p>
-                <p class="otp-expiry">Code expires in <strong>10 minutes</strong></p>
-              </div>
-
-              <p class="body-copy">Type the 6 digits above into the page that's still open in your browser. That's it — no link to click, no password to remember.</p>
-
-              <p class="disclaimer">If you didn't sign up for tadaify, you can safely ignore this email — your address won't be added to anything. We never share your email with third parties.</p>
-            </div>
-            <div class="email-footer">
-              tadaify · sent from noreply@tadaify.com · this address doesn't accept replies
-            </div>
-          </div>
         </div>
       </div>
     </div>
@@ -330,6 +271,7 @@ Your one-time code:
     1 8 4 6 2 9
 
 Code expires in 10 minutes.
+Your handle @waserek is reserved for 10 minutes.
 
 Type the 6 digits above into the page that's still open in your
 browser. That's it - no link to click, no password to remember.


### PR DESCRIPTION
## Summary

Phase 1 auth email mockups for tadaify, **v2** — replaces closed PR #153 (closed because all wordmark renderings carried `<span class="hyp">-</span>`, violating the 2026-04-24 brand lock). This is a fresh take dispatched after PR #155 swept the legacy hyphen scaffolding from `shared/tokens.css` and `docs/branding/brand-lock.md`.

Delivers 4 mockup files covering the full Phase 1 auth surface:

- `mockups/tadaify-mvp/emails/index.html` — Phase 1 landing tiles + 4 disabled Phase 2 tiles
- `mockups/tadaify-mvp/emails/otp-signup.html` — signup OTP, light + dark email client side-by-side, plain-text fallback
- `mockups/tadaify-mvp/emails/otp-login.html` — login OTP, same structure
- `mockups/tadaify-mvp/emails/_email-tokens-preview.html` — design-handoff tokens compare

The legacy `emails/index.html` (gallery from PR #133, used non-canonical `ta!da` wordmark) is deleted in the same commit and replaced wholesale by the new index.

## Business requirements implemented

- **BR-tadaify-AUTH-01** — passwordless OTP signup (new visitor confirms ownership of email with 6-digit code).
- **BR-tadaify-AUTH-02** — passwordless OTP login (only login path in Phase 1; no password sign-in until Phase 2).

## Technical requirements introduced or relied on

- **TR-tadaify-002** — token-only auth email delivery. Email body MUST NOT contain `{{ .ConfirmationURL }}` or any clickable auth link. The 6-digit code is the entire auth handshake. Rationale: minimises phishing surface, makes the link-rewriting attack class impossible, and keeps the email working in plain-text-only clients without degraded UX.
- **TR-tadaify-001** — every brand surface uses the canonical wordmark `tada!ify` (zero separators) per DEC-WORDMARK-01 (2026-04-24). Email body uses `.wm-ta` / `.wm-da` / `.wm-ify` classes from `shared/tokens.css`.
- **TR-tadaify-MOCKUP-01** — email mockups inline all CSS, never reference external stylesheets, never load remote fonts, never embed remote images. Crimson Pro falls back to Georgia → serif; Inter falls back to system stack. This matches what real Supabase GoTrue / Resend MJML templates can ship.

## Acceptance criteria from issue

Quoting the four Phase 1 acceptance criteria from issue #150:

- ✅ **AC1**: Mockup of signup OTP email exists at `mockups/tadaify-mvp/emails/otp-signup.html` and shows the full email body (wordmark, greeting, OTP card, trust strip, disclaimer, footer).
- ✅ **AC2**: Mockup of login OTP email exists at `mockups/tadaify-mvp/emails/otp-login.html` with the same structure and a returning-user greeting.
- ✅ **AC3**: Both mockups show the email rendered in a light email client AND a dark email client side-by-side (Inbucket frame style mirrors `register.html` chrome).
- ✅ **AC4**: Both mockups include the `multipart/alternative` `text/plain` fallback so the token-only contract is visible in plain-text-only clients.

## Test plan

No automated tests — mockup-only PR. Manual verification:

- Open `mockups/tadaify-mvp/emails/index.html` in Chrome and verify (a) wordmark renders as `tada!ify` with NO separator on all 4 files, (b) Inbucket frame structure matches `register.html` aesthetic, (c) plain-text fallback section visible per email, (d) dark-mode side-by-side renders correctly.
- Run brand-lock audit grep: `grep -rn 'class="hyp"\|wm-hyphen\|<span[^>]*>-</span>\|<span[^>]*>–</span>\|<span[^>]*>—</span>\|"ta!"\|>ta!<\|tada-ify' mockups/tadaify-mvp/emails/` — output must contain only escaped-prose mentions inside `<code>` blocks describing the FORBIDDEN form (zero real markup hits).

## Mockup

- Index (Phase 1 landing): https://github.com/graspsoftwarepw/tadaify-app/blob/main/mockups/tadaify-mvp/emails/index.html
- Signup OTP: https://github.com/graspsoftwarepw/tadaify-app/blob/main/mockups/tadaify-mvp/emails/otp-signup.html
- Login OTP: https://github.com/graspsoftwarepw/tadaify-app/blob/main/mockups/tadaify-mvp/emails/otp-login.html
- Tokens compare: https://github.com/graspsoftwarepw/tadaify-app/blob/main/mockups/tadaify-mvp/emails/_email-tokens-preview.html

(Blob URLs target `/blob/main/` per memory rule `feedback_story_refs_main_not_branch.md` — assume merge.)

## Rollback

Pure additive — no DB, no infra, no code path. Rollback = `git revert <merge-sha>`. Until merge, just close the PR.

## Context + background (Codex-pairing notes)

- **Why v2.** PR #153 was closed by user because every wordmark rendering carried `<span class="hyp">-</span>` between `tada` and `ify`, which violates the 2026-04-24 brand lock (DEC-WORDMARK-01 fixed the canonical form to `tada!ify` with zero separators — the `!` is part of the `da!` warm-yellow partition, not a separator). PR #155 then swept the residual `--wm-hyphen` token + the `.hyp` class from `shared/tokens.css` and updated `docs/branding/brand-lock.md` to make `Display form: tada!ify — zero separators` the locked truth. This v2 is dispatched off the post-#155 main and uses only canonical `.wm-ta` / `.wm-da` / `.wm-ify` classes.
- **Wordmark verification.** Every brand surface in this repo (header, register.html, login.html) renders the wordmark as three adjacent `<span>` siblings with no character node between them. We mirror that exactly. The 14 wordmark renderings across the 4 new files were grep-confirmed to all match the canonical pattern.
- **Inbucket framing.** The "🔧 LOCAL DEV — Inbucket http://localhost:54354" badge mirrors how `supabase start` exposes the local mail-catcher (port offset 4 above the API). Per `feedback_supabase_local_inbucket_for_auth_testing.md`, all auth-flow testing in tadaify goes e2e through Inbucket; the mockup chrome reflects that reality so click-test screenshots will look identical.
- **Token-only contract.** TR-tadaify-002 forbids `{{ .ConfirmationURL }}` placeholders. The downstream Supabase GoTrue email template will render `{{ .Token }}` only (no `{{ .ConfirmationURL }}`). The plain-text fallback hard-confirms this — clients without HTML rendering still get a fully working sign-in.

## NOT-changed in this PR

- No code under `src/`, `supabase/migrations/`, `supabase/functions/`, or `e2e/`.
- No changes to `shared/tokens.css`, `shared/header.html`, `shared/partials.js`, or `docs/branding/brand-lock.md`.
- No changes to `mockups/tadaify-mvp/emails/resend/` or `mockups/tadaify-mvp/emails/supabase-auth/` (legacy directories untouched).
- No changes to `mockups/tadaify-mvp/emails/README.md` (will follow in implementation PR if needed).

## Verification

- Pre-write sanity check: `grep -A 3 "Display form" docs/branding/brand-lock.md` confirmed `tada!ify — zero separators`. Token classes confirmed as `.wm-ta` / `.wm-da` / `.wm-ify` (no `.wm-hyphen`).
- Post-write audit: `grep -rn 'class="hyp"\|wm-hyphen\|<span[^>]*>-</span>\|<span[^>]*>–</span>\|<span[^>]*>—</span>' mockups/tadaify-mvp/emails/` — only escaped `&lt;span class="hyp"&gt;` matches inside documentation `<code>` blocks (describing the forbidden form). Zero matches in actual markup.
- Canonical wordmark count: 14 across 4 files (signup 4, login 4, tokens 4, index 2) — every one uses `wm-ta`/`wm-da`/`wm-ify`.

## Risk-focus

- **Wordmark regression.** Hard-fail criterion. Mitigated by post-write audit grep + Codex review.
- **Inline CSS drift vs `tokens.css`.** Email body hardcodes hex values (mail clients drop CSS custom properties). The tokens-compare mockup makes the values discoverable so the downstream MJML template can mirror them exactly. If `tokens.css` updates the brand palette, this mockup file must be updated in lockstep — flagged here for future maintenance.
- **No real auth wiring.** Mockups only; this PR cannot break production auth.

## Related in-flight

- Closed: PR #153 (v1, brand-lock violation).
- Merged: PR #155 (sweep `--wm-hyphen` token + `.hyp` class out of `shared/tokens.css` and `docs/branding/brand-lock.md`).
- Issue: #150 (Phase 1 auth email contract).
- Phase 2 follow-ups (NOT in this PR): password reset OTP, email change confirm, identity linked, welcome.

## Refs

- DEC-330 = A (close 153, cleanup first, re-dispatch).
- DEC-WORDMARK-01 (zero separators, locked 2026-04-24).
- Locked memory: `feedback_brand_lock_sweep_all_renderings.md`.
- Locked memory: `feedback_mockups_always_opus.md`.
