### PR TITLE
Email mockups Phase 2 — password-reset / email-change-confirm / identity-linked / welcome (per #150 + DEC-332)

### DIFF
--- a/mockups/tadaify-mvp/emails/email-change-confirm.html
+++ b/mockups/tadaify-mvp/emails/email-change-confirm.html
@@ -1,0 +1,234 @@
+<!--
+type: mockup
+project: tadaify
+title: Auth email — email change confirm OTP (token-only, multipart preview)
+created_at: 2026-05-02T14:05:00Z
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>tadaify — Email mockup: email change confirm</title>
+  <link rel="stylesheet" href="../shared/tokens.css">
+  <style>
+    body { background: var(--bg-muted); padding: 32px clamp(16px,4vw,48px); }
+    .page-header { max-width: 1280px; margin: 0 auto 24px; display: flex; align-items: baseline; gap: 16px; flex-wrap: wrap; }
+    .page-header h1 { font-size: 28px; }
+    .page-header .crumbs { font-size: 13px; color: var(--fg-muted); }
+    .page-header .crumbs a { color: var(--brand-primary); }
+    .page-header .pill { padding: 4px 10px; border-radius: var(--radius-full); font-size: 11px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; background: var(--info-bg); color: var(--info); }
+    .page-intro { max-width: 1280px; margin: 0 auto 24px; color: var(--fg-muted); font-size: 14px; line-height: 1.6; max-width: 840px; }
+
+    .pair-grid { max-width: 720px; margin: 0 auto; }
+    .scheme-label { font-size: 12px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: var(--fg-muted); margin: 0 0 8px 4px; }
+
+    .inbucket { background: var(--bg-elevated); border: 1px solid var(--border); border-radius: var(--radius-lg); box-shadow: var(--shadow); overflow: hidden; }
+    .inbucket-bar {
+      padding: 12px 18px; background: var(--bg-muted); border-bottom: 1px solid var(--border);
+      display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+      font-family: var(--font-mono); font-size: 11px; color: var(--fg-muted);
+    }
+    .inbucket-bar .dev-badge { background: #FEF3C7; color: #92400E; padding: 2px 8px; border-radius: 4px; font-weight: 700; font-size: 10px; letter-spacing: 0.04em; }
+    .inbucket-bar .scheme-mark { margin-left: auto; padding: 2px 8px; border-radius: 4px; background: var(--bg-elevated); border: 1px solid var(--border-strong); }
+    .inbucket-headers {
+      padding: 14px 22px; border-bottom: 1px solid var(--border);
+      font-family: var(--font-mono); font-size: 12px; color: var(--fg-muted);
+      display: grid; grid-template-columns: 70px 1fr; gap: 4px 14px;
+    }
+    .inbucket-headers .k { color: var(--fg-subtle); text-align: right; }
+    .inbucket-headers .v { color: var(--fg); word-break: break-all; }
+    .inbucket-headers .v strong { color: var(--fg); font-weight: 600; }
+
+    .email-canvas { padding: 32px 18px; background: #F3F4F6; }
+    .email {
+      max-width: 600px; margin: 0 auto;
+      background: #FFFFFF; border-radius: 14px; overflow: hidden;
+      font-family: 'Inter', system-ui, -apple-system, sans-serif;
+      color: #111827; box-shadow: 0 4px 12px rgba(17,24,39,0.08);
+    }
+    .email-mark { padding: 28px 32px 8px; }
+    .email-mark .wordmark {
+      font-family: 'Crimson Pro', Georgia, serif; font-weight: 600;
+      letter-spacing: -0.02em; font-size: 28px; line-height: 1;
+      display: inline-flex; align-items: baseline;
+    }
+    .email-mark .wm-ta  { color: #6366F1; }
+    .email-mark .wm-da  { color: #F59E0B; }
+    .email-mark .wm-ify { color: #111827; }
+
+    .email-body { padding: 16px 32px 32px; }
+    .greeting {
+      font-family: 'Crimson Pro', Georgia, serif; font-weight: 600;
+      font-size: 26px; line-height: 1.2; letter-spacing: -0.01em;
+      margin: 0 0 6px; color: #111827;
+    }
+    .sub { font-size: 15px; color: #4B5563; margin: 0 0 28px; line-height: 1.55; }
+    .sub code { font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: 13px; background: #F3F4F6; padding: 1px 6px; border-radius: 4px; color: #111827; }
+
+    .otp-card {
+      background: #F9FAFB; border: 1px solid #E5E7EB;
+      border-radius: 14px; padding: 28px 24px; text-align: center;
+      margin-bottom: 24px;
+    }
+    .otp-label {
+      font-size: 11px; font-weight: 700; letter-spacing: 0.14em;
+      text-transform: uppercase; color: #6B7280; margin: 0 0 14px;
+    }
+    .otp-code {
+      font-family: 'Crimson Pro', Georgia, serif; font-weight: 600;
+      font-size: 56px; letter-spacing: 0.1em; color: #111827;
+      line-height: 1; font-feature-settings: "tnum" 1, "lnum" 1;
+      margin: 0 0 14px; user-select: all;
+    }
+    .otp-expiry { font-size: 13px; color: #6B7280; margin: 0; }
+    .otp-expiry strong { color: #111827; font-weight: 600; }
+
+    .body-copy { font-size: 14px; line-height: 1.65; color: #374151; margin: 0 0 18px; }
+
+    .alert-note {
+      margin-top: 22px;
+      background: #FFFBEB;
+      border: 1px solid #FDE68A;
+      border-radius: 10px;
+      padding: 14px 16px;
+      font-size: 13px;
+      line-height: 1.6;
+      color: #78350F;
+    }
+    .alert-note strong { color: #92400E; }
+    .alert-note .wordmark { font-family: 'Crimson Pro', Georgia, serif; font-weight: 600; }
+    .alert-note .wm-ta  { color: #6366F1; }
+    .alert-note .wm-da  { color: #F59E0B; }
+    .alert-note .wm-ify { color: #78350F; }
+
+    .disclaimer {
+      margin-top: 22px; padding-top: 22px; border-top: 1px solid #E5E7EB;
+      font-size: 12px; line-height: 1.6; color: #6B7280;
+    }
+
+    .email-footer {
+      padding: 18px 32px 22px; border-top: 1px solid #F3F4F6;
+      font-size: 11px; color: #9CA3AF; text-align: center; letter-spacing: 0.02em;
+    }
+
+    .plain-section { max-width: 1280px; margin: 36px auto 0; }
+    .plain-section h2 { font-size: 18px; margin-bottom: 6px; }
+    .plain-section p { font-size: 13px; color: var(--fg-muted); margin-bottom: 14px; }
+    .plain-frame { background: var(--bg-elevated); border: 1px solid var(--border); border-radius: var(--radius); box-shadow: var(--shadow-sm); }
+    .plain-frame .inbucket-bar { border-radius: var(--radius) var(--radius) 0 0; }
+    .plain-frame pre {
+      margin: 0; padding: 22px 28px;
+      font-family: var(--font-mono); font-size: 13px;
+      line-height: 1.65; color: var(--fg);
+      white-space: pre-wrap; word-wrap: break-word;
+    }
+    .footer-links { max-width: 1280px; margin: 32px auto 0; font-size: 12px; color: var(--fg-subtle); text-align: center; }
+    .footer-links a { color: var(--brand-primary); margin: 0 8px; }
+  </style>
+</head>
+<body>
+
+  <header class="page-header">
+    <span class="pill">Email mockup</span>
+    <h1>Email change confirm — multipart preview</h1>
+    <span class="crumbs"><a href="./index.html">← email gallery</a></span>
+  </header>
+
+  <p class="page-intro">
+    Sent by Supabase GoTrue to the <strong>new</strong> address when a user updates their primary email. Token-only delivery (TR-tadaify-002) — no clickable confirm link; the 6-digit code confirms ownership of the new mailbox. Real-impl placeholders: <code>{{ .Email }}</code> for the current address, <code>{{ .NewEmail }}</code> for the new address. Below: rendered in a light email client; plain-text fallback (multipart/alternative) at the bottom.
+  </p>
+
+  <div class="pair-grid">
+
+    <div>
+      <div class="inbucket">
+        <div class="inbucket-bar">
+          <span class="dev-badge">🔧 LOCAL DEV</span>
+          <span>Inbucket http://localhost:54354</span>
+          <span class="scheme-mark">light</span>
+        </div>
+        <div class="inbucket-headers">
+          <span class="k">From:</span><span class="v"><strong>tadaify</strong> &lt;noreply@tadaify.com&gt;</span>
+          <span class="k">To:</span><span class="v">waserek-new@local.test</span>
+          <span class="k">Subject:</span><span class="v"><strong>Confirm your new tadaify email: 416052</strong></span>
+          <span class="k">Date:</span><span class="v">2026-05-02 12:34 UTC</span>
+        </div>
+        <div class="email-canvas">
+          <div class="email" role="article" aria-label="Email change confirm OTP email">
+            <div class="email-mark">
+              <span class="wordmark"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span></span>
+            </div>
+            <div class="email-body">
+              <h1 class="greeting">Hi 👋</h1>
+              <p class="sub">you asked to change your <span class="wordmark" style="font-size:15px;"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span><span class="wm-ify">.com</span></span> email from <code>waserek@local.test</code> to <code>waserek-new@local.test</code>.</p>
+
+              <div class="otp-card">
+                <p class="otp-label">Your confirmation code</p>
+                <p class="otp-code">416052</p>
+                <p class="otp-expiry">Code expires in <strong>10 minutes</strong>.</p>
+              </div>
+
+              <p class="body-copy">Enter the 6 digits above on the verification page to confirm the change. The new email becomes your primary login email after confirmation.</p>
+
+              <div class="alert-note">
+                🔔 <strong>Didn't request this change?</strong> Ignore this email and check your account security at
+                <span class="wordmark"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span><span class="wm-ify">.com/settings/security</span></span>.
+                The code expires automatically — no action required.
+              </div>
+
+              <p class="disclaimer">We never share your email address. This is a one-off confirmation; if you don't enter the code within 10 minutes, the change is discarded and your current email stays in place.</p>
+            </div>
+            <div class="email-footer">
+              tadaify · sent from noreply@tadaify.com · this address doesn't accept replies
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <section class="plain-section">
+    <div class="scheme-label">multipart/alternative — text/plain fallback</div>
+    <h2>What plain-text-only clients see</h2>
+    <p>Some clients (terminal mail readers, accessibility tools, SMS gateways, low-bandwidth previews) render only the <code>text/plain</code> part. The fallback contains the same code in clear ASCII — no markup, no CSS, no images. Token-only path is preserved.</p>
+    <div class="plain-frame">
+      <div class="inbucket-bar">
+        <span>Content-Type: text/plain; charset=UTF-8</span>
+        <span class="scheme-mark">plain</span>
+      </div>
+<pre>Hi,
+
+You asked to change your tadaify.com email from
+waserek@local.test to waserek-new@local.test.
+
+Your confirmation code:
+
+    4 1 6 0 5 2
+
+Code expires in 10 minutes.
+
+Enter the 6 digits above on the verification page to confirm
+the change. The new email becomes your primary login email
+after confirmation.
+
+Didn't request this change? Ignore this email and check your
+account security at tadaify.com/settings/security. The code
+expires automatically - no action required.
+
+We never share your email address. This is a one-off
+confirmation; if you don't enter the code within 10 minutes,
+the change is discarded and your current email stays in place.
+
+--
+tada!ify
+sent from noreply@tadaify.com
+this address doesn't accept replies</pre>
+    </div>
+  </section>
+
+  <p class="footer-links"><a href="./index.html">← back to email gallery</a> · <a href="./password-reset.html">← password reset</a> · <a href="./identity-linked.html">identity linked →</a></p>
+
+</body>
+</html>

--- a/mockups/tadaify-mvp/emails/identity-linked.html
+++ b/mockups/tadaify-mvp/emails/identity-linked.html
@@ -1,0 +1,241 @@
+<!--
+type: mockup
+project: tadaify
+title: Auth email — identity linked notification (informational, multipart preview)
+created_at: 2026-05-02T14:10:00Z
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>tadaify — Email mockup: identity linked</title>
+  <link rel="stylesheet" href="../shared/tokens.css">
+  <style>
+    body { background: var(--bg-muted); padding: 32px clamp(16px,4vw,48px); }
+    .page-header { max-width: 1280px; margin: 0 auto 24px; display: flex; align-items: baseline; gap: 16px; flex-wrap: wrap; }
+    .page-header h1 { font-size: 28px; }
+    .page-header .crumbs { font-size: 13px; color: var(--fg-muted); }
+    .page-header .crumbs a { color: var(--brand-primary); }
+    .page-header .pill { padding: 4px 10px; border-radius: var(--radius-full); font-size: 11px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; background: var(--info-bg); color: var(--info); }
+    .page-intro { max-width: 1280px; margin: 0 auto 24px; color: var(--fg-muted); font-size: 14px; line-height: 1.6; max-width: 840px; }
+
+    .pair-grid { max-width: 720px; margin: 0 auto; }
+    .scheme-label { font-size: 12px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: var(--fg-muted); margin: 0 0 8px 4px; }
+
+    .inbucket { background: var(--bg-elevated); border: 1px solid var(--border); border-radius: var(--radius-lg); box-shadow: var(--shadow); overflow: hidden; }
+    .inbucket-bar {
+      padding: 12px 18px; background: var(--bg-muted); border-bottom: 1px solid var(--border);
+      display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+      font-family: var(--font-mono); font-size: 11px; color: var(--fg-muted);
+    }
+    .inbucket-bar .dev-badge { background: #FEF3C7; color: #92400E; padding: 2px 8px; border-radius: 4px; font-weight: 700; font-size: 10px; letter-spacing: 0.04em; }
+    .inbucket-bar .scheme-mark { margin-left: auto; padding: 2px 8px; border-radius: 4px; background: var(--bg-elevated); border: 1px solid var(--border-strong); }
+    .inbucket-headers {
+      padding: 14px 22px; border-bottom: 1px solid var(--border);
+      font-family: var(--font-mono); font-size: 12px; color: var(--fg-muted);
+      display: grid; grid-template-columns: 70px 1fr; gap: 4px 14px;
+    }
+    .inbucket-headers .k { color: var(--fg-subtle); text-align: right; }
+    .inbucket-headers .v { color: var(--fg); word-break: break-all; }
+    .inbucket-headers .v strong { color: var(--fg); font-weight: 600; }
+
+    .email-canvas { padding: 32px 18px; background: #F3F4F6; }
+    .email {
+      max-width: 600px; margin: 0 auto;
+      background: #FFFFFF; border-radius: 14px; overflow: hidden;
+      font-family: 'Inter', system-ui, -apple-system, sans-serif;
+      color: #111827; box-shadow: 0 4px 12px rgba(17,24,39,0.08);
+    }
+    .email-mark { padding: 28px 32px 8px; }
+    .email-mark .wordmark {
+      font-family: 'Crimson Pro', Georgia, serif; font-weight: 600;
+      letter-spacing: -0.02em; font-size: 28px; line-height: 1;
+      display: inline-flex; align-items: baseline;
+    }
+    .email-mark .wm-ta  { color: #6366F1; }
+    .email-mark .wm-da  { color: #F59E0B; }
+    .email-mark .wm-ify { color: #111827; }
+
+    .email-body { padding: 16px 32px 32px; }
+    .greeting {
+      font-family: 'Crimson Pro', Georgia, serif; font-weight: 600;
+      font-size: 26px; line-height: 1.2; letter-spacing: -0.01em;
+      margin: 0 0 6px; color: #111827;
+    }
+    .sub { font-size: 15px; color: #4B5563; margin: 0 0 28px; line-height: 1.55; }
+
+    .info-card {
+      background: #F9FAFB; border: 1px solid #E5E7EB;
+      border-radius: 14px; padding: 22px 24px;
+      margin-bottom: 24px;
+      display: grid;
+      grid-template-columns: 56px 1fr;
+      gap: 18px;
+      align-items: center;
+    }
+    .provider-icon {
+      width: 56px; height: 56px;
+      border-radius: 14px;
+      background: #FFFFFF;
+      border: 1px solid #E5E7EB;
+      display: inline-flex; align-items: center; justify-content: center;
+    }
+    .provider-icon svg { display: block; }
+
+    .info-rows { display: grid; gap: 6px; font-size: 14px; }
+    .info-rows .row { display: grid; grid-template-columns: 96px 1fr; gap: 8px; align-items: baseline; }
+    .info-rows .label { font-size: 11px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; color: #6B7280; }
+    .info-rows .value { color: #111827; font-weight: 500; }
+    .info-rows .value code { font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: 13px; background: #F3F4F6; padding: 1px 6px; border-radius: 4px; }
+    .info-rows .value.mono { font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: 13px; color: #4B5563; }
+
+    .body-copy { font-size: 14px; line-height: 1.65; color: #374151; margin: 0 0 18px; }
+
+    .alert-note {
+      margin-top: 22px;
+      background: #FEF2F2;
+      border: 1px solid #FECACA;
+      border-radius: 10px;
+      padding: 14px 16px;
+      font-size: 13px;
+      line-height: 1.6;
+      color: #7F1D1D;
+    }
+    .alert-note strong { color: #991B1B; }
+    .alert-note code { font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: 12px; background: #FFFFFF; padding: 1px 6px; border-radius: 4px; color: #991B1B; }
+
+    .disclaimer {
+      margin-top: 22px; padding-top: 22px; border-top: 1px solid #E5E7EB;
+      font-size: 12px; line-height: 1.6; color: #6B7280;
+    }
+
+    .email-footer {
+      padding: 18px 32px 22px; border-top: 1px solid #F3F4F6;
+      font-size: 11px; color: #9CA3AF; text-align: center; letter-spacing: 0.02em;
+    }
+
+    .plain-section { max-width: 1280px; margin: 36px auto 0; }
+    .plain-section h2 { font-size: 18px; margin-bottom: 6px; }
+    .plain-section p { font-size: 13px; color: var(--fg-muted); margin-bottom: 14px; }
+    .plain-frame { background: var(--bg-elevated); border: 1px solid var(--border); border-radius: var(--radius); box-shadow: var(--shadow-sm); }
+    .plain-frame .inbucket-bar { border-radius: var(--radius) var(--radius) 0 0; }
+    .plain-frame pre {
+      margin: 0; padding: 22px 28px;
+      font-family: var(--font-mono); font-size: 13px;
+      line-height: 1.65; color: var(--fg);
+      white-space: pre-wrap; word-wrap: break-word;
+    }
+    .footer-links { max-width: 1280px; margin: 32px auto 0; font-size: 12px; color: var(--fg-subtle); text-align: center; }
+    .footer-links a { color: var(--brand-primary); margin: 0 8px; }
+  </style>
+</head>
+<body>
+
+  <header class="page-header">
+    <span class="pill">Email mockup</span>
+    <h1>Identity linked — multipart preview</h1>
+    <span class="crumbs"><a href="./index.html">← email gallery</a></span>
+  </header>
+
+  <p class="page-intro">
+    Informational notification (no token) sent after a third-party identity is linked to an existing tadaify account via OAuth. Real-impl placeholder: <code>{{ .Provider }}</code> for the provider name (Google / Apple / etc.). This is a security trail email — the user already authorized the link in-flow; this email arrives as a record so an unauthorized link triggers an immediate review. Below: rendered in a light email client; plain-text fallback (multipart/alternative) at the bottom.
+  </p>
+
+  <div class="pair-grid">
+
+    <div>
+      <div class="inbucket">
+        <div class="inbucket-bar">
+          <span class="dev-badge">🔧 LOCAL DEV</span>
+          <span>Inbucket http://localhost:54354</span>
+          <span class="scheme-mark">light</span>
+        </div>
+        <div class="inbucket-headers">
+          <span class="k">From:</span><span class="v"><strong>tadaify</strong> &lt;noreply@tadaify.com&gt;</span>
+          <span class="k">To:</span><span class="v">waserek@local.test</span>
+          <span class="k">Subject:</span><span class="v"><strong>We linked your Google account to tadaify</strong></span>
+          <span class="k">Date:</span><span class="v">2026-05-02 12:34 UTC</span>
+        </div>
+        <div class="email-canvas">
+          <div class="email" role="article" aria-label="Identity linked notification email">
+            <div class="email-mark">
+              <span class="wordmark"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span></span>
+            </div>
+            <div class="email-body">
+              <h1 class="greeting">Hey @waserek</h1>
+              <p class="sub">we linked your Google account to your <span class="wordmark" style="font-size:15px;"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span><span class="wm-ify">.com</span></span> profile.</p>
+
+              <div class="info-card">
+                <span class="provider-icon" aria-hidden="true">
+                  <svg width="32" height="32" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+                    <path fill="#4285F4" d="M43.611 20.083H42V20H24v8h11.303c-1.649 4.657-6.08 8-11.303 8-6.627 0-12-5.373-12-12s5.373-12 12-12c3.059 0 5.842 1.154 7.961 3.039l5.657-5.657C34.046 6.053 29.268 4 24 4 12.955 4 4 12.955 4 24s8.955 20 20 20 20-8.955 20-20c0-1.341-.138-2.65-.389-3.917z"/>
+                    <path fill="#34A853" d="M6.306 14.691l6.571 4.819C14.655 15.108 18.961 12 24 12c3.059 0 5.842 1.154 7.961 3.039l5.657-5.657C34.046 6.053 29.268 4 24 4 16.318 4 9.656 8.337 6.306 14.691z"/>
+                    <path fill="#FBBC05" d="M24 44c5.166 0 9.86-1.977 13.409-5.192l-6.19-5.238A11.91 11.91 0 0 1 24 36c-5.202 0-9.619-3.317-11.283-7.946l-6.522 5.025C9.505 39.556 16.227 44 24 44z"/>
+                    <path fill="#EA4335" d="M43.611 20.083H42V20H24v8h11.303a12.04 12.04 0 0 1-4.087 5.571l.003-.002 6.19 5.238C36.971 39.205 44 34 44 24c0-1.341-.138-2.65-.389-3.917z"/>
+                  </svg>
+                </span>
+                <div class="info-rows">
+                  <div class="row"><span class="label">Provider</span><span class="value">Google</span></div>
+                  <div class="row"><span class="label">Email used</span><span class="value mono">waserek@gmail.com</span></div>
+                  <div class="row"><span class="label">Linked at</span><span class="value mono">2026-05-02 12:34 UTC</span></div>
+                </div>
+              </div>
+
+              <p class="body-copy">Future sign-ins via Google will go straight in. You can still sign in with your email + 6-digit code at any time.</p>
+
+              <div class="alert-note">
+                🛡 <strong>Didn't link this?</strong> Contact support immediately at <code>support@tadaify.com</code> and open your security settings to revoke the linked account.
+              </div>
+
+              <p class="disclaimer">This is a security record — we email you whenever a new sign-in method is added so unauthorized links can be reviewed. We never share your address.</p>
+            </div>
+            <div class="email-footer">
+              tadaify · sent from noreply@tadaify.com · this address doesn't accept replies
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <section class="plain-section">
+    <div class="scheme-label">multipart/alternative — text/plain fallback</div>
+    <h2>What plain-text-only clients see</h2>
+    <p>Some clients (terminal mail readers, accessibility tools, SMS gateways, low-bandwidth previews) render only the <code>text/plain</code> part. The fallback contains the same notification in clear ASCII — no markup, no CSS, no images.</p>
+    <div class="plain-frame">
+      <div class="inbucket-bar">
+        <span>Content-Type: text/plain; charset=UTF-8</span>
+        <span class="scheme-mark">plain</span>
+      </div>
+<pre>Hey @waserek,
+
+We linked your Google account to your tadaify.com profile.
+
+  Provider:   Google
+  Email used: waserek@gmail.com
+  Linked at:  2026-05-02 12:34 UTC
+
+Future sign-ins via Google will go straight in. You can still
+sign in with your email + 6-digit code at any time.
+
+Didn't link this? Contact support immediately at
+support@tadaify.com and open your security settings to revoke
+the linked account.
+
+This is a security record - we email you whenever a new
+sign-in method is added so unauthorized links can be reviewed.
+We never share your address.
+
+--
+tada!ify
+sent from noreply@tadaify.com
+this address doesn't accept replies</pre>
+    </div>
+  </section>
+
+  <p class="footer-links"><a href="./index.html">← back to email gallery</a> · <a href="./email-change-confirm.html">← email change confirm</a> · <a href="./welcome.html">welcome →</a></p>
+
+</body>
+</html>

--- a/mockups/tadaify-mvp/emails/index.html
+++ b/mockups/tadaify-mvp/emails/index.html
@@ -9,7 +9,7 @@ created_at: 2026-05-02T13:15:00Z
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>tadaify — Email mockups · Phase 1</title>
+  <title>tadaify — Email mockups · Phase 1 + Phase 2 preview</title>
   <link rel="stylesheet" href="../shared/tokens.css">
   <style>
     body { background: var(--bg-muted); }
@@ -140,23 +140,27 @@ created_at: 2026-05-02T13:15:00Z
 
   <header class="gallery-header">
     <span class="wordmark"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span></span>
-    <h1>Email mockups · Phase 1</h1>
+    <h1>Email mockups · Phase 1 + Phase 2 preview</h1>
     <span class="crumbs"><a href="../index.html">← all mockups</a></span>
   </header>
 
   <section class="intro">
-    <h2>Auth emails — Phase 1</h2>
+    <h2>Auth + lifecycle emails — Phase 1 ready, Phase 2 preview</h2>
     <p>
-      Two transactional emails cover 100% of the Phase 1 auth surface: the OTP sent on signup
+      Phase 1 (merged) ships two transactional auth emails: the OTP sent on signup
       (new visitor confirms their address) and the OTP sent on every subsequent login
-      (passwordless sign-in is the only login path in tadaify). Token-only delivery per
-      <strong>TR-tadaify-002</strong> — the email body never contains <code>{{ .ConfirmationURL }}</code>
-      or any clickable auth link. The 6-digit code is the entire auth handshake. Each mockup
-      shows the email rendered side-by-side in a light client and a dark client, plus the
-      <code>text/plain</code> multipart fallback below.
+      (passwordless sign-in is the only login path in tadaify). Phase 2 (preview only —
+      not yet implemented in production) adds four more templates: password reset,
+      email-change confirmation, identity-linked notification, and the post-onboarding
+      welcome email. Token-only delivery per <strong>TR-tadaify-002</strong> — the auth
+      email body never contains <code>{{ .ConfirmationURL }}</code> or any clickable auth
+      link. The 6-digit code is the entire auth handshake. The welcome email is the only
+      non-auth surface and may carry a single user-page link. Each mockup shows the email
+      in a light client plus the <code>text/plain</code> multipart fallback below.
     </p>
     <div class="meta-pills">
       <span class="pill ok">Phase 1 — ready</span>
+      <span class="pill info">Phase 2 — preview</span>
       <span class="pill info">tadaify-app#150</span>
       <span class="pill warm">Brand lock 2026-04-24</span>
       <span class="pill muted">DEC-WORDMARK-01</span>
@@ -193,41 +197,41 @@ created_at: 2026-05-02T13:15:00Z
 
   </div>
 
-  <h3 class="section-title">Phase 2 — coming next</h3>
+  <h3 class="section-title">Phase 2 — preview (mockups only, not yet implemented in production)</h3>
 
   <div class="tile-grid">
 
-    <span class="tile disabled" aria-disabled="true">
-      <span class="tile-status later">Phase 2</span>
+    <a class="tile" href="./password-reset.html">
+      <span class="tile-status next">Preview</span>
       <span class="tile-icon">03</span>
       <h4 class="tile-title">Password reset OTP</h4>
-      <p class="tile-sub">Optional once we add password sign-in alongside OTP. Same token-only contract.</p>
-      <span class="tile-meta">coming Phase 2</span>
-    </span>
+      <p class="tile-sub">Sent when a user submits the password-reset form. Same token-only contract — no clickable reset link.</p>
+      <span class="tile-meta">Subject: "Reset your tadaify password: 738294" · TTL 10 min</span>
+    </a>
 
-    <span class="tile disabled" aria-disabled="true">
-      <span class="tile-status later">Phase 2</span>
+    <a class="tile" href="./email-change-confirm.html">
+      <span class="tile-status next">Preview</span>
       <span class="tile-icon">04</span>
       <h4 class="tile-title">Email change confirm</h4>
-      <p class="tile-sub">Sent to new address when a user updates their primary email. Confirms ownership of the new address.</p>
-      <span class="tile-meta">coming Phase 2</span>
-    </span>
+      <p class="tile-sub">Sent to the new address when a user updates their primary email. Confirms ownership of the new mailbox.</p>
+      <span class="tile-meta">Subject: "Confirm your new tadaify email: 416052" · TTL 10 min</span>
+    </a>
 
-    <span class="tile disabled" aria-disabled="true">
-      <span class="tile-status later">Phase 2</span>
+    <a class="tile" href="./identity-linked.html">
+      <span class="tile-status next">Preview</span>
       <span class="tile-icon">05</span>
       <h4 class="tile-title">Identity linked</h4>
-      <p class="tile-sub">Notification when a third-party identity (Google, Apple) is linked to an existing tadaify account.</p>
-      <span class="tile-meta">coming Phase 2</span>
-    </span>
+      <p class="tile-sub">Informational notification (no token) sent after a third-party identity is linked via OAuth — security trail.</p>
+      <span class="tile-meta">Subject: "We linked your Google account to tadaify"</span>
+    </a>
 
-    <span class="tile disabled" aria-disabled="true">
-      <span class="tile-status later">Phase 2</span>
+    <a class="tile warm" href="./welcome.html">
+      <span class="tile-status next">Preview</span>
       <span class="tile-icon">06</span>
       <h4 class="tile-title">Welcome email</h4>
-      <p class="tile-sub">Lifecycle (not auth). Sent ~1 hour after first login with onboarding tips and trust strip.</p>
-      <span class="tile-meta">coming Phase 2</span>
-    </span>
+      <p class="tile-sub">Lifecycle (not auth). Sent after onboarding completion with page URL, three setup tips, and one soft trust line.</p>
+      <span class="tile-meta">Subject: "Welcome to tadaify, @waserek!"</span>
+    </a>
 
   </div>
 

--- a/mockups/tadaify-mvp/emails/index.html
+++ b/mockups/tadaify-mvp/emails/index.html
@@ -229,8 +229,8 @@ created_at: 2026-05-02T13:15:00Z
       <span class="tile-status next">Preview</span>
       <span class="tile-icon">06</span>
       <h4 class="tile-title">Welcome email</h4>
-      <p class="tile-sub">Lifecycle (not auth). Sent after onboarding completion with page URL, three setup tips, and one soft trust line.</p>
-      <span class="tile-meta">Subject: "Welcome to tadaify, @waserek!"</span>
+      <p class="tile-sub">Lifecycle (not auth). Sent right after handle claim / OTP verification — celebrates that <code>@handle</code> is permanently the user's. URL is reserved but not yet live (page Publish-gated per DEC-332 = D).</p>
+      <span class="tile-meta">Subject: "@waserek is yours — welcome to tadaify"</span>
     </a>
 
   </div>

--- a/mockups/tadaify-mvp/emails/password-reset.html
+++ b/mockups/tadaify-mvp/emails/password-reset.html
@@ -1,0 +1,280 @@
+<!--
+type: mockup
+project: tadaify
+title: Auth email — password reset OTP (token-only, multipart preview)
+created_at: 2026-05-02T14:00:00Z
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>tadaify — Email mockup: password reset OTP</title>
+  <link rel="stylesheet" href="../shared/tokens.css">
+  <style>
+    body { background: var(--bg-muted); padding: 32px clamp(16px,4vw,48px); }
+    .page-header { max-width: 1280px; margin: 0 auto 24px; display: flex; align-items: baseline; gap: 16px; flex-wrap: wrap; }
+    .page-header h1 { font-size: 28px; }
+    .page-header .crumbs { font-size: 13px; color: var(--fg-muted); }
+    .page-header .crumbs a { color: var(--brand-primary); }
+    .page-header .pill { padding: 4px 10px; border-radius: var(--radius-full); font-size: 11px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; background: var(--info-bg); color: var(--info); }
+    .page-intro { max-width: 1280px; margin: 0 auto 24px; color: var(--fg-muted); font-size: 14px; line-height: 1.6; max-width: 840px; }
+
+    .pair-grid { max-width: 720px; margin: 0 auto; }
+
+    .scheme-label { font-size: 12px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: var(--fg-muted); margin: 0 0 8px 4px; }
+
+    .inbucket {
+      background: var(--bg-elevated);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-lg);
+      box-shadow: var(--shadow);
+      overflow: hidden;
+    }
+
+    .inbucket-bar {
+      padding: 12px 18px;
+      background: var(--bg-muted);
+      border-bottom: 1px solid var(--border);
+      display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+      font-family: var(--font-mono); font-size: 11px; color: var(--fg-muted);
+    }
+    .inbucket-bar .dev-badge {
+      background: #FEF3C7; color: #92400E;
+      padding: 2px 8px; border-radius: 4px; font-weight: 700;
+      font-size: 10px; letter-spacing: 0.04em;
+    }
+    .inbucket-bar .scheme-mark { margin-left: auto; padding: 2px 8px; border-radius: 4px; background: var(--bg-elevated); border: 1px solid var(--border-strong); }
+
+    .inbucket-headers {
+      padding: 14px 22px;
+      border-bottom: 1px solid var(--border);
+      font-family: var(--font-mono); font-size: 12px; color: var(--fg-muted);
+      display: grid; grid-template-columns: 70px 1fr; gap: 4px 14px;
+    }
+    .inbucket-headers .k { color: var(--fg-subtle); text-align: right; }
+    .inbucket-headers .v { color: var(--fg); word-break: break-all; }
+    .inbucket-headers .v strong { color: var(--fg); font-weight: 600; }
+
+    .email-canvas { padding: 32px 18px; background: #F3F4F6; }
+
+    .email {
+      max-width: 600px; margin: 0 auto;
+      background: #FFFFFF;
+      border-radius: 14px;
+      overflow: hidden;
+      font-family: 'Inter', system-ui, -apple-system, sans-serif;
+      color: #111827;
+      box-shadow: 0 4px 12px rgba(17,24,39,0.08);
+    }
+
+    .email-mark { padding: 28px 32px 8px; }
+    .email-mark .wordmark {
+      font-family: 'Crimson Pro', Georgia, serif;
+      font-weight: 600;
+      letter-spacing: -0.02em;
+      font-size: 28px;
+      line-height: 1;
+      display: inline-flex;
+      align-items: baseline;
+    }
+    .email-mark .wm-ta  { color: #6366F1; }
+    .email-mark .wm-da  { color: #F59E0B; }
+    .email-mark .wm-ify { color: #111827; }
+
+    .email-body { padding: 16px 32px 32px; }
+    .greeting {
+      font-family: 'Crimson Pro', Georgia, serif;
+      font-weight: 600;
+      font-size: 26px;
+      line-height: 1.2;
+      letter-spacing: -0.01em;
+      margin: 0 0 6px;
+      color: #111827;
+    }
+    .sub {
+      font-size: 15px;
+      color: #4B5563;
+      margin: 0 0 28px;
+      line-height: 1.55;
+    }
+
+    .otp-card {
+      background: #F9FAFB;
+      border: 1px solid #E5E7EB;
+      border-radius: 14px;
+      padding: 28px 24px;
+      text-align: center;
+      margin-bottom: 24px;
+    }
+
+    .otp-label {
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: #6B7280;
+      margin: 0 0 14px;
+    }
+
+    .otp-code {
+      font-family: 'Crimson Pro', Georgia, serif;
+      font-weight: 600;
+      font-size: 56px;
+      letter-spacing: 0.1em;
+      color: #111827;
+      line-height: 1;
+      font-feature-settings: "tnum" 1, "lnum" 1;
+      margin: 0 0 14px;
+      user-select: all;
+    }
+
+    .otp-expiry {
+      font-size: 13px;
+      color: #6B7280;
+      margin: 0;
+    }
+    .otp-expiry strong { color: #111827; font-weight: 600; }
+
+    .body-copy {
+      font-size: 14px;
+      line-height: 1.65;
+      color: #374151;
+      margin: 0 0 18px;
+    }
+
+    .disclaimer {
+      margin-top: 22px;
+      padding-top: 22px;
+      border-top: 1px solid #E5E7EB;
+      font-size: 12px;
+      line-height: 1.6;
+      color: #6B7280;
+    }
+
+    .email-footer {
+      padding: 18px 32px 22px;
+      border-top: 1px solid #F3F4F6;
+      font-size: 11px;
+      color: #9CA3AF;
+      text-align: center;
+      letter-spacing: 0.02em;
+    }
+
+    .plain-section { max-width: 1280px; margin: 36px auto 0; }
+    .plain-section h2 { font-size: 18px; margin-bottom: 6px; }
+    .plain-section p { font-size: 13px; color: var(--fg-muted); margin-bottom: 14px; }
+    .plain-frame {
+      background: var(--bg-elevated);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      box-shadow: var(--shadow-sm);
+    }
+    .plain-frame .inbucket-bar { border-radius: var(--radius) var(--radius) 0 0; }
+    .plain-frame pre {
+      margin: 0;
+      padding: 22px 28px;
+      font-family: var(--font-mono);
+      font-size: 13px;
+      line-height: 1.65;
+      color: var(--fg);
+      white-space: pre-wrap;
+      word-wrap: break-word;
+    }
+
+    .footer-links { max-width: 1280px; margin: 32px auto 0; font-size: 12px; color: var(--fg-subtle); text-align: center; }
+    .footer-links a { color: var(--brand-primary); margin: 0 8px; }
+  </style>
+</head>
+<body>
+
+  <header class="page-header">
+    <span class="pill">Email mockup</span>
+    <h1>Password reset OTP — multipart preview</h1>
+    <span class="crumbs"><a href="./index.html">← email gallery</a></span>
+  </header>
+
+  <p class="page-intro">
+    Sent by Supabase GoTrue when a user submits the password-reset form. Token-only delivery (TR-tadaify-002) — there is no <code>{{ .RecoveryURL }}</code> placeholder and no clickable reset link. The 6-digit code is the entire reset path: user enters it on the still-open browser page to set a new password. Below: rendered in a light email client; plain-text fallback (multipart/alternative) at the bottom.
+  </p>
+
+  <div class="pair-grid">
+
+    <div>
+      <div class="inbucket">
+        <div class="inbucket-bar">
+          <span class="dev-badge">🔧 LOCAL DEV</span>
+          <span>Inbucket http://localhost:54354</span>
+          <span class="scheme-mark">light</span>
+        </div>
+        <div class="inbucket-headers">
+          <span class="k">From:</span><span class="v"><strong>tadaify</strong> &lt;noreply@tadaify.com&gt;</span>
+          <span class="k">To:</span><span class="v">waserek@local.test</span>
+          <span class="k">Subject:</span><span class="v"><strong>Reset your tadaify password: 738294</strong></span>
+          <span class="k">Date:</span><span class="v">2026-05-02 12:34 UTC</span>
+        </div>
+        <div class="email-canvas">
+          <div class="email" role="article" aria-label="Password reset OTP email">
+            <div class="email-mark">
+              <span class="wordmark"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span></span>
+            </div>
+            <div class="email-body">
+              <h1 class="greeting">Hey 👋</h1>
+              <p class="sub">someone (hopefully you) requested a password reset for your <span class="wordmark" style="font-size:15px;"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span><span class="wm-ify">.com</span></span> account.</p>
+
+              <div class="otp-card">
+                <p class="otp-label">Your reset code</p>
+                <p class="otp-code">738294</p>
+                <p class="otp-expiry">Code expires in <strong>10 minutes</strong>.</p>
+              </div>
+
+              <p class="body-copy">Enter the 6 digits above on the password-reset page to set a new password. We never email a clickable reset link — only this code, only to your inbox.</p>
+
+              <p class="disclaimer">If you didn't request this, ignore this email — your password stays unchanged. We never share your address.</p>
+            </div>
+            <div class="email-footer">
+              tadaify · sent from noreply@tadaify.com · this address doesn't accept replies
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <section class="plain-section">
+    <div class="scheme-label">multipart/alternative — text/plain fallback</div>
+    <h2>What plain-text-only clients see</h2>
+    <p>Some clients (terminal mail readers, accessibility tools, SMS gateways, low-bandwidth previews) render only the <code>text/plain</code> part. The fallback contains the same code in clear ASCII — no markup, no CSS, no images. Token-only path is preserved.</p>
+    <div class="plain-frame">
+      <div class="inbucket-bar">
+        <span>Content-Type: text/plain; charset=UTF-8</span>
+        <span class="scheme-mark">plain</span>
+      </div>
+<pre>Hey,
+
+Someone (hopefully you) requested a password reset for your tadaify.com account.
+
+Your reset code:
+
+    7 3 8 2 9 4
+
+Code expires in 10 minutes.
+
+Enter the 6 digits above on the password-reset page to set a
+new password. We never email a clickable reset link.
+
+If you didn't request this, ignore this email - your password
+stays unchanged. We never share your address.
+
+--
+tada!ify
+sent from noreply@tadaify.com
+this address doesn't accept replies</pre>
+    </div>
+  </section>
+
+  <p class="footer-links"><a href="./index.html">← back to email gallery</a> · <a href="./email-change-confirm.html">email change confirm →</a> · <a href="./_email-tokens-preview.html">tokens compare</a></p>
+
+</body>
+</html>

--- a/mockups/tadaify-mvp/emails/welcome.html
+++ b/mockups/tadaify-mvp/emails/welcome.html
@@ -202,13 +202,13 @@ created_at: 2026-05-02T14:15:00Z
               </div>
 
               <p style="margin: 0 0 18px 0; font-size: 14px; color: #4B5563; line-height: 1.6;">
-                Your page goes live the moment you publish your first block. Until then, visitors who hit your URL see a "coming soon" placeholder — no empty page, no awkward first impression. Take your time.
+                Your page goes live the moment you click <strong>Publish</strong> — any time after you've added at least one block. Until then, visitors who hit your URL see a "coming soon" placeholder — no empty page, no awkward first impression. Take your time.
               </p>
 
               <ul class="tips-list">
                 <li>
                   <span class="step-num">1</span>
-                  <span class="step-text"><strong>Add your first link block.</strong> Drop a YouTube video, an external shop link, or a contact form — whatever your audience needs first. The page publishes automatically the moment you save.</span>
+                  <span class="step-text"><strong>Add your first link block.</strong> Drop a YouTube video, an external shop link, or a contact form — whatever your audience needs first. Your page stays in draft until you're ready.</span>
                 </li>
                 <li>
                   <span class="step-num">2</span>
@@ -255,17 +255,17 @@ for you, forever.
 Set up your page:
 https://tadaify.com/app/setup
 
-Your page goes live the moment you publish your first block.
-Until then, visitors who hit your URL see a "coming soon"
-placeholder - no empty page, no awkward first impression.
-Take your time.
+Your page goes live the moment you click Publish - any time
+after you've added at least one block. Until then, visitors
+who hit your URL see a "coming soon" placeholder - no empty
+page, no awkward first impression. Take your time.
 
 Three quick steps when you're ready:
 
   1. Add your first link block. Drop a YouTube video, an
      external shop link, or a contact form - whatever your
-     audience needs first. The page publishes automatically
-     the moment you save.
+     audience needs first. Your page stays in draft until
+     you're ready.
 
   2. Pick a theme. Light, dark, or your own colors. Switch
      any time from Settings -> Appearance.

--- a/mockups/tadaify-mvp/emails/welcome.html
+++ b/mockups/tadaify-mvp/emails/welcome.html
@@ -1,0 +1,277 @@
+<!--
+type: mockup
+project: tadaify
+title: Lifecycle email — welcome (post-onboarding, multipart preview)
+created_at: 2026-05-02T14:15:00Z
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>tadaify — Email mockup: welcome</title>
+  <link rel="stylesheet" href="../shared/tokens.css">
+  <style>
+    body { background: var(--bg-muted); padding: 32px clamp(16px,4vw,48px); }
+    .page-header { max-width: 1280px; margin: 0 auto 24px; display: flex; align-items: baseline; gap: 16px; flex-wrap: wrap; }
+    .page-header h1 { font-size: 28px; }
+    .page-header .crumbs { font-size: 13px; color: var(--fg-muted); }
+    .page-header .crumbs a { color: var(--brand-primary); }
+    .page-header .pill { padding: 4px 10px; border-radius: var(--radius-full); font-size: 11px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; background: rgba(245,158,11,0.18); color: #92400E; }
+    .page-intro { max-width: 1280px; margin: 0 auto 24px; color: var(--fg-muted); font-size: 14px; line-height: 1.6; max-width: 840px; }
+
+    .pair-grid { max-width: 720px; margin: 0 auto; }
+    .scheme-label { font-size: 12px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: var(--fg-muted); margin: 0 0 8px 4px; }
+
+    .inbucket { background: var(--bg-elevated); border: 1px solid var(--border); border-radius: var(--radius-lg); box-shadow: var(--shadow); overflow: hidden; }
+    .inbucket-bar {
+      padding: 12px 18px; background: var(--bg-muted); border-bottom: 1px solid var(--border);
+      display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+      font-family: var(--font-mono); font-size: 11px; color: var(--fg-muted);
+    }
+    .inbucket-bar .dev-badge { background: #FEF3C7; color: #92400E; padding: 2px 8px; border-radius: 4px; font-weight: 700; font-size: 10px; letter-spacing: 0.04em; }
+    .inbucket-bar .scheme-mark { margin-left: auto; padding: 2px 8px; border-radius: 4px; background: var(--bg-elevated); border: 1px solid var(--border-strong); }
+    .inbucket-headers {
+      padding: 14px 22px; border-bottom: 1px solid var(--border);
+      font-family: var(--font-mono); font-size: 12px; color: var(--fg-muted);
+      display: grid; grid-template-columns: 70px 1fr; gap: 4px 14px;
+    }
+    .inbucket-headers .k { color: var(--fg-subtle); text-align: right; }
+    .inbucket-headers .v { color: var(--fg); word-break: break-all; }
+    .inbucket-headers .v strong { color: var(--fg); font-weight: 600; }
+
+    .email-canvas { padding: 32px 18px; background: #F3F4F6; }
+    .email {
+      max-width: 600px; margin: 0 auto;
+      background: #FFFFFF; border-radius: 14px; overflow: hidden;
+      font-family: 'Inter', system-ui, -apple-system, sans-serif;
+      color: #111827; box-shadow: 0 4px 12px rgba(17,24,39,0.08);
+    }
+
+    .email-mark { padding: 36px 32px 12px; text-align: left; }
+    .email-mark .wordmark {
+      font-family: 'Crimson Pro', Georgia, serif; font-weight: 600;
+      letter-spacing: -0.02em; font-size: 40px; line-height: 1;
+      display: inline-flex; align-items: baseline;
+    }
+    .email-mark .wm-ta  { color: #6366F1; }
+    .email-mark .wm-da  { color: #F59E0B; }
+    .email-mark .wm-ify { color: #111827; }
+
+    .email-body { padding: 8px 32px 32px; }
+    .greeting {
+      font-family: 'Crimson Pro', Georgia, serif; font-weight: 600;
+      font-size: 30px; line-height: 1.2; letter-spacing: -0.01em;
+      margin: 0 0 8px; color: #111827;
+    }
+    .sub { font-size: 15px; color: #4B5563; margin: 0 0 24px; line-height: 1.55; }
+
+    .hero-card {
+      background: linear-gradient(135deg, rgba(99,102,241,0.06) 0%, rgba(245,158,11,0.06) 100%);
+      border: 1px solid #E5E7EB;
+      border-radius: 14px;
+      padding: 22px 24px;
+      margin-bottom: 26px;
+    }
+    .hero-rows { display: grid; gap: 8px; font-size: 14px; margin-bottom: 18px; }
+    .hero-rows .row { display: grid; grid-template-columns: 110px 1fr; gap: 10px; align-items: baseline; }
+    .hero-rows .label { font-size: 11px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; color: #6B7280; }
+    .hero-rows .value { color: #111827; font-weight: 500; }
+    .hero-rows .value code { font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: 14px; background: #FFFFFF; padding: 2px 8px; border-radius: 5px; border: 1px solid #E5E7EB; color: #111827; }
+
+    .cta-button {
+      display: inline-block;
+      background: #6366F1;
+      color: #FFFFFF !important;
+      font-family: 'Inter', system-ui, -apple-system, sans-serif;
+      font-weight: 600;
+      font-size: 14px;
+      padding: 12px 22px;
+      border-radius: 10px;
+      text-decoration: none;
+      letter-spacing: 0.01em;
+      box-shadow: 0 1px 2px rgba(17,24,39,0.08);
+    }
+    .cta-button:hover { background: #4F46E5; }
+
+    .tips-list {
+      margin: 4px 0 24px;
+      padding: 0;
+      list-style: none;
+    }
+    .tips-list li {
+      display: grid;
+      grid-template-columns: 28px 1fr;
+      gap: 12px;
+      padding: 12px 0;
+      border-bottom: 1px solid #F3F4F6;
+      font-size: 14px;
+      line-height: 1.55;
+      color: #374151;
+    }
+    .tips-list li:last-child { border-bottom: 0; }
+    .tips-list .step-num {
+      width: 26px; height: 26px;
+      border-radius: 50%;
+      background: rgba(99,102,241,0.12);
+      color: #6366F1;
+      font-family: 'Crimson Pro', Georgia, serif;
+      font-weight: 600;
+      font-size: 14px;
+      display: inline-flex; align-items: center; justify-content: center;
+      margin-top: 1px;
+    }
+    .tips-list .step-text strong { color: #111827; font-weight: 600; }
+
+    .trust-line {
+      margin-top: 20px;
+      padding: 12px 16px;
+      background: #F9FAFB;
+      border: 1px solid #E5E7EB;
+      border-radius: 10px;
+      font-size: 13px;
+      color: #4B5563;
+      text-align: center;
+    }
+    .trust-line strong { color: #111827; }
+
+    .email-footer {
+      padding: 18px 32px 22px; border-top: 1px solid #F3F4F6;
+      font-size: 11px; color: #9CA3AF; text-align: center; letter-spacing: 0.02em;
+    }
+    .email-footer a { color: #6B7280; text-decoration: underline; }
+
+    .plain-section { max-width: 1280px; margin: 36px auto 0; }
+    .plain-section h2 { font-size: 18px; margin-bottom: 6px; }
+    .plain-section p { font-size: 13px; color: var(--fg-muted); margin-bottom: 14px; }
+    .plain-frame { background: var(--bg-elevated); border: 1px solid var(--border); border-radius: var(--radius); box-shadow: var(--shadow-sm); }
+    .plain-frame .inbucket-bar { border-radius: var(--radius) var(--radius) 0 0; }
+    .plain-frame pre {
+      margin: 0; padding: 22px 28px;
+      font-family: var(--font-mono); font-size: 13px;
+      line-height: 1.65; color: var(--fg);
+      white-space: pre-wrap; word-wrap: break-word;
+    }
+    .footer-links { max-width: 1280px; margin: 32px auto 0; font-size: 12px; color: var(--fg-subtle); text-align: center; }
+    .footer-links a { color: var(--brand-primary); margin: 0 8px; }
+  </style>
+</head>
+<body>
+
+  <header class="page-header">
+    <span class="pill">Lifecycle email</span>
+    <h1>Welcome — multipart preview</h1>
+    <span class="crumbs"><a href="./index.html">← email gallery</a></span>
+  </header>
+
+  <p class="page-intro">
+    Sent after onboarding completion (Slice C) — first time the user reaches a published page. <strong>No token, not auth.</strong> This is the one transactional surface where a clickable link is OK because the destination is the user's own page (not a credential / auth flow). Larger wordmark + softer copy reflect the celebratory tone. One soft trust line ("price locked for life") is allowed here; auth emails carry none. Below: rendered in a light email client; plain-text fallback (multipart/alternative) at the bottom.
+  </p>
+
+  <div class="pair-grid">
+
+    <div>
+      <div class="inbucket">
+        <div class="inbucket-bar">
+          <span class="dev-badge">🔧 LOCAL DEV</span>
+          <span>Inbucket http://localhost:54354</span>
+          <span class="scheme-mark">light</span>
+        </div>
+        <div class="inbucket-headers">
+          <span class="k">From:</span><span class="v"><strong>tadaify</strong> &lt;noreply@tadaify.com&gt;</span>
+          <span class="k">To:</span><span class="v">waserek@local.test</span>
+          <span class="k">Subject:</span><span class="v"><strong>Welcome to tadaify, @waserek!</strong></span>
+          <span class="k">Date:</span><span class="v">2026-05-02 12:34 UTC</span>
+        </div>
+        <div class="email-canvas">
+          <div class="email" role="article" aria-label="Welcome email">
+            <div class="email-mark">
+              <span class="wordmark"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span></span>
+            </div>
+            <div class="email-body">
+              <h1 class="greeting">Welcome, @waserek 🎉</h1>
+              <p class="sub">your page is live at <span class="wordmark" style="font-size:15px;"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span><span class="wm-ify">.com/waserek</span></span>.</p>
+
+              <div class="hero-card">
+                <div class="hero-rows">
+                  <div class="row"><span class="label">Your handle</span><span class="value"><code>@waserek</code></span></div>
+                  <div class="row"><span class="label">Your page</span><span class="value"><code>https://tadaify.com/waserek</code></span></div>
+                </div>
+                <a class="cta-button" href="https://tadaify.com/waserek">View your page →</a>
+              </div>
+
+              <ul class="tips-list">
+                <li>
+                  <span class="step-num">1</span>
+                  <span class="step-text"><strong>Add your first link block.</strong> Drop a YouTube video, an external shop link, or a contact form — whatever your audience needs first.</span>
+                </li>
+                <li>
+                  <span class="step-num">2</span>
+                  <span class="step-text"><strong>Pick a theme.</strong> Light, dark, or your own colors. Switch any time from <code style="font-family:'JetBrains Mono',ui-monospace,monospace;font-size:12px;background:#F3F4F6;padding:1px 5px;border-radius:4px;">Settings → Appearance</code>.</span>
+                </li>
+                <li>
+                  <span class="step-num">3</span>
+                  <span class="step-text"><strong>Share your URL anywhere.</strong> Drop <code style="font-family:'JetBrains Mono',ui-monospace,monospace;font-size:12px;background:#F3F4F6;padding:1px 5px;border-radius:4px;">tadaify.com/waserek</code> in your bio on Instagram, TikTok, X, YouTube, anywhere.</span>
+                </li>
+              </ul>
+
+              <p class="trust-line">
+                🔒 <strong>Price locked for life</strong> — your plan never increases. Whatever tier you pick today is what you pay forever.
+              </p>
+            </div>
+            <div class="email-footer">
+              tadaify · sent from noreply@tadaify.com · <a href="https://tadaify.com/settings/email-preferences">manage email preferences</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <section class="plain-section">
+    <div class="scheme-label">multipart/alternative — text/plain fallback</div>
+    <h2>What plain-text-only clients see</h2>
+    <p>Some clients (terminal mail readers, accessibility tools, low-bandwidth previews) render only the <code>text/plain</code> part. Same content in clear ASCII — no markup, no CSS, no images.</p>
+    <div class="plain-frame">
+      <div class="inbucket-bar">
+        <span>Content-Type: text/plain; charset=UTF-8</span>
+        <span class="scheme-mark">plain</span>
+      </div>
+<pre>Welcome, @waserek!
+
+Your page is live at tadaify.com/waserek.
+
+  Your handle: @waserek
+  Your page:   https://tadaify.com/waserek
+
+View your page:
+https://tadaify.com/waserek
+
+Three quick steps to make it yours:
+
+  1. Add your first link block. Drop a YouTube video, an
+     external shop link, or a contact form - whatever your
+     audience needs first.
+
+  2. Pick a theme. Light, dark, or your own colors. Switch
+     any time from Settings -> Appearance.
+
+  3. Share your URL anywhere. Drop tadaify.com/waserek in
+     your bio on Instagram, TikTok, X, YouTube, anywhere.
+
+Price locked for life - your plan never increases. Whatever
+tier you pick today is what you pay forever.
+
+--
+tada!ify
+sent from noreply@tadaify.com
+manage email preferences:
+https://tadaify.com/settings/email-preferences</pre>
+    </div>
+  </section>
+
+  <p class="footer-links"><a href="./index.html">← back to email gallery</a> · <a href="./identity-linked.html">← identity linked</a> · <a href="./_email-tokens-preview.html">tokens compare</a></p>
+
+</body>
+</html>

--- a/mockups/tadaify-mvp/emails/welcome.html
+++ b/mockups/tadaify-mvp/emails/welcome.html
@@ -1,7 +1,7 @@
 <!--
 type: mockup
 project: tadaify
-title: Lifecycle email — welcome (post-onboarding, multipart preview)
+title: Lifecycle email — welcome (handle-claim celebration, multipart preview)
 created_at: 2026-05-02T14:15:00Z
 -->
 <!DOCTYPE html>
@@ -165,7 +165,7 @@ created_at: 2026-05-02T14:15:00Z
   </header>
 
   <p class="page-intro">
-    Sent after onboarding completion (Slice C) — first time the user reaches a published page. <strong>No token, not auth.</strong> This is the one transactional surface where a clickable link is OK because the destination is the user's own page (not a credential / auth flow). Larger wordmark + softer copy reflect the celebratory tone. One soft trust line ("price locked for life") is allowed here; auth emails carry none. Below: rendered in a light email client; plain-text fallback (multipart/alternative) at the bottom.
+    Sent right after handle claim (post-OTP verification, before / regardless of onboarding completion) per <strong>DEC-332 = D</strong>. The email celebrates that <code>@handle</code> is now permanently the user's; it does NOT claim the page is live (page becomes live only after explicit Publish action — see DEC-332 = D semantics). Skip-the-onboarding users still receive this email; they own the handle either way. <strong>No token, not auth.</strong> No clickable links to a "live page" because the page is reserved-not-published; the only CTA is "Set up your page" deep-linking into the dashboard. One soft trust line ("price locked for life") is allowed; auth emails carry none. Below: rendered in a light email client; plain-text fallback (multipart/alternative) at the bottom.
   </p>
 
   <div class="pair-grid">
@@ -180,7 +180,7 @@ created_at: 2026-05-02T14:15:00Z
         <div class="inbucket-headers">
           <span class="k">From:</span><span class="v"><strong>tadaify</strong> &lt;noreply@tadaify.com&gt;</span>
           <span class="k">To:</span><span class="v">waserek@local.test</span>
-          <span class="k">Subject:</span><span class="v"><strong>Welcome to tadaify, @waserek!</strong></span>
+          <span class="k">Subject:</span><span class="v"><strong>@waserek is yours — welcome to tadaify</strong></span>
           <span class="k">Date:</span><span class="v">2026-05-02 12:34 UTC</span>
         </div>
         <div class="email-canvas">
@@ -189,21 +189,26 @@ created_at: 2026-05-02T14:15:00Z
               <span class="wordmark"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span></span>
             </div>
             <div class="email-body">
-              <h1 class="greeting">Welcome, @waserek 🎉</h1>
-              <p class="sub">your page is live at <span class="wordmark" style="font-size:15px;"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span><span class="wm-ify">.com/waserek</span></span>.</p>
+              <h1 class="greeting">@waserek is yours 🎉</h1>
+              <p class="sub">welcome to <span class="wordmark" style="font-size:15px;"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span><span class="wm-ify">.com</span></span> — we're holding <span class="wordmark" style="font-size:15px;"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span><span class="wm-ify">.com/waserek</span></span> for you, forever.</p>
 
               <div class="hero-card">
                 <div class="hero-rows">
                   <div class="row"><span class="label">Your handle</span><span class="value"><code>@waserek</code></span></div>
-                  <div class="row"><span class="label">Your page</span><span class="value"><code>https://tadaify.com/waserek</code></span></div>
+                  <div class="row"><span class="label">Reserved URL</span><span class="value"><code>https://tadaify.com/waserek</code></span></div>
+                  <div class="row"><span class="label">Status</span><span class="value"><code>not yet published</code></span></div>
                 </div>
-                <a class="cta-button" href="https://tadaify.com/waserek">View your page →</a>
+                <a class="cta-button" href="https://tadaify.com/app/setup">Set up your page →</a>
               </div>
+
+              <p style="margin: 0 0 18px 0; font-size: 14px; color: #4B5563; line-height: 1.6;">
+                Your page goes live the moment you publish your first block. Until then, visitors who hit your URL see a "coming soon" placeholder — no empty page, no awkward first impression. Take your time.
+              </p>
 
               <ul class="tips-list">
                 <li>
                   <span class="step-num">1</span>
-                  <span class="step-text"><strong>Add your first link block.</strong> Drop a YouTube video, an external shop link, or a contact form — whatever your audience needs first.</span>
+                  <span class="step-text"><strong>Add your first link block.</strong> Drop a YouTube video, an external shop link, or a contact form — whatever your audience needs first. The page publishes automatically the moment you save.</span>
                 </li>
                 <li>
                   <span class="step-num">2</span>
@@ -211,7 +216,7 @@ created_at: 2026-05-02T14:15:00Z
                 </li>
                 <li>
                   <span class="step-num">3</span>
-                  <span class="step-text"><strong>Share your URL anywhere.</strong> Drop <code style="font-family:'JetBrains Mono',ui-monospace,monospace;font-size:12px;background:#F3F4F6;padding:1px 5px;border-radius:4px;">tadaify.com/waserek</code> in your bio on Instagram, TikTok, X, YouTube, anywhere.</span>
+                  <span class="step-text"><strong>Share once you're ready.</strong> Drop <code style="font-family:'JetBrains Mono',ui-monospace,monospace;font-size:12px;background:#F3F4F6;padding:1px 5px;border-radius:4px;">tadaify.com/waserek</code> in your bio on Instagram, TikTok, X, YouTube, anywhere — but only after you've published at least one block.</span>
                 </li>
               </ul>
 
@@ -238,27 +243,36 @@ created_at: 2026-05-02T14:15:00Z
         <span>Content-Type: text/plain; charset=UTF-8</span>
         <span class="scheme-mark">plain</span>
       </div>
-<pre>Welcome, @waserek!
+<pre>@waserek is yours.
 
-Your page is live at tadaify.com/waserek.
+Welcome to tadaify.com - we're holding tadaify.com/waserek
+for you, forever.
 
-  Your handle: @waserek
-  Your page:   https://tadaify.com/waserek
+  Your handle:   @waserek
+  Reserved URL:  https://tadaify.com/waserek
+  Status:        not yet published
 
-View your page:
-https://tadaify.com/waserek
+Set up your page:
+https://tadaify.com/app/setup
 
-Three quick steps to make it yours:
+Your page goes live the moment you publish your first block.
+Until then, visitors who hit your URL see a "coming soon"
+placeholder - no empty page, no awkward first impression.
+Take your time.
+
+Three quick steps when you're ready:
 
   1. Add your first link block. Drop a YouTube video, an
      external shop link, or a contact form - whatever your
-     audience needs first.
+     audience needs first. The page publishes automatically
+     the moment you save.
 
   2. Pick a theme. Light, dark, or your own colors. Switch
      any time from Settings -> Appearance.
 
-  3. Share your URL anywhere. Drop tadaify.com/waserek in
-     your bio on Instagram, TikTok, X, YouTube, anywhere.
+  3. Share once you're ready. Drop tadaify.com/waserek in
+     your bio on Instagram, TikTok, X, YouTube, anywhere -
+     but only after you've published at least one block.
 
 Price locked for life - your plan never increases. Whatever
 tier you pick today is what you pay forever.


### PR DESCRIPTION
## Summary

Phase 2 email mockups for tadaify auth + lifecycle flow. 4 new templates + index.html update reflecting Phase 2 promotion from "coming — disabled" to "preview — clickable". Welcome email content reflects locked **DEC-332 = D** (handle reserved on OTP / page Publish-gated; welcome celebrates handle claim, not page liveness).

User explicitly accepted mockups in chat 2026-05-02 after iterative inline review per locked rule `feedback_mockup_iterate_in_tmp_before_pr.md` (no PR until user accepts).

## Business requirements implemented

- BR-Slice-B (OTP-only auth flow) — extended to cover Phase 2 templates (password reset, email change confirm) which all use token-only payload, no magic-link `{{ .ConfirmationURL }}`.
- New (implicit, will be formalized in `docs/BUSINESS_REQUIREMENTS.md` when production templates land in #150 IMPL): page lifecycle = handle reserved permanent on OTP / page live only after explicit Publish (first-block save). Welcome email reflects this.

## Technical requirements introduced or relied on

- TR-tadaify-002 (auth email templates contract — multipart MIME / token-only / local files / inline CSS only) from refined #150 issue body. All 4 new templates honor it. Production templates landing in #150 IMPL will codify TR-tadaify-002 in `docs/TECHNICAL_REQUIREMENTS.md`.
- Brand-lock DEC-WORDMARK-01 (zero separators) — 14+ wordmark renderings across 5 files, all canonical 3-span without separator. Audit grep zerowy.

## Acceptance criteria from issue

#150 §"Templates required" Phase 2 column — 4 templates listed:
- ✅ password-reset (token-only OTP for password reset)
- ✅ email-change-confirm (token-only OTP for new-email confirmation)
- ✅ identity-linked (informational, no token, OAuth identity link notification)
- ✅ welcome (lifecycle, no token, handle-claim celebration per DEC-332 = D)
- ✅ `mockups/tadaify-mvp/emails/index.html` updated — Phase 2 tiles promoted to preview-clickable

DEC-332 = D acceptance:
- ✅ Welcome email celebrates handle claim, not "page is live"
- ✅ "Status: not yet published" row visible in hero card
- ✅ CTA "Set up your page →" (NOT "View your page") deep-links to `/app/setup`
- ✅ New paragraph documents lifecycle: page goes live on first block save, visitors see "coming soon" placeholder until then

## Test plan

### Unit tests shipped in this PR

None — mockup-only PR. Static HTML.

### Playwright specs shipped in this PR

None — mockup-only PR. No browser-testable behavior introduced. Production templates IMPL (#150 in flight) will ship S1-S5 Playwright scenarios per refined #150 body.

### Manual verification

- Open `mockups/tadaify-mvp/emails/index.html` locally; confirm 4 Phase 2 tiles in "preview — clickable" section.
- Click each tile; confirm 4 mockups render: Inbucket frame + email body + plain-text fallback section + light-only single-column layout.
- Audit grep `grep -rn 'class="hyp"\|wm-hyphen\|<span[^>]*>-</span>' mockups/tadaify-mvp/emails/` — must return zero hits (DEC-WORDMARK-01).
- Side-by-side compare welcome.html vs Phase 1 otp-signup.html — confirm shared canonical pattern (Crimson Pro display, Inter body, hardcoded indigo/warm/dark hex, no `var(--*)` inside email body, multipart fallback).

## Mockup

📎 [Phase 2 email mockups index](https://github.com/graspsoftwarepw/tadaify-app/blob/main/mockups/tadaify-mvp/emails/index.html) — landing tile gallery for all 6 email templates (Phase 1 ready + Phase 2 preview).

Per `feedback_mockup_iterate_in_tmp_before_pr.md` (locked 2026-05-02): mockups iterated locally in `/tmp/tadaify-app-wt/email-mockups-phase2/` with user inline corrections, PR only opened on explicit user "ok / push" — this PR fulfills that contract.

## Rollback

`git revert <merge-sha>` — single merge commit covers all 4 new files + index.html update. Removes mockup files; no production impact (mockups only, not wired into Supabase yet — production templates ship via #150 IMPL).

## Context + background (for reviewer)

**Why now:** Phase 1 mockups merged via PR #156 (2026-05-02). User pushed for full coverage same day: *"od razu wygeneruj wszystkie pozostale maile i zasetpuj w supabase local zeby przychodzily w nowym formacie"*. This PR ships Phase 2 mockup half; production templates + config wiring + tests ship via #150 IMPL (currently paused; resumes after this mockup PR merges).

**DEC-332 = D background:** User raised concern after Phase 2 mockups generated: *"co jezeli user da skip onboardingu? Strona bedzie pusta. Czy na pewno chcemy auto publikowac strony?"*. 5-option brainstorm in chat; user picked D (handle reserved on OTP, page Publish-gated, welcome celebrates handle claim). Welcome.html mockup updated inline before push.

**Implementation implications (NOT in this PR; for #150 IMPL + Slice C):**
1. `pages.published_at` column (NULL until first block save) — Slice C migration territory
2. `tadaify.com/<handle>` route renders "coming soon" placeholder when `published_at IS NULL` — Slice C
3. Welcome email Supabase auth hook: fires on `auth.users` insert post-OTP-verify, NOT on onboarding completion — production template wiring in #150 IMPL
4. First-block-save handler: auto-set `published_at = now()` per Step 1 copy in welcome email

**What's NOT in this PR:**
- Production templates (`supabase/templates/auth/*.html`) — #150 IMPL territory, paused awaiting this PR
- `supabase/config.toml` `[auth.email.template.*]` wiring — #150 IMPL
- Coming-soon placeholder for empty pages — Slice C / `creator-public.html` mockup territory (separate refinement)
- BR-NNN / TR-NNN formal entries — land with #150 IMPL

**Codex-pairing notes:**
- Brand-lock DEC-WORDMARK-01 (PR #155) — verify wordmark canonical 3-span rendering; audit grep should return zero hits
- DEC-332 = D — verify welcome.html semantics: NO "page is live" copy, YES "Set up your page" CTA, YES "Status: not yet published" row, YES "coming soon" placeholder mention in tips
- TR-tadaify-002 §4 (no external resources) — verify all 4 templates use inline CSS only, no remote CDN images / fonts / scripts
- Phase 1 canonical pattern (PR #156, merged 2026-05-02) — Phase 2 templates mirror its structure
- Mockup-only contract — no automated tests, no production impact, no DB migration; pure HTML preview surface

## Closes / fixes

Partially advances #150 (extends scope from Phase 1 mockups to Phase 1 + Phase 2). #150 stays open until production templates + config wiring land via the IMPL PR.
