### PR TITLE
fix(test): un-fixme S1-S6 register-cascade — Mailpit + debounce + TTL + OTP paste (#163)

### DIFF
--- a/e2e/register-cascade.spec.ts
+++ b/e2e/register-cascade.spec.ts
@@ -155,7 +155,7 @@ async function cleanupHandleReservations(prefix: string): Promise<void> {
 async function fillHandleAndContinue(
   page: Page,
   handle: string,
-  timeout = 5_000
+  timeout = 8_000
 ): Promise<void> {
   await page.locator("#handle-input").fill(handle);
   const continueBtn = page.getByRole("button", { name: /continue/i }).first();
@@ -166,7 +166,7 @@ async function fillHandleAndContinue(
 async function fillRegisterForm(page: Page, handle: string, email: string) {
   await page.goto("/register");
   // Step A: handle input (debounce-aware — Layer 1)
-  await fillHandleAndContinue(page, handle, 5_000);
+  await fillHandleAndContinue(page, handle, 8_000);
   // Step B: method selection — click "Continue with Email"
   await page.getByRole("button", { name: /continue with email/i }).click();
   // Step B-email: email input
@@ -396,7 +396,8 @@ test("S6 — handle reservation expires after short TTL, becomes available again
   await pageB.goto("/register");
   await pageB.locator("#handle-input").fill(handle);
   await pageB.waitForTimeout(1500); // debounce + some margin
-  await expect(pageB.getByText(/reserved|not available/i)).toBeVisible({ timeout: 5_000 });
+  // UI shows "This handle is already taken." — matches /reserved|taken|not available/i
+  await expect(pageB.getByText(/reserved|taken|not available/i)).toBeVisible({ timeout: 5_000 });
 
   // Wait past TTL
   await pageB.waitForTimeout((ttlSeconds + 2) * 1000);
@@ -406,8 +407,8 @@ test("S6 — handle reservation expires after short TTL, becomes available again
   await pageB.locator("#handle-input").fill(handle);
   await pageB.waitForTimeout(1500); // debounce
 
-  // After TTL expiry, the handle must be available (no reserved/not available text)
-  await expect(pageB.getByText(/reserved|not available/i)).not.toBeVisible({ timeout: 5_000 });
+  // After TTL expiry, the handle must be available (no reserved/taken/not available text)
+  await expect(pageB.getByText(/reserved|taken|not available/i)).not.toBeVisible({ timeout: 5_000 });
 
   // Context B should be able to proceed — Continue button becomes enabled
   const continueBtn = pageB.getByRole("button", { name: /continue/i }).first();

--- a/e2e/register-cascade.spec.ts
+++ b/e2e/register-cascade.spec.ts
@@ -10,7 +10,7 @@
  *   - Mailpit accessible at http://localhost:54354 (Supabase local SMTP catcher)
  *
  * S4 (Bug 5 — email template) is deferred to #150.
- * S6 requires HANDLE_RESERVATION_TTL_SECONDS<=30 (legitimate runtime gate).
+ * S6 requires HANDLE_RESERVATION_TTL_SECONDS<=30 (reads .dev.vars as fallback).
  *
  * Layer 1: debounce-aware button-enabled wait (300ms debounce on handle check)
  * Layer 2: per-test handle isolation (fixed handles + beforeAll/afterAll cleanup)
@@ -24,6 +24,26 @@
  */
 
 import { test, expect, Page, BrowserContext } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Helper — read a key from .dev.vars when process.env doesn't have it.
+// .dev.vars is loaded by the Workers runtime but NOT by the Playwright Node
+// process, so we parse it ourselves as a fallback.
+// ---------------------------------------------------------------------------
+
+function readDevVar(key: string): string | undefined {
+  if (process.env[key]) return process.env[key];
+  try {
+    const devVarsPath = resolve(__dirname, "..", ".dev.vars");
+    const content = readFileSync(devVarsPath, "utf-8");
+    const match = content.match(new RegExp(`^${key}=(.+)$`, "m"));
+    return match?.[1]?.trim();
+  } catch {
+    return undefined;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Constants — Supabase local (from .dev.vars / env)
@@ -362,15 +382,15 @@ test("S5 — handle reservation conflict: second session sees reserved error", a
 // S6 — Handle reservation expires after TTL (env-overridden short TTL)
 // Covers: BUG-149-6, ECN-149-10, ECN-149-12
 // Note: Requires HANDLE_RESERVATION_TTL_SECONDS<=30 at test time.
-//       This is a LEGITIMATE runtime gate — NOT a fixme.
-//       Run with: HANDLE_RESERVATION_TTL_SECONDS=10 npm run test:e2e
+//       Reads from process.env first, then falls back to .dev.vars.
+//       Set HANDLE_RESERVATION_TTL_SECONDS=10 in .dev.vars or shell env.
 // ---------------------------------------------------------------------------
 
 test("S6 — handle reservation expires after short TTL, becomes available again", async ({
   browser,
 }) => {
   // Covers: BUG-149-6 / ECN-149-10 / ECN-149-12
-  const ttlSeconds = parseInt(process.env.HANDLE_RESERVATION_TTL_SECONDS ?? "600", 10);
+  const ttlSeconds = parseInt(readDevVar("HANDLE_RESERVATION_TTL_SECONDS") ?? "600", 10);
   test.skip(
     ttlSeconds > 30,
     `HANDLE_RESERVATION_TTL_SECONDS=${ttlSeconds} — skipping S6 (would wait ${ttlSeconds}s); set to ≤30 to run`


### PR DESCRIPTION
## Summary

- Converts all `test.fixme(...)` calls in `e2e/register-cascade.spec.ts` to `test(...)` — S1-S5 now run and pass; S6 uses the legitimate `test.skip(ttlSeconds > 30)` runtime gate.
- Fixes the two Layer-specific bugs that kept S6 broken: (1) assertion regex mismatched actual UI copy, (2) `.dev.vars` needed `HANDLE_RESERVATION_TTL_SECONDS=10` so Workers runtime uses the short TTL under test.
- Increases `fillHandleAndContinue` debounce timeout from 5s → 8s for margin on consecutive runs.
- Unblocked by #168 (`bin/worktree-env-init.sh`).

## Business requirements implemented

No new BRs. This is a test-infrastructure fix covering existing requirements:
- BUG-149-{1,2,3,4,6} / ECN-149-{01,04,05,09,10,12} — already in the changelog 2026-05-02 (register-flow cascade fix).

## Technical requirements introduced or relied on

- TR-tadaify-001 — Playwright local-only test suite (pre-existing).
- No new TRs.

## Acceptance criteria from issue #163

- [x] S1 — happy path: signup sends OTP email (no stub, no magic link) → **passes**
- [x] S2 — hook URL port: signup succeeds (no hook-unavailable error) → **passes**
- [x] S3 — verify_jwt: hook invoked without 401 error → **passes**
- [x] S5 — handle reservation conflict: second session sees reserved error → **passes**
- [x] S6 — handle reservation expires after short TTL, becomes available again → **passes** (runtime-gated on TTL≤30; `HANDLE_RESERVATION_TTL_SECONDS=10` in `.dev.vars` activates it)
- [x] Zero `test.fixme()` in final spec state
- [x] 3 consecutive runs with no flakes confirmed

## Test plan

**Changed spec:** `e2e/register-cascade.spec.ts`

Run: `HANDLE_RESERVATION_TTL_SECONDS=10 npx playwright test e2e/register-cascade.spec.ts`

```
Running 5 tests using 1 worker

  ✓  1 [chromium] › e2e/register-cascade.spec.ts:226:1 › S1 — happy path: signup sends OTP email (no stub, no magic link) (2.4s)
  ✓  2 [chromium] › e2e/register-cascade.spec.ts:272:1 › S2 — hook URL port: signup succeeds (no hook-unavailable error) (1.3s)
  ✓  3 [chromium] › e2e/register-cascade.spec.ts:296:1 › S3 — verify_jwt: hook invoked without 401 error (1.1s)
  ✓  4 [chromium] › e2e/register-cascade.spec.ts:319:1 › S5 — handle reservation conflict: second session sees reserved error (2.5s)
  ✓  5 [chromium] › e2e/register-cascade.spec.ts:369:1 › S6 — handle reservation expires after short TTL, becomes available again (16.7s)

  5 passed (31.4s)
```

3 consecutive clean runs (31.7s / 27.4s / 26.2s) — no flakes.

Critical-path: 3/3 passed (9.0s). Unit tests: 285/285 passed (1.07s). Build: ✓ (616ms + 335ms).

**Root-cause fixes applied:**
1. S6 assertion regex `/reserved|not available/` → `/reserved|taken|not available/` — UI shows "This handle is already taken." (not "reserved"); `register.tsx` uses a single error string regardless of `reason`.
2. `.dev.vars` `HANDLE_RESERVATION_TTL_SECONDS` 600 → 10 — `@cloudflare/vite-plugin` reads `.dev.vars` directly, not `process.env`; shell-env override alone insufficient for Workers runtime.
3. `toBeEnabled` timeout 5 000 ms → 8 000 ms — buffer for 300ms debounce + async fetch on consecutive runs.

## Mockup

No UI change — mockup not required.

## Rollback

`git revert 473c6db` — test-only change; no migration, no schema change; production unaffected.

---

**Codex-pairing notes:**
- Env-unblock dependency: #168 (`bin/worktree-env-init.sh`) already merged → base commit abc18f9.
- `feedback_no_skip_only_spec_files.md` — zero `.fixme()` in final state; S6's `test.skip(ttl > 30)` is a legitimate runtime gate.
- `feedback_pr_body_test_enumeration.md` (DEC-325) — per-test names + actual output pasted above.
- `e2e/auth-email-templates.spec.ts` NOT touched — production-template dependency (#161), separate scope.
- `e2e/onboarding-wizard.spec.ts` NOT touched — different agent scope (#165).

Fixes #163
