### PR TITLE
Add Playwright e2e for onboarding wizard — 5 scenarios (#165)

### DIFF
--- a/docs/BUSINESS_REQUIREMENTS.md
+++ b/docs/BUSINESS_REQUIREMENTS.md
@@ -18,5 +18,11 @@ The full functional specification lives in `docs/specs/functional-spec.md`. This
 | BR-AUTH-06 | Handle availability check (live, 300 ms debounce) during registration | Issue #129 | Implemented |
 | BR-AUTH-07 | Handle reservation (15 min) prevents race on landing → register flow | Issue #129 | Implemented |
 | BR-AUTH-08 | 3-strike OTP lockout protects against brute-force attempts | Issue #129 | Implemented |
+| BR-ONBOARDING-001 | Post-registration wizard: step 1/5 — platform picker (welcome) | Issue #136 | Implemented |
+| BR-ONBOARDING-002 | Post-registration wizard: step 2/5 — social handle entry | Issue #136 | Implemented |
+| BR-ONBOARDING-003 | Post-registration wizard: step 3/5 — profile setup (name + bio) | Issue #136 | Implemented |
+| BR-ONBOARDING-004 | Post-registration wizard: step 4/5 — template picker | Issue #136 | Implemented |
+| BR-ONBOARDING-005 | Post-registration wizard: step 5/5 — plan overview (read-only, DEC-311=A) | Issue #136 | Implemented |
+| BR-ONBOARDING-006 | Post-registration wizard: success / complete screen (DEC-332=D page-coming-soon semantics) | Issue #136 | Implemented |
 
 > Add BRs as features are implemented. Every PR must cite the BRs it implements in the commit body and changelog entry.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,8 @@
 All notable changes to tadaify are documented here.
 Format: date · description · BR/TR refs · PR link.
 
+- 2026-05-03 · test: onboarding wizard e2e spec — 5 scenarios (S1 happy path, S2 back-nav URL state, S3 name-required validator, S4 tier=free DEC-311=A, S5 DEC-332=D complete page semantics); covers BR-ONBOARDING-001..006; no DB changes; afterAll cleanup hook — Issue #165
+
 - 2026-05-02 · test infra: un-fixme S1-S5 register-cascade (Layer 1-7 fix: Mailpit API, debounce-aware selectors, per-test handle isolation, afterAll cleanup, method-selection step, OTP paste helper); fix critical-path strict-mode + POST handle/check — no new BR/TR (test-only, covers existing BUG-149-{1,2,3,4,6}) — Issue #163
 
 ---

--- a/e2e/onboarding-wizard.spec.ts
+++ b/e2e/onboarding-wizard.spec.ts
@@ -1,0 +1,295 @@
+/**
+ * Playwright test suite for onboarding wizard skeleton (#165 / #136).
+ *
+ * Covers: BR-Slice-C / BR-ONBOARDING-001..006 / DEC-310=B / DEC-311=A / DEC-332=D
+ *
+ * Prerequisites:
+ *   - `supabase start` (port-band 5435X) with env-setup reliability fix (#168)
+ *   - `.dev.vars` populated via `./bin/worktree-env-init.sh`
+ *   - `npm run dev` (App: http://localhost:5173)
+ *
+ * Layer 1: URL-state-machine traversal (no auth required — wizard is pre-auth)
+ * Layer 2: per-test handle isolation (t165s1–t165s5 prefixed handles)
+ * Layer 3: afterAll cleanup hook (DELETE handle_reservations where handle ilike t165%)
+ * Layer 4: debounce-aware waits where needed
+ *
+ * Run: npx playwright test e2e/onboarding-wizard.spec.ts
+ */
+
+import { test, expect } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const SUPABASE_URL = process.env.SUPABASE_URL ?? "http://127.0.0.1:54351";
+const SERVICE_ROLE_KEY =
+  process.env.SUPABASE_SERVICE_ROLE_KEY ??
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU";
+
+/** Handle prefix — all t165* rows cleaned up in afterAll */
+const HANDLE_PREFIX = "t165";
+
+// ---------------------------------------------------------------------------
+// Helpers — cleanup (Layer 3)
+// ---------------------------------------------------------------------------
+
+async function cleanupHandleReservations(prefix: string): Promise<void> {
+  try {
+    const res = await fetch(
+      `${SUPABASE_URL}/rest/v1/handle_reservations?handle=ilike.${encodeURIComponent(prefix + "*")}`,
+      {
+        method: "DELETE",
+        headers: {
+          apikey: SERVICE_ROLE_KEY,
+          Authorization: `Bearer ${SERVICE_ROLE_KEY}`,
+          "Content-Type": "application/json",
+          Prefer: "return=minimal",
+        },
+      }
+    );
+    if (!res.ok && res.status !== 404) {
+      console.warn(`[cleanup] handle_reservations cleanup returned ${res.status}`);
+    }
+  } catch (e) {
+    console.warn("[cleanup] handle_reservations cleanup failed:", e);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Global lifecycle
+// ---------------------------------------------------------------------------
+
+test.beforeAll(async () => {
+  // Pre-run cleanup: remove stale reservations from interrupted prior runs
+  await cleanupHandleReservations(HANDLE_PREFIX);
+});
+
+test.afterAll(async () => {
+  await cleanupHandleReservations(HANDLE_PREFIX);
+});
+
+// ---------------------------------------------------------------------------
+// S1 — Happy path full 5-step walkthrough → /onboarding/complete
+// Covers: BR-Slice-C / DEC-310=B / DEC-311=A / DEC-332=D
+// ---------------------------------------------------------------------------
+
+test("S1 — happy path: full 5-step walkthrough reaches complete page", async ({ page }) => {
+  // Covers: BR-Slice-C / DEC-310=B / DEC-311=A / DEC-332=D
+  const handle = `${HANDLE_PREFIX}s1`;
+
+  // Step 1 — Welcome (platform picker)
+  await page.goto(`/onboarding/welcome?handle=${handle}`);
+  await expect(page.locator("input[name='platform'][value='instagram']")).toBeVisible({
+    timeout: 10_000,
+  });
+
+  // Select at least one platform (instagram)
+  await page.locator("input[name='platform'][value='instagram']").check();
+  await expect(page.locator("input[name='platform'][value='instagram']")).toBeChecked();
+
+  // Continue → Step 2 (social handles)
+  await page.locator("button[name='intent'][value='continue']").click();
+  await expect(page).toHaveURL(/\/onboarding\/social/, { timeout: 8_000 });
+  expect(new URL(page.url()).searchParams.get("handle")).toBe(handle);
+  expect(new URL(page.url()).searchParams.get("platforms")).toContain("instagram");
+
+  // Step 2 — Social handles (enter instagram handle)
+  await page.locator("input#social_instagram").fill("testuser165");
+
+  // Continue → Step 3 (profile)
+  await page.locator("button[name='intent'][value='continue']").click();
+  await expect(page).toHaveURL(/\/onboarding\/profile/, { timeout: 8_000 });
+
+  // Step 3 — Profile (name + bio)
+  await page.locator("input#name").fill("Test User");
+  await page.locator("textarea#bio").fill("Test bio for S1");
+
+  // Continue → Step 4 (template)
+  await page.locator("button[type='submit']").click();
+  await expect(page).toHaveURL(/\/onboarding\/template/, { timeout: 8_000 });
+
+  // Step 4 — Template picker (chopin is default)
+  await expect(page.locator("input[name='tpl'][value='chopin']")).toBeVisible({ timeout: 5_000 });
+  // chopin is pre-selected as default; no extra click needed
+  // Continue → Step 5 (tier)
+  await page.locator("button[type='submit']").click();
+  await expect(page).toHaveURL(/\/onboarding\/tier/, { timeout: 8_000 });
+
+  // Step 5 — Tier (read-only, DEC-311=A)
+  await expect(page.locator("button[type='submit']")).toBeVisible({ timeout: 5_000 });
+  // "Start for free →" button
+  await page.locator("button[type='submit']").click();
+
+  // Complete page
+  await expect(page).toHaveURL(/\/onboarding\/complete/, { timeout: 8_000 });
+  // DEC-311=A: tier=free on complete
+  expect(new URL(page.url()).searchParams.get("tier")).toBe("free");
+  // DEC-332=D: welcome heading with handle
+  await expect(page.getByRole("heading", { name: new RegExp(`@${handle}`, "i") })).toBeVisible({
+    timeout: 5_000,
+  });
+  // DEC-332=D: page coming-soon semantics
+  await expect(page.getByText(/your page is being set up/i)).toBeVisible();
+  // Go to dashboard CTA visible (aria-label="Go to your dashboard")
+  await expect(page.getByRole("link", { name: /go to (your )?dashboard/i })).toBeVisible();
+});
+
+// ---------------------------------------------------------------------------
+// S2 — Back navigation preserves URL state across steps
+// Covers: BR-Slice-C / DEC-310=B
+// ---------------------------------------------------------------------------
+
+test("S2 — back navigation: URL state preserved across back/forward traversal", async ({
+  page,
+}) => {
+  // Covers: BR-Slice-C / DEC-310=B / DEC-311=A / DEC-332=D
+  const handle = `${HANDLE_PREFIX}s2`;
+
+  // Step 1 — Welcome: select instagram + youtube
+  await page.goto(`/onboarding/welcome?handle=${handle}`);
+  await page.locator("input[name='platform'][value='instagram']").check();
+  await page.locator("input[name='platform'][value='youtube']").check();
+  await page.locator("button[name='intent'][value='continue']").click();
+  await expect(page).toHaveURL(/\/onboarding\/social/, { timeout: 8_000 });
+
+  // Step 2 — Social: skip socials to reach step 3
+  await page.locator("button[name='intent'][value='skip']").click();
+  await expect(page).toHaveURL(/\/onboarding\/profile/, { timeout: 8_000 });
+
+  // Step 3 — Profile: fill name
+  await page.locator("input#name").fill("Back Test");
+  await page.locator("textarea#bio").fill("back nav bio");
+
+  // Navigate Back → Step 2
+  await page.getByRole("link", { name: /← back|back to social/i }).click();
+  await expect(page).toHaveURL(/\/onboarding\/social/, { timeout: 8_000 });
+
+  // URL must still carry handle from step 1
+  const socialUrl = new URL(page.url());
+  expect(socialUrl.searchParams.get("handle")).toBe(handle);
+
+  // Navigate Back again → Step 1
+  await page.getByRole("link", { name: /← back|back to platform/i }).click();
+  await expect(page).toHaveURL(/\/onboarding\/welcome/, { timeout: 8_000 });
+  expect(new URL(page.url()).searchParams.get("handle")).toBe(handle);
+
+  // Forward from step 1: re-select instagram + continue
+  await page.locator("input[name='platform'][value='instagram']").check();
+  await page.locator("button[name='intent'][value='continue']").click();
+  await expect(page).toHaveURL(/\/onboarding\/social/, { timeout: 8_000 });
+
+  // Skip socials again → profile
+  await page.locator("button[name='intent'][value='skip']").click();
+  await expect(page).toHaveURL(/\/onboarding\/profile/, { timeout: 8_000 });
+
+  // Profile fields should be empty (URL-state not pre-filled because we navigated away
+  // and back; form is blank on direct arrival without URL state)
+  // Fill name again and continue forward to complete the path
+  await page.locator("input#name").fill("Back Test");
+  await page.locator("button[type='submit']").click();
+  await expect(page).toHaveURL(/\/onboarding\/template/, { timeout: 8_000 });
+
+  // Verify handle is still in the URL (preserved through the traversal)
+  expect(new URL(page.url()).searchParams.get("handle")).toBe(handle);
+});
+
+// ---------------------------------------------------------------------------
+// S3 — Validator inline error: name required
+// Covers: BR-Slice-C / DEC-310=B
+// ---------------------------------------------------------------------------
+
+test("S3 — validator: empty name shows inline error, stays on profile page", async ({
+  page,
+}) => {
+  // Covers: BR-Slice-C / DEC-310=B / DEC-311=A / DEC-332=D
+  // Direct URL navigation — no prior steps needed; wizard is URL-state-machine
+  const handle = `${HANDLE_PREFIX}s3`;
+
+  await page.goto(`/onboarding/profile?handle=${handle}`);
+  await expect(page.locator("input#name")).toBeVisible({ timeout: 10_000 });
+
+  // Submit without filling name
+  await page.locator("button[type='submit']").click();
+
+  // Inline error must appear
+  await expect(page.locator("#name-error")).toBeVisible({ timeout: 5_000 });
+  await expect(page.locator("#name-error")).toContainText(/name is required/i);
+
+  // Must NOT have navigated away — still on /onboarding/profile
+  expect(page.url()).toMatch(/\/onboarding\/profile/);
+});
+
+// ---------------------------------------------------------------------------
+// S4 — Tier step is read-only / always free (DEC-311=A)
+// Covers: BR-Slice-C / DEC-311=A
+// ---------------------------------------------------------------------------
+
+test("S4 — tier step: tier=premium in URL is ignored, complete receives tier=free", async ({
+  page,
+}) => {
+  // Covers: BR-Slice-C / DEC-310=B / DEC-311=A / DEC-332=D
+  const handle = `${HANDLE_PREFIX}s4`;
+
+  // Arrive at tier step with ?tier=premium — DEC-311=A says loader ignores it
+  await page.goto(
+    `/onboarding/tier?handle=${handle}&name=S4User&tpl=chopin&tier=premium`
+  );
+
+  // Tier comparison should be visible (read-only, no selection UI)
+  await expect(page.getByText(/your starting plan/i)).toBeVisible({ timeout: 10_000 });
+
+  // Free tier must be highlighted
+  const freePlanCard = page.locator('[aria-label*="Free plan"]');
+  await expect(freePlanCard).toBeVisible({ timeout: 5_000 });
+
+  // "Start for free →" CTA — always free
+  const submitBtn = page.locator("button[type='submit']");
+  await expect(submitBtn).toBeVisible();
+  await expect(submitBtn).toContainText(/start for free/i);
+
+  await submitBtn.click();
+
+  // Complete page: tier MUST be "free" regardless of the ?tier=premium we passed in
+  await expect(page).toHaveURL(/\/onboarding\/complete/, { timeout: 8_000 });
+  const completeUrl = new URL(page.url());
+  expect(completeUrl.searchParams.get("tier")).toBe("free");
+  // Also confirm "premium" does NOT appear as tier in URL
+  expect(completeUrl.searchParams.get("tier")).not.toBe("premium");
+});
+
+// ---------------------------------------------------------------------------
+// S5 — Complete page renders DEC-332=D handle-claim semantics
+// Covers: BR-Slice-C / DEC-311=A / DEC-332=D
+// ---------------------------------------------------------------------------
+
+test("S5 — complete page: DEC-332=D semantics — welcome heading + page-setup copy visible", async ({
+  page,
+}) => {
+  // Covers: BR-Slice-C / DEC-310=B / DEC-311=A / DEC-332=D
+  const handle = `${HANDLE_PREFIX}s5`;
+
+  // Direct navigation to complete with tier=free (valid post-wizard state)
+  await page.goto(`/onboarding/complete?handle=${handle}&tier=free&tpl=chopin&name=S5User`);
+
+  // DEC-332=D: welcome heading includes @handle
+  await expect(
+    page.getByRole("heading", { name: new RegExp(`@${handle}`, "i") })
+  ).toBeVisible({ timeout: 10_000 });
+
+  // DEC-332=D: "page is being set up" copy — NOT auto-live
+  await expect(page.getByText(/your page is being set up/i)).toBeVisible();
+
+  // "Go to dashboard →" CTA (DEC-332=D: set up your page / dashboard CTA)
+  // aria-label="Go to your dashboard" — match either form
+  await expect(page.getByRole("link", { name: /go to (your )?dashboard/i })).toBeVisible();
+
+  // tadaify.com/<handle> URL display chip
+  await expect(
+    page.getByText(new RegExp(`tadaify\\.com/${handle}`, "i"))
+  ).toBeVisible();
+
+  // DEC-332=D: NO "View your page" CTA (page is NOT auto-live, Publish-gated)
+  await expect(page.getByRole("link", { name: /view your page/i })).not.toBeVisible();
+  await expect(page.getByRole("button", { name: /view your page/i })).not.toBeVisible();
+});

--- a/e2e/onboarding-wizard.spec.ts
+++ b/e2e/onboarding-wizard.spec.ts
@@ -23,9 +23,7 @@ import { test, expect } from "@playwright/test";
 // ---------------------------------------------------------------------------
 
 const SUPABASE_URL = process.env.SUPABASE_URL ?? "http://127.0.0.1:54351";
-const SERVICE_ROLE_KEY =
-  process.env.SUPABASE_SERVICE_ROLE_KEY ??
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU";
+const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? "";
 
 /** Handle prefix — all t165* rows cleaned up in afterAll */
 const HANDLE_PREFIX = "t165";
@@ -35,6 +33,13 @@ const HANDLE_PREFIX = "t165";
 // ---------------------------------------------------------------------------
 
 async function cleanupHandleReservations(prefix: string): Promise<void> {
+  if (!SERVICE_ROLE_KEY) {
+    console.warn(
+      "[cleanup] SUPABASE_SERVICE_ROLE_KEY not set — skipping handle_reservations cleanup. " +
+      "Set the env var via .dev.vars or export it before running tests."
+    );
+    return;
+  }
   try {
     const res = await fetch(
       `${SUPABASE_URL}/rest/v1/handle_reservations?handle=ilike.${encodeURIComponent(prefix + "*")}`,


### PR DESCRIPTION
## Feature report
http://localhost:4444/feature-reports/tadaify-app/PR-169/report.html

(Dashboard route lands in rollout PR 11. Until then, link may 404 — the per-feature HTML report exists at `.feature-reports/PR-169/report.html` in the local repo.)

---
<!-- feature-slug: onboarding-e2e-165 -->
<!-- mockup-waived: test-only PR no UI change -->

## Summary

- Adds `e2e/onboarding-wizard.spec.ts` with 5 active Playwright scenarios covering the full onboarding wizard URL state-machine (Steps 1–5 + complete screen), using the real local Supabase + Cloudflare Workers dev server — no auth required (wizard is pre-auth, URL-state-only).
- No `.fixme()` / `.skip()` calls — all 5 pass in 3 consecutive runs. afterAll cleanup deletes `t165*` handle_reservations rows.
- Env-blocker unblocked by #168 (`bin/worktree-env-init.sh`) — this is the deferred e2e work from DEC-334=B.

## Business requirements implemented

- BR-ONBOARDING-001: Step 1/5 platform picker — S1 happy path traverses welcome → selects platform → continues
- BR-ONBOARDING-002: Step 2/5 social handle entry — S1 fills social handle and continues
- BR-ONBOARDING-003: Step 3/5 profile setup — S1 fills name + bio; S3 verifies empty-name inline error
- BR-ONBOARDING-004: Step 4/5 template picker — S1 picks chopin template and continues
- BR-ONBOARDING-005: Step 5/5 plan overview (DEC-311=A read-only, always free) — S4 verifies tier=premium URL is ignored → tier=free on complete
- BR-ONBOARDING-006: Post-wizard complete screen DEC-332=D semantics — S5 verifies @handle heading + "Your page is being set up." copy; no "View your page" CTA

## Technical requirements introduced or relied on

- TR-tadaify-001 (Playwright stays local — NOT in CI): spec file added; runs locally via `npm run test:e2e`; no CI workflow change
- TR-004 (Supabase local Docker port-band 5435X): afterAll cleanup uses service role key to DELETE from handle_reservations
- TR-AUTH-01..06: wizard is pre-auth URL state-machine — no auth calls; no dependency on auth routes

## Acceptance criteria (from issue #165)

- [x] `e2e/onboarding-wizard.spec.ts` ships with 5 active `test()` calls (no `.fixme`, no `.skip`)
- [x] `npm run test:e2e e2e/onboarding-wizard.spec.ts` passes 5/5 in 3 consecutive runs (no flake)
- [x] PR body has DEC-325 enumeration of S1-S5 file path + test name list
- [x] `afterAll` cleanup hook prevents DB pollution between runs
- [x] Env-setup reliability fix landed (Layer 1 — via #168 `bin/worktree-env-init.sh`)

## Test plan

**Unit tests:** No new unit tests (test-only PR; wizard route logic is already covered by #136 unit tests).

**Playwright scenarios (e2e/onboarding-wizard.spec.ts — 5/5 pass, 3 consecutive runs):**
- S1 (`S1 — happy path: full 5-step walkthrough reaches complete page`): visits welcome, selects instagram, fills social handle, fills name + bio, picks chopin template, submits tier step, asserts /onboarding/complete with tier=free + @t165s1 heading + "Your page is being set up." copy
- S2 (`S2 — back navigation: URL state preserved across back/forward traversal`): walks to step 3, clicks ← Back twice to step 1, re-navigates forward, asserts handle persists in URL throughout
- S3 (`S3 — validator: empty name shows inline error, stays on profile page`): direct-visits /onboarding/profile, submits without filling name, asserts #name-error contains "Name is required." and URL stays on /onboarding/profile
- S4 (`S4 — tier step: tier=premium in URL is ignored, complete receives tier=free`): visits /onboarding/tier?tier=premium, asserts "Your starting plan" ribbon on Free card, submits, asserts complete URL has tier=free (not premium)
- S5 (`S5 — complete page: DEC-332=D semantics — welcome heading + page-setup copy visible`): direct-visits /onboarding/complete?handle=t165s5&tier=free, asserts @t165s5 heading, "Your page is being set up." copy, "Go to your dashboard" link, tadaify.com/t165s5 URL chip, no "View your page" link/button

**Edge cases tested:**
- DEC-311=A: tier param tampering (premium → always free) — S4
- DEC-332=D: no auto-live CTA — S5
- Validator inline error (required field) — S3
- Handle preserved through back navigation — S2

## Mockup

No UI change — test-only PR (Playwright spec + BR/changelog docs). Mockup waived: test-only PR no UI change.

## Rollback

`git revert a2bf075 b8fe4a6` — removes the spec file and BR/changelog docs additions. No DB migrations, no schema changes, no edge function deploys. Safe to revert at any time.

## Files changed

**Tests:**
- `e2e/onboarding-wizard.spec.ts` — 5 Playwright scenarios for onboarding wizard (S1–S5); afterAll cleanup; handles t165s1–t165s5

**Docs:**
- `docs/BUSINESS_REQUIREMENTS.md` — BR-ONBOARDING-001..006 added (routes shipped in #136; BRs now formally indexed)
- `docs/changelog.md` — entry for 2026-05-03

## Related

Fixes #165
Mentions: #136 (wizard routes shipped), #168 (env-init unblock), DEC-311=A, DEC-332=D, DEC-334=B

## Codex-pairing notes

- #168 (`bin/worktree-env-init.sh`) landed as env-blocker unblock — this PR consumes it.
- #136 shipped Phase 1 wizard routes + unit tests (no Playwright); this PR is the deferred e2e from DEC-334=B.
- All 5 scenarios are URL-state-machine only — no auth flow, no OTP, no Supabase INSERT. They test the client-side form → redirect chain entirely via React Router loaders/actions.
- DEC-311=A: tier step loader ignores the `?tier` param and action always emits `tier=free`. S4 verifies the tamper-proof constraint.
- DEC-332=D: complete page is "page coming soon" (not auto-live). S5 asserts the copy and absence of "View your page" CTA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
