### PR TITLE
fix: 4 bugs from 2026-05-05 verification (handle-taken / email templates / login 404 / post-onboarding flow) — issue tadaify-app#190

### DIFF
--- a/app/routes/api.auth.login-otp.test.ts
+++ b/app/routes/api.auth.login-otp.test.ts
@@ -3,6 +3,13 @@
  * Run: npx vitest run app/routes/api.auth.login-otp.test.ts
  * Story: F-REGISTER-001a — Codex review round-1 fix (F1)
  * Covers: BR-AUTH-05, TR-AUTH-01
+ *
+ * U3 (issue tadaify-app#190 Bug #2b, DEC-364=A):
+ *   login-otp looks up handle from profiles by email + passes via data.handle.
+ *   Fallback: data.handle=null when no profile found.
+ * U4 (issue tadaify-app#190 Bug #2c, DEC-364=A):
+ *   identity-linked dispatch passes handle from profiles via data.handle.
+ *   (Tested at source level — identity-linked is a Supabase Auth webhook.)
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
@@ -101,6 +108,7 @@ describe("api.auth.login-otp — Supabase OTP send", () => {
   };
 
   it("sends OTP with create_user: false (no new account creation)", async () => {
+    // Without service role key, no profiles lookup — data.handle will be absent
     const mockFetch = vi.fn().mockResolvedValue(
       new Response("{}", { status: 200 })
     );
@@ -108,20 +116,26 @@ describe("api.auth.login-otp — Supabase OTP send", () => {
 
     const res = await action({
       request: makeRequest({ email: "user@example.com" }),
-      context: makeContext(supabaseEnv),
+      context: makeContext(supabaseEnv), // no service role key — no profiles lookup
     });
     const data = (await res.json()) as { sent: boolean };
     expect(res.status).toBe(200);
     expect(data.sent).toBe(true);
 
     // Verify the Supabase call uses create_user: false
-    const [, fetchInit] = mockFetch.mock.calls[0] as [string, RequestInit];
+    // (find the /auth/v1/otp call specifically, not the profiles lookup)
+    const otpCalls = (mockFetch.mock.calls as Array<[string, RequestInit]>).filter(
+      ([url]) => url.includes("/auth/v1/otp")
+    );
+    expect(otpCalls.length).toBeGreaterThan(0);
+    const [, fetchInit] = otpCalls[0];
     const body = JSON.parse(fetchInit.body as string) as Record<string, unknown>;
     expect(body.create_user).toBe(false);
     expect(body.email).toBe("user@example.com");
-    // No handle or data payload in login-otp
-    expect(body.data).toBeUndefined();
+    // No handle field at top level
     expect(body.handle).toBeUndefined();
+    // Without service role key: no profiles lookup, so data.handle not set
+    expect(body.data).toBeUndefined();
   });
 
   it("returns 502 + 'server_error' on unexpected Supabase failure", async () => {
@@ -306,5 +320,120 @@ describe("api.auth.login-otp — rate-limit (BR-OTP-RATE-LIMIT-001)", () => {
       (call: unknown[]) => String(call[0]).includes("rpc/acquire_otp_slot")
     );
     expect(acquireCalls.length).toBeGreaterThan(0);
+  });
+});
+
+// ── U3 (issue tadaify-app#190 Bug #2b, DEC-364=A): login-otp handles lookup ──────────────────
+
+describe("api.auth.login-otp — U3: looks up handle from profiles by email (DEC-364=A)", () => {
+  const supabaseEnvWithSR = {
+    SUPABASE_URL: "http://supabase.test",
+    SUPABASE_ANON_KEY: "anon_key",
+    SUPABASE_SERVICE_ROLE_KEY: "service_role_key",
+  };
+
+  it("login-otp looks up handle from profiles by email + passes via data.handle", async () => {
+    // DEC-364=A: when service role key is present, login-otp:
+    //   1. acquireOtpSlot (rate-limit)
+    //   2. profiles lookup (NEW)
+    //   3. OTP send (with data.handle)
+    //   4. finalizeOtpSlot
+    const mockFetch = vi
+      .fn()
+      // 1st call: acquire_otp_slot RPC → allowed
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ allowed: true, reservation_id: "abc-123" }), { status: 200 })
+      )
+      // 2nd call: profiles lookup → returns handle
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([{ handle: "mycreator" }]), { status: 200 })
+      )
+      // 3rd call: OTP send → 200
+      .mockResolvedValueOnce(new Response("{}", { status: 200 }))
+      // 4th call: finalize_otp_slot → 200
+      .mockResolvedValueOnce(new Response(JSON.stringify({ finalized: true }), { status: 200 }));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const res = await action({
+      request: makeRequest({ email: "creator@test.com" }),
+      context: makeContext(supabaseEnvWithSR),
+    });
+    expect(res.status).toBe(200);
+
+    // Find the OTP send call and verify data.handle is set
+    const otpCalls = (mockFetch.mock.calls as Array<[string, RequestInit]>).filter(
+      ([url]) => url.includes("/auth/v1/otp")
+    );
+    expect(otpCalls.length).toBeGreaterThan(0);
+    const body = JSON.parse(otpCalls[0][1].body as string) as Record<string, unknown>;
+    expect(body.data).toBeDefined();
+    expect((body.data as Record<string, unknown>).handle).toBe("mycreator");
+  });
+
+  it("login-otp passes data.handle=null (omits data field) when no profile matches email", async () => {
+    // Fallback path: profiles returns empty array — OTP send must NOT fail,
+    // data field is omitted (template shows "@creator" fallback).
+    const mockFetch = vi
+      .fn()
+      // 1st call: acquire_otp_slot RPC → allowed
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ allowed: true, reservation_id: "def-456" }), { status: 200 })
+      )
+      // 2nd call: profiles lookup → empty (no match)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([]), { status: 200 })
+      )
+      // 3rd call: OTP send → 200
+      .mockResolvedValueOnce(new Response("{}", { status: 200 }))
+      // 4th call: finalize → 200
+      .mockResolvedValueOnce(new Response(JSON.stringify({ finalized: true }), { status: 200 }));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const res = await action({
+      request: makeRequest({ email: "unknown@example.com" }),
+      context: makeContext(supabaseEnvWithSR),
+    });
+    // Must still succeed (OTP sent) — empty profiles is non-fatal
+    expect(res.status).toBe(200);
+
+    const otpCalls = (mockFetch.mock.calls as Array<[string, RequestInit]>).filter(
+      ([url]) => url.includes("/auth/v1/otp")
+    );
+    expect(otpCalls.length).toBeGreaterThan(0);
+    const body = JSON.parse(otpCalls[0][1].body as string) as Record<string, unknown>;
+    // No handle found → data field should be absent (omitted) for template fallback
+    expect(body.data).toBeUndefined();
+  });
+});
+
+// ── U4 (issue tadaify-app#190 Bug #2c, DEC-364=A): identity-linked source-level check ─────────
+// identity-linked is triggered by Supabase Auth internally when OAuth auto-links.
+// The template fix ({{ if .Data.handle }}@{{ .Data.handle }}{{ else }}@creator{{ end }})
+// is in supabase/templates/auth/identity-linked.html. Since there is no application-layer
+// caller in React Router routes, U4 verifies the template source and the profiles
+// lookup pattern is present in the broader codebase.
+
+describe("api.auth.login-otp — U4: identity-linked template uses @handle fallback (DEC-364=A)", () => {
+  it("identity-linked.html template uses .Data.handle with fallback to @creator", async () => {
+    const { readFileSync } = await import("fs");
+    const { fileURLToPath } = await import("url");
+    const templateSrc = readFileSync(
+      fileURLToPath(new URL("../../supabase/templates/auth/identity-linked.html", import.meta.url)),
+      "utf8"
+    );
+    // DEC-364=A: template must use .Data.handle not .Email
+    expect(templateSrc).toContain(".Data.handle");
+    expect(templateSrc).not.toMatch(/@{{ \.Email }}/);
+  });
+
+  it("identity-linked.html template has @creator fallback when handle absent", async () => {
+    const { readFileSync } = await import("fs");
+    const { fileURLToPath } = await import("url");
+    const templateSrc = readFileSync(
+      fileURLToPath(new URL("../../supabase/templates/auth/identity-linked.html", import.meta.url)),
+      "utf8"
+    );
+    // Template must have a fallback so emails don't show blank @
+    expect(templateSrc).toMatch(/@creator/);
   });
 });

--- a/app/routes/api.auth.login-otp.ts
+++ b/app/routes/api.auth.login-otp.ts
@@ -89,9 +89,39 @@ export async function action({ request, context }: Route.ActionArgs) {
     console.warn("[api.auth.login-otp] SUPABASE_SERVICE_ROLE_KEY not set — skipping rate-limit check");
   }
 
+  // ── Handle lookup for email template personalisation (DEC-364=A) ───────────
+  // Look up the user's handle from the profiles table so the OTP email can
+  // greet them as "@handle" rather than "@email" (Bug #2b).
+  // Requires SUPABASE_SERVICE_ROLE_KEY to bypass RLS.
+  // Falls back to null on any error — template falls back to "@creator".
+
+  let lookedUpHandle: string | null = null;
+
+  if (supabaseServiceRoleKey) {
+    try {
+      const profilesRes = await fetch(
+        `${supabaseUrl}/rest/v1/profiles?email=eq.${encodeURIComponent(rawEmail)}&select=handle&limit=1`,
+        {
+          headers: {
+            apikey: supabaseServiceRoleKey,
+            Authorization: `Bearer ${supabaseServiceRoleKey}`,
+            "Content-Type": "application/json",
+          },
+        }
+      );
+      if (profilesRes.ok) {
+        const rows = (await profilesRes.json()) as Array<{ handle: string }>;
+        lookedUpHandle = rows[0]?.handle ?? null;
+      }
+    } catch {
+      // Non-fatal — template fallback "@creator" will be shown
+    }
+  }
+
   // ── Supabase OTP send ────────────────────────────────────────────────────
 
   // Call Supabase Auth REST API with create_user: false — login only, no new account.
+  // Pass data.handle so the email template can personalise the greeting (DEC-364=A).
   const otpRes = await fetch(`${supabaseUrl}/auth/v1/otp`, {
     method: "POST",
     headers: {
@@ -101,6 +131,7 @@ export async function action({ request, context }: Route.ActionArgs) {
     body: JSON.stringify({
       email: rawEmail,
       create_user: false,
+      ...(lookedUpHandle !== null ? { data: { handle: lookedUpHandle } } : {}),
     }),
   });
 

--- a/app/routes/api.auth.signup.test.ts
+++ b/app/routes/api.auth.signup.test.ts
@@ -198,6 +198,57 @@ describe("api.auth.signup — Supabase OTP send", () => {
   });
 });
 
+// ── U2 (issue tadaify-app#190 Bug #2a): signup-otp passes data.handle to Supabase ─────────────
+// DEC-364=A: email template greeted @email — fix is to pass handle in data payload
+
+describe("api.auth.signup — U2: signup-otp passes data.handle from request body (DEC-364=A)", () => {
+  const supabaseEnv = {
+    SUPABASE_URL: "http://supabase.test",
+    SUPABASE_ANON_KEY: "anon_key",
+  };
+
+  it("signup-otp passes data.handle from request body to Supabase signInWithOtp call", async () => {
+    // DEC-364=A: the OTP send body must include data.handle so the email template
+    // can greet "@alex" instead of "@user@example.com".
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({}), { status: 200 })
+    );
+    vi.stubGlobal("fetch", mockFetch);
+
+    await action({
+      request: makeRequest({ email: "user@example.com", handle: "alex", tos_version: "v1" }),
+      context: makeContext(supabaseEnv),
+    });
+
+    // Find the OTP send call (to /auth/v1/otp)
+    const otpCalls = (mockFetch.mock.calls as Array<[string, RequestInit]>).filter(
+      ([url]) => url.includes("/auth/v1/otp")
+    );
+    expect(otpCalls.length).toBeGreaterThan(0);
+    const [, fetchInit] = otpCalls[0];
+    const body = JSON.parse(fetchInit.body as string) as Record<string, unknown>;
+    // Must include data.handle === "alex"
+    expect(body.data).toBeDefined();
+    expect((body.data as Record<string, unknown>).handle).toBe("alex");
+  });
+
+  it("signup-otp data.handle matches the handle from request body exactly", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", mockFetch);
+
+    await action({
+      request: makeRequest({ email: "creator@test.com", handle: "mycreator", tos_version: "v1" }),
+      context: makeContext(supabaseEnv),
+    });
+
+    const otpCalls = (mockFetch.mock.calls as Array<[string, RequestInit]>).filter(
+      ([url]) => url.includes("/auth/v1/otp")
+    );
+    const body = JSON.parse(otpCalls[0][1].body as string) as Record<string, unknown>;
+    expect((body.data as Record<string, unknown>).handle).toBe("mycreator");
+  });
+});
+
 // ── Rate-limit (BR-OTP-RATE-LIMIT-001 / DEC-342) — U4 ───────────────────────
 
 describe("api.auth.signup — rate-limit (BR-OTP-RATE-LIMIT-001)", () => {

--- a/app/routes/login.test.tsx
+++ b/app/routes/login.test.tsx
@@ -4,11 +4,14 @@
  * Verifies that the /login route source contains exactly 3 SSO provider references
  * (Google, X, Email) and zero Apple references after cleanup (issue tadaify-app#183).
  *
+ * U5 (issue tadaify-app#190 Bug #3, DEC-307 canonical route fix):
+ *   successful OTP verify navigates to /app, NOT /dashboard (which 404s).
+ *
  * These are static-analysis tests against the route source. We use fs.readFileSync
  * so they run under vitest node environment without jsdom/React rendering.
  *
- * Story: F-REGISTER-001a cleanup (issue tadaify-app#183)
- * Covers: U1 per issue spec
+ * Story: F-REGISTER-001a cleanup (issue tadaify-app#183, tadaify-app#190)
+ * Covers: U1, U5 per issue spec
  */
 
 import { describe, it, expect } from "vitest";
@@ -70,5 +73,29 @@ describe("login.tsx — no user-facing Apple copy (DEC-346=C)", () => {
 
   it("apple key is absent from the coming-soon messages map", () => {
     expect(loginSrc).not.toMatch(/apple:\s*["']Apple sign-in/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// U5 (issue tadaify-app#190 Bug #3): successful OTP verify navigates to /app
+// DEC-307: returning user → dashboard — canonical route is /app, not /dashboard
+// ---------------------------------------------------------------------------
+
+describe("login.tsx — U5: successful OTP verify navigates to /app (Bug #3 DEC-307)", () => {
+  it("source contains navigate('/app') for OTP verify success", () => {
+    // After OTP verify success, navigate must go to /app (not /dashboard which 404s)
+    expect(loginSrc).toContain('navigate("/app")');
+  });
+
+  it("source does NOT contain navigate('/dashboard') (regression-lock — /dashboard 404s)", () => {
+    // Regression-lock: /dashboard route does not exist; /app is the canonical dashboard.
+    expect(loginSrc).not.toContain('navigate("/dashboard")');
+  });
+
+  it("DEC-307 comment still present but references /app as canonical route", () => {
+    // The DEC-307 comment may reference 'dashboard' semantically — that's OK.
+    // The literal navigate call must be /app.
+    const navigateDashboard = /navigate\(["']\/dashboard["']\)/.test(loginSrc);
+    expect(navigateDashboard).toBe(false);
   });
 });

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -183,8 +183,8 @@ export default function LoginPage() {
         dispatch({ type: "OTP_FAILURE", now });
         return;
       }
-      // DEC-307: returning user → dashboard
-      navigate("/dashboard");
+      // DEC-307: returning user → dashboard (canonical route is /app, not /dashboard)
+      navigate("/app");
     } catch {
       dispatch({ type: "SET_ERROR", error: "Network error. Please try again." });
     }

--- a/app/routes/onboarding.complete.test.ts
+++ b/app/routes/onboarding.complete.test.ts
@@ -1,102 +1,106 @@
 /**
- * Unit tests for onboarding.complete.tsx — Post-wizard success screen
+ * Unit tests for onboarding.complete.tsx — DEC-366=A SSR redirect handler
  *
  * Story: F-ONBOARDING-001a
- * Covers: BR-ONBOARDING-006 / DEC-311=A / DEC-332=D
+ * Covers: BR-ONBOARDING-006 / DEC-311=A / DEC-332=D / DEC-366=A
  *
- * U1: loader reads handle and tier from URL
- * U2: loader enforces tier=free regardless of URL value (DEC-311=A)
- * U3: loader reads all accumulated state fields
- * U4: loader handles empty/missing params gracefully
+ * DEC-366=A (2026-05-05): loader + action both redirect to /app.
+ * No UI render — the intermediate "tada! 🎉" celebration screen is removed.
+ * Tests updated per issue tadaify-app#190 (Bug #4 / U8 entries).
+ *
+ * U8a: loader returns 302 redirect to /app, not page data
+ * U8b: action returns 302 redirect to /app
+ *
+ * Legacy U1-U4 tests (loader returning handle/tier fields) are replaced —
+ * the loader no longer reads URL params, it just redirects.
  */
 
 import { describe, it, expect } from "vitest";
-import { loader } from "./onboarding.complete";
+import { loader, action } from "./onboarding.complete";
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
-function makeRequest(path: string): Request {
+function makeGetRequest(path: string): Request {
   return new Request(`http://localhost${path}`);
 }
 
-// ── U1: loader reads handle and tier ──────────────────────────────────────────
+function makePostRequest(path: string): Request {
+  return new Request(`http://localhost${path}`, { method: "POST", body: new FormData() });
+}
 
-describe("onboarding.complete — U1: loader handle + tier", () => {
-  it("reads handle from URL", async () => {
-    const req = makeRequest("/onboarding/complete?handle=alice&tier=free");
+// ── U8a: loader returns 302 redirect, no page data (DEC-366=A) ───────────────
+// Covers Bug #4 / U8 from issue tadaify-app#190
+
+describe("onboarding.complete — U8a: loader returns 302 redirect (DEC-366=A)", () => {
+  it("loader returns 302 redirect to /app, NOT page data", async () => {
+    const req = makeGetRequest("/onboarding/complete?handle=alice&tier=free");
     const result = await loader({ request: req, params: {}, context: {} } as never);
-    expect(result.handle).toBe("alice");
+    expect(result).toBeInstanceOf(Response);
+    const res = result as Response;
+    expect(res.status).toBe(302);
+    const location = res.headers.get("Location");
+    expect(location).toBe("/app");
   });
 
-  it("reads tier=free from URL", async () => {
-    const req = makeRequest("/onboarding/complete?handle=alice&tier=free");
+  it("loader redirects to /app even with no query params", async () => {
+    const req = makeGetRequest("/onboarding/complete");
     const result = await loader({ request: req, params: {}, context: {} } as never);
-    expect(result.tier).toBe("free");
-  });
-});
-
-// ── U2: loader enforces free tier ────────────────────────────────────────────
-
-describe("onboarding.complete — U2: tier always free (DEC-311=A)", () => {
-  it("returns tier=free even when URL has tier=premium", async () => {
-    const req = makeRequest("/onboarding/complete?handle=alice&tier=premium");
-    const result = await loader({ request: req, params: {}, context: {} } as never);
-    // DEC-311=A: loader normalises any tier value to "free"
-    expect(result.tier).toBe("free");
+    const res = result as Response;
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/app");
   });
 
-  it("returns tier=free when tier param absent", async () => {
-    const req = makeRequest("/onboarding/complete?handle=alice");
+  it("loader redirects to /app regardless of tier param (DEC-311=A no longer applies — DEC-366=A supersedes)", async () => {
+    const req = makeGetRequest("/onboarding/complete?handle=alice&tier=premium");
     const result = await loader({ request: req, params: {}, context: {} } as never);
-    expect(result.tier).toBe("free");
+    const res = result as Response;
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/app");
   });
 
-  it("returns tier=free for tier=creator", async () => {
-    const req = makeRequest("/onboarding/complete?handle=alice&tier=creator");
+  it("loader does NOT return handle, tier, or any page data", async () => {
+    const req = makeGetRequest("/onboarding/complete?handle=alice&tier=free&name=Alice");
     const result = await loader({ request: req, params: {}, context: {} } as never);
-    expect(result.tier).toBe("free");
-  });
-});
-
-// ── U3: loader reads accumulated state ───────────────────────────────────────
-
-describe("onboarding.complete — U3: accumulated state", () => {
-  it("reads all accumulated URL params", async () => {
-    const socials = encodeURIComponent('{"instagram":"alice"}');
-    const url =
-      `/onboarding/complete?handle=alice&tier=free&tpl=neon&name=Alice+Smith` +
-      `&bio=Hello&av=&platforms=instagram&socials=${socials}`;
-    const req = makeRequest(url);
-    const result = await loader({ request: req, params: {}, context: {} } as never);
-    expect(result.handle).toBe("alice");
-    expect(result.tier).toBe("free");
-    expect(result.tpl).toBe("neon");
-    expect(result.name).toBe("Alice Smith");
-    expect(result.bio).toBe("Hello");
-    expect(result.platforms).toBe("instagram");
+    // result must be a Response (redirect), not a plain object with page data
+    expect(result).toBeInstanceOf(Response);
+    // It must NOT be a plain object with data fields
+    const maybeObj = result as Record<string, unknown>;
+    expect(maybeObj.handle).toBeUndefined();
+    expect(maybeObj.tier).toBeUndefined();
+    expect(maybeObj.name).toBeUndefined();
   });
 });
 
-// ── U4: loader handles empty/missing params ───────────────────────────────────
+// ── U8b: action returns 302 redirect to /app (DEC-366=A) ─────────────────────
+// Covers Bug #4 / U8 from issue tadaify-app#190
 
-describe("onboarding.complete — U4: empty/missing params", () => {
-  it("returns empty strings for all missing params", async () => {
-    const req = makeRequest("/onboarding/complete");
-    const result = await loader({ request: req, params: {}, context: {} } as never);
-    expect(result.handle).toBe("");
-    expect(result.tier).toBe("free"); // DEC-311=A default
-    expect(result.tpl).toBe("");
-    expect(result.name).toBe("");
-    expect(result.bio).toBe("");
+describe("onboarding.complete — U8b: action returns 302 redirect (DEC-366=A)", () => {
+  it("action redirects to /app on success, no UI render", async () => {
+    const req = makePostRequest("/onboarding/complete");
+    const result = await action({ request: req, params: {}, context: {} } as never);
+    expect(result).toBeInstanceOf(Response);
+    const res = result as Response;
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/app");
   });
 
-  it("returns handle=test-136 from URL param (Playwright S5 pattern)", async () => {
-    const req = makeRequest(
-      "/onboarding/complete?handle=test-136&tier=free&tpl=chopin&name=Test+User"
-    );
-    const result = await loader({ request: req, params: {}, context: {} } as never);
-    expect(result.handle).toBe("test-136");
-    expect(result.tier).toBe("free");
-    expect(result.name).toBe("Test User");
+  it("action does NOT redirect to /onboarding/complete or any other path", async () => {
+    const req = makePostRequest("/onboarding/complete");
+    const result = await action({ request: req, params: {}, context: {} } as never);
+    const res = result as Response;
+    const location = res.headers.get("Location") ?? "";
+    expect(location).toBe("/app");
+    expect(location).not.toContain("/onboarding/complete");
+    expect(location).not.toContain("/dashboard");
+  });
+});
+
+// ── Regression-lock: celebration screen copy absent from source ───────────────
+
+describe("onboarding.complete — regression-lock: celebration UI removed (DEC-366=A)", () => {
+  it("source has no default export component (no UI render)", async () => {
+    const mod = await import("./onboarding.complete");
+    // DEC-366=A: no default export — route is pure SSR redirect handler
+    expect((mod as Record<string, unknown>).default).toBeUndefined();
   });
 });

--- a/app/routes/onboarding.complete.tsx
+++ b/app/routes/onboarding.complete.tsx
@@ -1,264 +1,42 @@
 /**
- * /onboarding/complete — Post-wizard success screen (F-ONBOARDING-001a)
+ * /onboarding/complete — SSR redirect to /app (DEC-366=A)
  *
- * Visual contract: mockups/tadaify-mvp/onboarding-complete.html (merged PR #135)
+ * DEC-366=A (2026-05-05): skip the intermediate "tada! 🎉" celebration screen;
+ * both loader and action redirect immediately to /app. The celebration will be
+ * surfaced as a first-publish overlay once the page editor ships.
  *
- * URL state:
- *   loader reads → ?handle=&tier=free&tpl=&name=&bio=&av=&platforms=&socials=
+ * Historical UI render (DEC-332=D "page coming soon" semantics) is removed.
+ * If an inbound GET hits this route (deep-link, back-nav), the loader's 302
+ * redirect is safe — user lands on /app rather than a stale/blank celebration.
  *
- * DEC trail:
- *   DEC-311=A  tier is always "free" on arrival; any other value is invalid
- *   DEC-332=D  "page coming soon" semantics: show success + "your page is being set up"
+ * DB finalization note: onboarding_completed_at is set by a Supabase Auth Hook
+ * on the before-user-created / post-sign-in chain, not here. No DB work is
+ * needed in this route handler.
  *
  * Covers: BR-ONBOARDING-006 (post-wizard success)
+ *
+ * DEC trail:
+ *   DEC-311=A  tier is always "free" — this route no longer reads tier
+ *   DEC-332=D  "page coming soon" UI — REMOVED per DEC-366=A
+ *   DEC-366=A  skip intermediate screen; redirect to /app directly
  */
 
-import { Link, redirect } from "react-router";
+import { redirect } from "react-router";
 import type { Route } from "./+types/onboarding.complete";
-import { MotionLogo } from "~/components/landing/MotionLogo";
 
-// ─── Action ────────────────────────────────────────────────────────────────────
-// POST from the "Go to dashboard →" button redirects to /app (#171 spec).
+// ─── Loader ────────────────────────────────────────────────────────────────────
+// Any GET to /onboarding/complete (back-nav, deep-link) → 302 /app
 
-export async function action({ request }: Route.ActionArgs) {
+export async function loader(_: Route.LoaderArgs) {
   return redirect("/app");
 }
 
-// ─── Loader ────────────────────────────────────────────────────────────────────
+// ─── Action ────────────────────────────────────────────────────────────────────
+// POST from any lingering form submission → 302 /app
 
-export async function loader({ request }: Route.LoaderArgs) {
-  const url = new URL(request.url);
-  const handle = url.searchParams.get("handle") ?? "";
-  const tier = url.searchParams.get("tier") ?? "free";
-  const tpl = url.searchParams.get("tpl") ?? "";
-  const name = url.searchParams.get("name") ?? "";
-  const bio = url.searchParams.get("bio") ?? "";
-  const av = url.searchParams.get("av") ?? "";
-  const platforms = url.searchParams.get("platforms") ?? "";
-  const socials = url.searchParams.get("socials") ?? "";
-
-  // DEC-311=A: only "free" is valid in this step
-  const effectiveTier = tier === "free" ? "free" : "free";
-
-  return { handle, tier: effectiveTier, tpl, name, bio, av, platforms, socials };
+export async function action(_: Route.ActionArgs) {
+  return redirect("/app");
 }
 
-// ─── Component ─────────────────────────────────────────────────────────────────
-
-export default function CompletePage({ loaderData }: Route.ComponentProps) {
-  const { handle, tier, tpl, name } = loaderData;
-
-  const displayName = name || (handle ? `@${handle}` : "there");
-
-  return (
-    <div
-      style={{
-        minHeight: "calc(100vh - 54px)",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        padding: "clamp(24px, 5vw, 64px)",
-        textAlign: "center",
-      }}
-    >
-      <div style={{ maxWidth: 560, width: "100%" }}>
-        {/* Logo */}
-        <div
-          style={{
-            display: "flex",
-            justifyContent: "center",
-            marginBottom: 20,
-          }}
-        >
-          <MotionLogo size="nav" />
-        </div>
-
-        {/* tada! celebration */}
-        <div
-          className="font-display font-semibold"
-          style={{
-            fontSize: "clamp(44px, 8vw, 72px)",
-            lineHeight: 1,
-            marginBottom: 16,
-          }}
-          aria-hidden
-        >
-          tada! 🎉
-        </div>
-
-        {/* Welcome heading */}
-        <h1
-          className="font-display"
-          style={{
-            fontSize: "clamp(24px, 4vw, 36px)",
-            lineHeight: 1.15,
-            marginBottom: 12,
-          }}
-        >
-          Welcome,{" "}
-          <span style={{ color: "var(--brand-primary)" }}>
-            {handle ? `@${handle}` : displayName}
-          </span>
-          !
-        </h1>
-
-        {/* DEC-332=D: page coming soon semantics */}
-        <p
-          style={{
-            fontSize: 17,
-            color: "var(--fg-muted)",
-            lineHeight: 1.6,
-            marginBottom: 8,
-          }}
-        >
-          Your page is being set up.
-        </p>
-        <p
-          style={{
-            fontSize: 15,
-            color: "var(--fg-muted)",
-            lineHeight: 1.6,
-            marginBottom: 32,
-          }}
-        >
-          You'll be able to customise everything once the editor is live. We'll let you know
-          when it's ready.
-        </p>
-
-        {/* URL display */}
-        {handle && (
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              gap: 8,
-              padding: "12px 20px",
-              background: "var(--bg-muted)",
-              border: "1px solid var(--border)",
-              borderRadius: "var(--radius)",
-              marginBottom: 28,
-              fontSize: 15,
-              fontWeight: 600,
-            }}
-            aria-label={`Your page URL: tadaify.com/${handle}`}
-          >
-            <span style={{ color: "var(--fg-muted)" }}>tadaify.com/</span>
-            <span style={{ color: "var(--brand-primary)" }}>{handle}</span>
-            <button
-              type="button"
-              onClick={() => {
-                const url = `https://tadaify.com/${handle}`;
-                void navigator.clipboard?.writeText(url);
-              }}
-              style={{
-                marginLeft: 8,
-                padding: "4px 10px",
-                background: "var(--bg-elevated)",
-                border: "1px solid var(--border-strong)",
-                borderRadius: "var(--radius-sm)",
-                fontSize: 12,
-                cursor: "pointer",
-                color: "var(--fg-muted)",
-              }}
-              aria-label={`Copy URL tadaify.com/${handle}`}
-            >
-              Copy
-            </button>
-          </div>
-        )}
-
-        {/* Next steps */}
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            gap: 10,
-            alignItems: "stretch",
-          }}
-        >
-          <Link
-            to="/app"
-            style={{
-              display: "block",
-              padding: "14px 24px",
-              background: "var(--brand-primary)",
-              color: "#FFF",
-              textDecoration: "none",
-              borderRadius: "var(--radius)",
-              fontSize: 15,
-              fontWeight: 600,
-            }}
-            aria-label="Go to your dashboard"
-          >
-            Go to dashboard →
-          </Link>
-
-          <div
-            style={{
-              display: "flex",
-              gap: 10,
-            }}
-          >
-            <button
-              type="button"
-              onClick={() => {
-                const text = encodeURIComponent(
-                  `Just set up my page on @tadaify! Check it out: https://tadaify.com/${handle}`
-                );
-                window.open(`https://x.com/intent/tweet?text=${text}`, "_blank");
-              }}
-              style={{
-                flex: 1,
-                padding: "10px 16px",
-                background: "transparent",
-                border: "1px solid var(--border-strong)",
-                borderRadius: "var(--radius)",
-                fontSize: 13,
-                fontWeight: 500,
-                cursor: "pointer",
-                color: "var(--fg-muted)",
-              }}
-            >
-              𝕏 Tweet
-            </button>
-
-            <button
-              type="button"
-              onClick={() => {
-                const url = `https://tadaify.com/${handle}`;
-                void navigator.clipboard?.writeText(url);
-              }}
-              style={{
-                flex: 1,
-                padding: "10px 16px",
-                background: "transparent",
-                border: "1px solid var(--border-strong)",
-                borderRadius: "var(--radius)",
-                fontSize: 13,
-                fontWeight: 500,
-                cursor: "pointer",
-                color: "var(--fg-muted)",
-              }}
-            >
-              🔗 Copy URL
-            </button>
-          </div>
-        </div>
-
-        {/* Plan info */}
-        <p
-          style={{
-            marginTop: 24,
-            fontSize: 13,
-            color: "var(--fg-subtle)",
-            lineHeight: 1.5,
-          }}
-        >
-          You're on the <strong>Free</strong> plan. Upgrade anytime from Settings → Billing.
-          30-day money-back on any paid tier.
-        </p>
-      </div>
-    </div>
-  );
-}
+// No default export — this route renders nothing.
+// React Router requires at least a loader or action; both are defined above.

--- a/app/routes/onboarding.tier.test.ts
+++ b/app/routes/onboarding.tier.test.ts
@@ -73,10 +73,10 @@ describe("onboarding.tier — U1: loader", () => {
   });
 });
 
-// ── U2: action always free ────────────────────────────────────────────────────
+// ── U2: action redirects to /app (DEC-366=A — supersedes DEC-311=A intermediate) ─────────
 
-describe("onboarding.tier — U2: action always free (DEC-311=A)", () => {
-  it("redirects to /onboarding/complete with tier=free", async () => {
+describe("onboarding.tier — U2: action redirects to /app (DEC-366=A)", () => {
+  it("action returns 302 redirect to /app regardless of form data", async () => {
     const req = makeRequest("/onboarding/tier", "POST", {
       handle: "alice",
       platforms: "instagram",
@@ -91,58 +91,40 @@ describe("onboarding.tier — U2: action always free (DEC-311=A)", () => {
     const res = result as Response;
     expect(res.status).toBe(302);
     const loc = res.headers.get("Location") ?? "";
-    expect(loc).toMatch(/^\/onboarding\/complete/);
-    const u = new URL(`http://localhost${loc}`);
-    expect(u.searchParams.get("tier")).toBe("free");
+    // DEC-366=A: goes directly to /app, not /onboarding/complete
+    expect(loc).toBe("/app");
+    expect(loc).not.toContain("/onboarding/complete");
   });
 
-  it("always sets tier=free even if form would try to set premium", async () => {
-    // Even if someone manually submits tier=premium via form, action always sets free
+  it("action always redirects to /app even with empty form (DEC-366=A)", async () => {
     const fd = new FormData();
-    fd.append("handle", "alice");
-    fd.append("tpl", "chopin");
-    fd.append("platforms", "");
-    fd.append("socials", "");
-    fd.append("name", "Alice");
-    fd.append("bio", "");
-    fd.append("av", "");
-    // No "tier" field in form data since tier is not a form field in the component
     const req = new Request("http://localhost/onboarding/tier", { method: "POST", body: fd });
     const result = await action({ request: req, params: {}, context: {} } as never);
     const res = result as Response;
-    const u = new URL(`http://localhost${res.headers.get("Location") ?? ""}`);
-    expect(u.searchParams.get("tier")).toBe("free");
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/app");
   });
 });
 
-// ── U3: action carries all params ────────────────────────────────────────────
+// ── U3: loader still reads params (for back-link) ────────────────────────────
 
-describe("onboarding.tier — U3: action param propagation", () => {
-  it("carries all accumulated params to complete step", async () => {
-    const req = makeRequest("/onboarding/tier", "POST", {
-      handle: "bob",
-      platforms: "tiktok,youtube",
-      socials: '{"tiktok":"bobtok"}',
-      name: "Bob",
-      bio: "Video creator",
-      av: "",
-      tpl: "neon",
-    });
-    const result = await action({ request: req, params: {}, context: {} } as never);
-    const res = result as Response;
-    const u = new URL(`http://localhost${res.headers.get("Location") ?? ""}`);
-    expect(u.searchParams.get("handle")).toBe("bob");
-    expect(u.searchParams.get("platforms")).toBe("tiktok,youtube");
-    expect(u.searchParams.get("name")).toBe("Bob");
-    expect(u.searchParams.get("tpl")).toBe("neon");
-    expect(u.searchParams.get("tier")).toBe("free");
+describe("onboarding.tier — U3: loader reads params for back-link", () => {
+  it("loader still reads handle and other params (used for back-link URL)", async () => {
+    const req = makeRequest(
+      "/onboarding/tier?handle=bob&platforms=tiktok%2Cyoutube&name=Bob&tpl=neon"
+    );
+    const result = await loader({ request: req, params: {}, context: {} } as never);
+    expect(result.handle).toBe("bob");
+    expect(result.platforms).toBe("tiktok,youtube");
+    expect(result.name).toBe("Bob");
+    expect(result.tpl).toBe("neon");
   });
 });
 
-// ── U4: action with minimal params ───────────────────────────────────────────
+// ── U4: action ignores all form state ────────────────────────────────────────
 
-describe("onboarding.tier — U4: action with minimal params", () => {
-  it("still redirects with tier=free when no params provided", async () => {
+describe("onboarding.tier — U4: action ignores form state (DEC-366=A)", () => {
+  it("action still redirects to /app even if someone submits unexpected fields", async () => {
     const req = makeRequest("/onboarding/tier", "POST", {
       handle: "",
       platforms: "",
@@ -155,20 +137,77 @@ describe("onboarding.tier — U4: action with minimal params", () => {
     const result = await action({ request: req, params: {}, context: {} } as never);
     expect(result).toBeInstanceOf(Response);
     const res = result as Response;
-    const u = new URL(`http://localhost${res.headers.get("Location") ?? ""}`);
-    expect(u.searchParams.get("tier")).toBe("free");
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/app");
   });
 });
 
 // ── U5: submit button text — Bug #6a regression (issue tadaify-app#188) ──────
 
-describe("onboarding.tier — U5: submit button text (Bug #6a)", () => {
-  it("source contains button text matching /Take me to my page/", () => {
-    expect(tierSrc).toMatch(/Take me to my page/);
-  });
-
+describe("onboarding.tier — U5: submit button text (Bug #6a / updated for DEC-366=A)", () => {
   it("source does NOT contain old 'Start for free →' button text", () => {
     expect(tierSrc).not.toContain("Start for free");
+  });
+
+  // U5 regression-lock updated: old "Take me to my page" replaced by "Take me to my dashboard"
+  // per DEC-366=A (issue tadaify-app#190 Bug #4). The original assertion is replaced.
+  it("source does NOT contain legacy 'Take me to my page' text (DEC-366=A)", () => {
+    expect(tierSrc).not.toMatch(/Take me to my page/);
+  });
+});
+
+// ── U6: CTA button text === "Take me to my dashboard →" (Bug #4, issue tadaify-app#190) ─────
+
+describe("onboarding.tier — U6: CTA button text 'Take me to my dashboard →' (Bug #4)", () => {
+  it("source contains button text 'Take me to my dashboard →'", () => {
+    expect(tierSrc).toContain("Take me to my dashboard →");
+  });
+
+  it("source does NOT contain legacy 'Take me to my page →' copy", () => {
+    // Regression-lock: old label was "Take me to my page →"
+    expect(tierSrc).not.toMatch(/Take me to my page/i);
+  });
+
+  it("source does NOT contain 'Go to dashboard →' (that was the complete-screen label)", () => {
+    // Regression-lock: ensure we didn't accidentally use the old complete-screen CTA text
+    expect(tierSrc).not.toMatch(/Go to dashboard/i);
+  });
+});
+
+// ── U7: action redirects to /app, NOT to /onboarding/complete (Bug #4, issue tadaify-app#190) ─
+
+describe("onboarding.tier — U7: action redirects to /app (DEC-366=A, Bug #4)", () => {
+  it("submitting tier form redirects to /app, NOT to /onboarding/complete", async () => {
+    const req = new Request("http://localhost/onboarding/tier", { method: "POST", body: new FormData() });
+    const result = await action({ request: req, params: {}, context: {} } as never);
+    expect(result).toBeInstanceOf(Response);
+    const res = result as Response;
+    expect(res.status).toBe(302);
+    const location = res.headers.get("Location") ?? "";
+    expect(location).toBe("/app");
+    // Regression-lock: must NOT redirect to /onboarding/complete
+    expect(location).not.toContain("/onboarding/complete");
+    expect(location).not.toContain("/dashboard");
+  });
+
+  it("action redirects to /app even with empty form", async () => {
+    const fd = new FormData();
+    const req = new Request("http://localhost/onboarding/tier", { method: "POST", body: fd });
+    const result = await action({ request: req, params: {}, context: {} } as never);
+    const res = result as Response;
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/app");
+  });
+
+  it("action code does NOT produce a redirect to /onboarding/complete (DEC-366=A)", async () => {
+    // Behavioural regression-lock: the action must redirect to /app, never to /onboarding/complete.
+    // (Source may mention /onboarding/complete in comments — test against runtime behaviour.)
+    const req = new Request("http://localhost/onboarding/tier", { method: "POST", body: new FormData() });
+    const result = await action({ request: req, params: {}, context: {} } as never);
+    const res = result as Response;
+    const location = res.headers.get("Location") ?? "";
+    expect(location).not.toContain("/onboarding/complete");
+    expect(location).toBe("/app");
   });
 });
 

--- a/app/routes/onboarding.tier.tsx
+++ b/app/routes/onboarding.tier.tsx
@@ -6,14 +6,15 @@
  * DEC-311=A refined: read-only plan comparison.
  *   - No billing UI, no tier selection.
  *   - Every user starts on Free.
- *   - The single CTA always routes to /onboarding/complete?tier=free.
- *   - If URL contains ?tier=<anything>, it is IGNORED — complete always
- *     receives tier=free. This is the DEC-311 refinement: S4 test verifies
- *     that tier=premium in the URL still produces tier=free in the output.
+ *
+ * DEC-366=A (2026-05-05): action redirects directly to /app, bypassing the
+ *   intermediate /onboarding/complete celebration screen (DEC-332=D UI removed).
+ *   Button label changed to "Take me to my dashboard →" — "my page" was
+ *   misleading since the page is not published at this point.
  *
  * URL state:
- *   loader reads → all accumulated params + optional tier (ignored)
- *   action emits → /onboarding/complete?<all params>&tier=free
+ *   loader reads → all accumulated params (for back-link construction only)
+ *   action emits → /app directly (DEC-366=A)
  *
  * Covers: BR-ONBOARDING-005 (step 5 plan overview)
  */
@@ -108,29 +109,11 @@ export async function loader({ request }: Route.LoaderArgs) {
 }
 
 // ─── Action ────────────────────────────────────────────────────────────────────
+// DEC-366=A: CTA submits form → action redirects directly to /app.
+// No form data processing needed — onboarding accumulation is complete.
 
-export async function action({ request }: Route.ActionArgs) {
-  const form = await request.formData();
-  const handle = (form.get("handle") as string) ?? "";
-  const platforms = (form.get("platforms") as string) ?? "";
-  const socials = (form.get("socials") as string) ?? "";
-  const name = (form.get("name") as string) ?? "";
-  const bio = (form.get("bio") as string) ?? "";
-  const av = (form.get("av") as string) ?? "";
-  const tpl = (form.get("tpl") as string) ?? "";
-
-  // DEC-311=A: always free — ignore any tier value from form or URL
-  const params = new URLSearchParams();
-  if (handle) params.set("handle", handle);
-  if (platforms) params.set("platforms", platforms);
-  if (socials) params.set("socials", socials);
-  if (name) params.set("name", name);
-  if (bio) params.set("bio", bio);
-  if (av) params.set("av", av);
-  if (tpl) params.set("tpl", tpl);
-  params.set("tier", "free"); // always free — DEC-311=A
-
-  return redirect(`/onboarding/complete?${params.toString()}`);
+export async function action(_: Route.ActionArgs) {
+  return redirect("/app");
 }
 
 // ─── Component ─────────────────────────────────────────────────────────────────
@@ -279,14 +262,8 @@ export default function TierPage({ loaderData }: Route.ComponentProps) {
         any paid tier.
       </p>
 
+      {/* DEC-366=A: action redirects to /app directly — no form data needed */}
       <form method="post">
-        <input type="hidden" name="handle" value={handle} />
-        <input type="hidden" name="platforms" value={platforms} />
-        <input type="hidden" name="socials" value={socials} />
-        <input type="hidden" name="name" value={name} />
-        <input type="hidden" name="bio" value={bio} />
-        <input type="hidden" name="av" value={av} />
-        <input type="hidden" name="tpl" value={tpl} />
 
         <div style={{ display: "flex", gap: 10, alignItems: "center", flexWrap: "wrap" }}>
           <Link
@@ -323,7 +300,7 @@ export default function TierPage({ loaderData }: Route.ComponentProps) {
               cursor: "pointer",
             }}
           >
-            Take me to my page →
+            Take me to my dashboard →
           </button>
         </div>
       </form>

--- a/app/routes/register.test.tsx
+++ b/app/routes/register.test.tsx
@@ -9,10 +9,15 @@
  * U2 — Apple SSO removal verification (DEC-346=C):
  *   Verifies 3 SSO providers (Google, X, Email) and zero Apple references.
  *
+ * U1-190 — Bug #1 (issue tadaify-app#190, DEC-363=A):
+ *   Handle-taken error region must show new "Already taken. Try:" copy +
+ *   3 clickable chips from generateAlternatives(). Old "Taken — someone beat
+ *   you to it." text must be absent.
+ *
  * These are static-analysis tests against the route source. We use fs.readFileSync
  * so they run under vitest node environment without jsdom/React rendering.
  *
- * Story: F-REGISTER-001a cleanup (issue tadaify-app#183, tadaify-app#188)
+ * Story: F-REGISTER-001a cleanup (issue tadaify-app#183, tadaify-app#188, tadaify-app#190)
  */
 
 import { describe, it, expect } from "vitest";
@@ -90,5 +95,48 @@ describe("register.tsx — no user-facing Apple copy (DEC-346=C)", () => {
   it("ProviderButton Apple SVG path is absent from source", () => {
     // Apple icon path prefix: d="M17.05 20.28
     expect(registerSrc).not.toMatch(/M17\.05 20\.28/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// U1-190: Bug #1 (issue tadaify-app#190) — handle-taken renders new copy + 3 chips
+// DEC-363=A: "Already taken. Try: <chip1> · <chip2> · <chip3>"
+// ---------------------------------------------------------------------------
+
+describe("register.tsx — U1-190: handle-taken 'Already taken. Try:' copy + chip rendering (DEC-363=A)", () => {
+  it("source contains 'Already taken. Try:' copy (DEC-363=A)", () => {
+    // New copy per DEC-363=A must be present in source
+    expect(registerSrc).toContain("Already taken. Try:");
+  });
+
+  it("source does NOT contain legacy 'someone beat you to it' copy (regression-lock)", () => {
+    // Old text that appeared before DEC-363=A fix
+    expect(registerSrc).not.toMatch(/someone beat you to it/i);
+  });
+
+  it("source does NOT contain legacy 'Taken —' prefix (regression-lock)", () => {
+    expect(registerSrc).not.toMatch(/Taken —\s/i);
+  });
+
+  it("source imports generateAlternatives from handle-validator (chips source)", () => {
+    // generateAlternatives must be imported (not inlined) for testability
+    expect(registerSrc).toContain("generateAlternatives");
+    expect(registerSrc).toMatch(/from ["']~\/lib\/handle-validator["']/);
+  });
+
+  it("source renders handleAlternatives as clickable buttons (chips)", () => {
+    // Each chip must be a <button> element with onClick handler
+    expect(registerSrc).toContain("handleAlternatives");
+    expect(registerSrc).toMatch(/onAlternativeClick/);
+  });
+
+  it("handleAlternatives state is reset when user changes handle input", () => {
+    // Regression-lock: chips must clear when user types a new handle
+    expect(registerSrc).toMatch(/setHandleAlternatives\(\[\]\)/);
+  });
+
+  it("source uses ✦ brand marker for taken copy (DEC-363=A)", () => {
+    // The ✦ (sparkle) marker is the brand indicator for the taken state
+    expect(registerSrc).toContain("✦ Already taken. Try:");
   });
 });

--- a/app/routes/register.tsx
+++ b/app/routes/register.tsx
@@ -27,7 +27,7 @@
 import { useReducer, useEffect, useRef, useCallback, useState } from "react";
 import { useSearchParams, useNavigate } from "react-router";
 import type { Route } from "./+types/register";
-import { validateHandle } from "~/lib/handle-validator";
+import { validateHandle, generateAlternatives } from "~/lib/handle-validator";
 import {
   validateEmail,
   validatePassword,
@@ -99,6 +99,7 @@ export default function RegisterPage({ loaderData }: Route.ComponentProps) {
   );
   const [handleAvailable, setHandleAvailable] = useState<boolean | null>(null);
   const [handleError, setHandleError] = useState<string | null>(null);
+  const [handleAlternatives, setHandleAlternatives] = useState<string[]>([]);
 
   const otpInputRefs = useRef<(HTMLInputElement | null)[]>([null, null, null, null, null, null]);
   const handleCheckTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -181,7 +182,16 @@ export default function RegisterPage({ loaderData }: Route.ComponentProps) {
         });
         const data = (await res.json()) as { available: boolean };
         setHandleAvailable(data.available);
-        setHandleError(data.available ? null : "This handle is already taken.");
+        if (data.available) {
+          setHandleError(null);
+          setHandleAlternatives([]);
+        } else {
+          // DEC-363=A: show alternatives as clickable chips (not static "Taken" message)
+          const locale = navigator.language?.startsWith("pl") ? "pl" : "en";
+          const alts = generateAlternatives(handle, locale);
+          setHandleAlternatives(alts);
+          setHandleError("Already taken. Try:");
+        }
       } catch {
         // Network error — allow proceed, server validates on submit
       }
@@ -193,6 +203,7 @@ export default function RegisterPage({ loaderData }: Route.ComponentProps) {
     dispatch({ type: "SET_HANDLE", handle: lower });
     setHandleAvailable(null);
     setHandleError(null);
+    setHandleAlternatives([]);
     checkHandleAvailability(lower);
   };
 
@@ -494,10 +505,14 @@ export default function RegisterPage({ loaderData }: Route.ComponentProps) {
               state={state}
               handleAvailable={handleAvailable}
               handleError={handleError}
+              handleAlternatives={handleAlternatives}
               onHandleChange={handleHandleChange}
               onHandleKeyDown={handleHandleKeyDown}
               onContinue={handleProceedToMethod}
               handleValid={handleValid}
+              onAlternativeClick={(alt) => {
+                handleHandleChange(alt);
+              }}
             />
 
             {/* ── SECTION B — Method selection ───────────────────────────── */}
@@ -709,18 +724,22 @@ function SectionA({
   state,
   handleAvailable,
   handleError,
+  handleAlternatives,
   onHandleChange,
   onHandleKeyDown,
   onContinue,
   handleValid,
+  onAlternativeClick,
 }: {
   state: OtpState;
   handleAvailable: boolean | null;
   handleError: string | null;
+  handleAlternatives: string[];
   onHandleChange: (v: string) => void;
   onHandleKeyDown: (e: React.KeyboardEvent) => void;
   onContinue: () => void;
   handleValid: boolean;
+  onAlternativeClick: (alt: string) => void;
 }) {
   return (
     <section aria-label="Choose your handle" style={{ marginBottom: state.section !== "A" ? 0 : undefined }}>
@@ -825,21 +844,49 @@ function SectionA({
               marginTop: 10,
               fontSize: 14,
               minHeight: 22,
-              display: "flex",
-              alignItems: "center",
-              gap: 8,
               fontWeight: 500,
-              color:
-                handleAvailable === true
-                  ? "var(--success)"
-                  : handleAvailable === false
-                  ? "var(--danger)"
-                  : "var(--fg-subtle)",
             }}
           >
-            {handleAvailable === true && state.handle && "✓ Available!"}
-            {handleAvailable === false && (handleError ?? "Handle unavailable.")}
-            {handleAvailable === null && state.handle && "Checking…"}
+            {handleAvailable === true && state.handle && (
+              <span style={{ color: "var(--success)", display: "flex", alignItems: "center", gap: 8 }}>
+                ✓ Available!
+              </span>
+            )}
+            {handleAvailable === false && handleAlternatives.length > 0 && (
+              /* DEC-363=A: "Already taken. Try: <chip1> · <chip2> · <chip3>" */
+              <span style={{ display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap", color: "var(--danger)" }}>
+                <span>✦ Already taken. Try:</span>
+                {handleAlternatives.map((alt, i) => (
+                  <button
+                    key={alt}
+                    type="button"
+                    aria-label={`Try handle ${alt}`}
+                    onClick={() => onAlternativeClick(alt)}
+                    style={{
+                      padding: "2px 10px",
+                      border: "1.5px solid var(--danger)",
+                      borderRadius: "var(--radius-full, 9999px)",
+                      background: "transparent",
+                      color: "var(--danger)",
+                      fontSize: 13,
+                      fontWeight: 600,
+                      cursor: "pointer",
+                      lineHeight: 1.6,
+                    }}
+                  >
+                    {alt}
+                  </button>
+                ))}
+              </span>
+            )}
+            {handleAvailable === false && handleAlternatives.length === 0 && (
+              <span style={{ color: "var(--danger)", display: "flex", alignItems: "center", gap: 8 }}>
+                {handleError ?? "Handle unavailable."}
+              </span>
+            )}
+            {handleAvailable === null && state.handle && (
+              <span style={{ color: "var(--fg-subtle)" }}>Checking…</span>
+            )}
           </div>
 
           {/* Error message */}

--- a/e2e/email-templates-show-handle.spec.ts
+++ b/e2e/email-templates-show-handle.spec.ts
@@ -33,11 +33,12 @@ const SERVICE_ROLE_KEY =
   process.env.SUPABASE_SERVICE_ROLE_KEY ??
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU";
 
-// Unique seeds for this spec (prefix t190s2)
-const SIGNUP_HANDLE = `t190s2sig${Date.now()}`;
-const SIGNUP_EMAIL = `t190s2sig${Date.now()}@local.test`;
-const LOGIN_HANDLE = "t190s3login"; // pre-seeded user (created in beforeAll)
-const LOGIN_EMAIL = `t190s3login@local.test`;
+// Unique seeds for this spec (prefix t190s2/s3) — unique per run for idempotency
+const RUN_ID = Date.now();
+const SIGNUP_HANDLE = `t190s2s${RUN_ID}`.slice(0, 30);
+const SIGNUP_EMAIL = `t190s2s${RUN_ID}@local.test`;
+const LOGIN_HANDLE = `t190s3l${RUN_ID}`.slice(0, 30);
+const LOGIN_EMAIL = `t190s3l${RUN_ID}@local.test`;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -104,6 +105,29 @@ async function deleteHandleReservation(handle: string): Promise<void> {
   } catch { /* best-effort */ }
 }
 
+async function cleanupAuthUserByEmail(email: string): Promise<void> {
+  try {
+    const res = await fetch(`${SUPABASE_URL}/auth/v1/admin/users?per_page=100`, {
+      headers: {
+        apikey: SERVICE_ROLE_KEY,
+        Authorization: `Bearer ${SERVICE_ROLE_KEY}`,
+      },
+    });
+    if (!res.ok) return;
+    const data = (await res.json()) as { users?: Array<{ id: string; email?: string }> };
+    const match = (data.users ?? []).find((u) => u.email === email);
+    if (match) {
+      await fetch(`${SUPABASE_URL}/auth/v1/admin/users/${match.id}`, {
+        method: "DELETE",
+        headers: {
+          apikey: SERVICE_ROLE_KEY,
+          Authorization: `Bearer ${SERVICE_ROLE_KEY}`,
+        },
+      });
+    }
+  } catch { /* best-effort */ }
+}
+
 // ---------------------------------------------------------------------------
 // S2 — signup OTP email greets @{handle}, not @{email}
 // Covers Bug #2a (tadaify-app#190)
@@ -111,11 +135,13 @@ async function deleteHandleReservation(handle: string): Promise<void> {
 
 test.describe("S2 — signup OTP email greets @handle (DEC-364=A)", () => {
   test.beforeAll(async () => {
+    await cleanupAuthUserByEmail(SIGNUP_EMAIL);
     await clearMailpitForEmail(SIGNUP_EMAIL);
     await deleteHandleReservation(SIGNUP_HANDLE);
   });
 
   test.afterAll(async () => {
+    await cleanupAuthUserByEmail(SIGNUP_EMAIL);
     await deleteHandleReservation(SIGNUP_HANDLE);
     await clearMailpitForEmail(SIGNUP_EMAIL);
   });
@@ -171,13 +197,13 @@ test.describe("S2 — signup OTP email greets @handle (DEC-364=A)", () => {
 
 test.describe("S3 — login OTP email greets @handle from profile lookup (DEC-364=A)", () => {
   test.beforeAll(async () => {
-    // Seed a user with a known handle for the login test.
-    // We need them registered first — use the signup API directly.
+    await cleanupAuthUserByEmail(LOGIN_EMAIL);
     await clearMailpitForEmail(LOGIN_EMAIL);
     await deleteHandleReservation(LOGIN_HANDLE);
   });
 
   test.afterAll(async () => {
+    await cleanupAuthUserByEmail(LOGIN_EMAIL);
     await deleteHandleReservation(LOGIN_HANDLE);
     await clearMailpitForEmail(LOGIN_EMAIL);
   });

--- a/e2e/email-templates-show-handle.spec.ts
+++ b/e2e/email-templates-show-handle.spec.ts
@@ -1,0 +1,250 @@
+/**
+ * S2, S3 (issue tadaify-app#190 Bug #2, DEC-364=A)
+ *
+ * S2: "signup OTP email greets @{handle}, not @{email}"
+ * S3: "login OTP email greets @{handle} from looked-up profile"
+ *
+ * Before fix (Bug #2):
+ *   - Signup OTP email: "Hey @vvaser@gmail.com 👋" (email in greeting)
+ *   - Login OTP email: "Welcome back, @vvaser@gmail.com" (email in greeting)
+ *
+ * After fix (DEC-364=A):
+ *   - Signup OTP email: "Hey @<handle> 👋"
+ *   - Login OTP email: "Welcome back, @<handle>"
+ *   - Identity-linked email: "Hey @<handle>" (manual verification — OAuth trigger)
+ *
+ * Prerequisites:
+ *   - `supabase start` (Mailpit at http://localhost:54354 — local port-band 5435X)
+ *   - `.dev.vars` configured with Workers env bindings
+ *   - `npm run dev` (App: http://localhost:5173)
+ *
+ * Run: npx playwright test e2e/email-templates-show-handle.spec.ts
+ */
+
+import { test, expect } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MAILPIT_URL = "http://localhost:54354";
+const SUPABASE_URL = process.env.SUPABASE_URL ?? "http://127.0.0.1:54351";
+const SERVICE_ROLE_KEY =
+  process.env.SUPABASE_SERVICE_ROLE_KEY ??
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU";
+
+// Unique seeds for this spec (prefix t190s2)
+const SIGNUP_HANDLE = `t190s2sig${Date.now()}`;
+const SIGNUP_EMAIL = `t190s2sig${Date.now()}@local.test`;
+const LOGIN_HANDLE = "t190s3login"; // pre-seeded user (created in beforeAll)
+const LOGIN_EMAIL = `t190s3login@local.test`;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function clearMailpitForEmail(email: string): Promise<void> {
+  try {
+    const listRes = await fetch(
+      `${MAILPIT_URL}/api/v1/messages?query=${encodeURIComponent(`to:${email}`)}`
+    );
+    if (!listRes.ok) return;
+    const data = (await listRes.json()) as { messages?: Array<{ ID: string }> };
+    for (const msg of (data.messages ?? [])) {
+      await fetch(`${MAILPIT_URL}/api/v1/messages`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ IDs: [msg.ID] }),
+      });
+    }
+  } catch {
+    // Mailpit not running — test will fail at email check step
+  }
+}
+
+async function getMailpitEmailContent(email: string, timeoutMs = 30_000): Promise<{ subject: string; html: string; text: string } | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const listRes = await fetch(
+        `${MAILPIT_URL}/api/v1/messages?query=${encodeURIComponent(`to:${email}`)}`
+      );
+      if (listRes.ok) {
+        const data = (await listRes.json()) as { messages?: Array<{ ID: string; Subject: string }> };
+        const msgs = data.messages ?? [];
+        if (msgs.length > 0) {
+          const msgRes = await fetch(`${MAILPIT_URL}/api/v1/message/${msgs[0].ID}`);
+          if (msgRes.ok) {
+            const msg = (await msgRes.json()) as { Subject: string; HTML: string; Text: string };
+            return { subject: msg.Subject ?? "", html: msg.HTML ?? "", text: msg.Text ?? "" };
+          }
+        }
+      }
+    } catch {
+      // retry
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  return null;
+}
+
+async function deleteHandleReservation(handle: string): Promise<void> {
+  try {
+    await fetch(
+      `${SUPABASE_URL}/rest/v1/handle_reservations?handle=eq.${encodeURIComponent(handle)}`,
+      {
+        method: "DELETE",
+        headers: {
+          apikey: SERVICE_ROLE_KEY,
+          Authorization: `Bearer ${SERVICE_ROLE_KEY}`,
+          Prefer: "return=minimal",
+        },
+      }
+    );
+  } catch { /* best-effort */ }
+}
+
+// ---------------------------------------------------------------------------
+// S2 — signup OTP email greets @{handle}, not @{email}
+// Covers Bug #2a (tadaify-app#190)
+// ---------------------------------------------------------------------------
+
+test.describe("S2 — signup OTP email greets @handle (DEC-364=A)", () => {
+  test.beforeAll(async () => {
+    await clearMailpitForEmail(SIGNUP_EMAIL);
+    await deleteHandleReservation(SIGNUP_HANDLE);
+  });
+
+  test.afterAll(async () => {
+    await deleteHandleReservation(SIGNUP_HANDLE);
+    await clearMailpitForEmail(SIGNUP_EMAIL);
+  });
+
+  test("signup OTP email greets @{handle}, not @{email}", async ({ page }) => {
+    await page.goto("/register");
+
+    // Fill handle
+    const handleInput = page.locator("#handle-input");
+    await handleInput.fill(SIGNUP_HANDLE);
+
+    // Wait for availability check
+    const availability = page.locator("#handle-availability");
+    await expect(availability).toContainText("Available!", { timeout: 8_000 });
+
+    // Continue to method selection
+    await page.getByRole("button", { name: /continue/i }).first().click();
+
+    // Choose email path
+    await page.getByRole("button", { name: /continue with email/i }).click();
+
+    // Fill email
+    const emailInput = page.locator("#email-input");
+    await emailInput.fill(SIGNUP_EMAIL);
+
+    // Send code
+    await page.getByRole("button", { name: /send.*code/i }).click();
+
+    // Wait for OTP screen to appear
+    await expect(page.getByRole("heading", { name: /check your email/i })).toBeVisible({ timeout: 15_000 });
+
+    // Retrieve email from Mailpit
+    const email = await getMailpitEmailContent(SIGNUP_EMAIL, 30_000);
+    expect(email).not.toBeNull();
+
+    const fullContent = (email?.html ?? "") + (email?.text ?? "");
+
+    // MUST contain @handle — not @email
+    expect(fullContent).toContain(`@${SIGNUP_HANDLE}`);
+
+    // Regression-lock: email address must NOT appear as the @ greeting
+    // (the email address IS in "to:" header — just not in the greeting body)
+    const emailDomain = SIGNUP_EMAIL.split("@")[1];
+    // The greeting line specifically should not show "@user@domain" pattern
+    expect(fullContent).not.toMatch(new RegExp(`@${SIGNUP_EMAIL.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`, "i"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// S3 — login OTP email greets @{handle} from looked-up profile
+// Covers Bug #2b (tadaify-app#190)
+// ---------------------------------------------------------------------------
+
+test.describe("S3 — login OTP email greets @handle from profile lookup (DEC-364=A)", () => {
+  test.beforeAll(async () => {
+    // Seed a user with a known handle for the login test.
+    // We need them registered first — use the signup API directly.
+    await clearMailpitForEmail(LOGIN_EMAIL);
+    await deleteHandleReservation(LOGIN_HANDLE);
+  });
+
+  test.afterAll(async () => {
+    await deleteHandleReservation(LOGIN_HANDLE);
+    await clearMailpitForEmail(LOGIN_EMAIL);
+  });
+
+  test("login OTP email greets @{handle} looked up from profile", async ({ page }) => {
+    // Step 1: Register the user so they have a profile with a known handle.
+    await page.goto("/register");
+    const handleInput = page.locator("#handle-input");
+    await handleInput.fill(LOGIN_HANDLE);
+
+    const availability = page.locator("#handle-availability");
+    await expect(availability).toContainText("Available!", { timeout: 8_000 });
+    await page.getByRole("button", { name: /continue/i }).first().click();
+    await page.getByRole("button", { name: /continue with email/i }).click();
+
+    const emailInput = page.locator("#email-input");
+    await emailInput.fill(LOGIN_EMAIL);
+    await page.getByRole("button", { name: /send.*code/i }).click();
+    await expect(page.getByRole("heading", { name: /check your email/i })).toBeVisible({ timeout: 15_000 });
+
+    // Get OTP from Mailpit and complete registration
+    const signupOtp = await getMailpitEmailContent(LOGIN_EMAIL, 30_000);
+    expect(signupOtp).not.toBeNull();
+    const otpMatch = ((signupOtp?.html ?? "") + (signupOtp?.text ?? "")).match(/\b(\d{6})\b/);
+    expect(otpMatch).not.toBeNull();
+    const otpCode = otpMatch![1];
+
+    // Enter OTP digits
+    const digits = page.getByRole("textbox");
+    for (let i = 0; i < 6; i++) {
+      await digits.nth(i).fill(otpCode[i]);
+    }
+
+    // Password toggle → continue with OTP mode (default)
+    await expect(page.getByRole("button", { name: /continue/i }).last()).toBeEnabled({ timeout: 10_000 });
+    await page.getByRole("button", { name: /continue/i }).last().click();
+
+    // Wait for onboarding (Section C or onboarding redirect)
+    await expect(page).toHaveURL(/\/(register|onboarding)/, { timeout: 10_000 });
+
+    // Clear Mailpit for clean login test
+    await clearMailpitForEmail(LOGIN_EMAIL);
+
+    // Step 2: Log out (navigate to landing, then login)
+    await page.goto("/login");
+
+    // Step 3: Send login OTP
+    await page.locator("#login-email").fill(LOGIN_EMAIL);
+    await page.getByRole("button", { name: /send me a code/i }).click();
+
+    // Wait for OTP entry or confirmation of sent
+    await expect(
+      page.getByRole("textbox", { name: /digit 1/i })
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Step 4: Retrieve login OTP email from Mailpit and check greeting
+    const loginEmail = await getMailpitEmailContent(LOGIN_EMAIL, 30_000);
+    expect(loginEmail).not.toBeNull();
+
+    const loginFullContent = (loginEmail?.html ?? "") + (loginEmail?.text ?? "");
+
+    // MUST greet with @handle — not @email address
+    expect(loginFullContent).toContain(`@${LOGIN_HANDLE}`);
+
+    // Regression-lock: email address must NOT appear as the greeting target
+    expect(loginFullContent).not.toMatch(
+      new RegExp(`@${LOGIN_EMAIL.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`, "i")
+    );
+  });
+});

--- a/e2e/email-templates-show-handle.spec.ts
+++ b/e2e/email-templates-show-handle.spec.ts
@@ -177,16 +177,19 @@ test.describe("S2 — signup OTP email greets @handle (DEC-364=A)", () => {
     const email = await getMailpitEmailContent(SIGNUP_EMAIL, 30_000);
     expect(email).not.toBeNull();
 
-    const fullContent = (email?.html ?? "") + (email?.text ?? "");
+    // Check HTML and text bodies INDEPENDENTLY (not concatenated)
+    const htmlBody = email?.html ?? "";
+    const textBody = email?.text ?? "";
 
-    // MUST contain @handle — not @email
-    expect(fullContent).toContain(`@${SIGNUP_HANDLE}`);
+    // HTML part MUST contain @handle
+    expect(htmlBody).toContain(`@${SIGNUP_HANDLE}`);
+    // Text part MUST contain @handle
+    expect(textBody).toContain(`@${SIGNUP_HANDLE}`);
 
-    // Regression-lock: email address must NOT appear as the @ greeting
-    // (the email address IS in "to:" header — just not in the greeting body)
-    const emailDomain = SIGNUP_EMAIL.split("@")[1];
-    // The greeting line specifically should not show "@user@domain" pattern
-    expect(fullContent).not.toMatch(new RegExp(`@${SIGNUP_EMAIL.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`, "i"));
+    // Regression-lock: email address must NOT appear as the @ greeting in EITHER part
+    const emailPattern = new RegExp(`@${SIGNUP_EMAIL.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`, "i");
+    expect(htmlBody).not.toMatch(emailPattern);
+    expect(textBody).not.toMatch(emailPattern);
   });
 });
 
@@ -263,14 +266,18 @@ test.describe("S3 — login OTP email greets @handle from profile lookup (DEC-36
     const loginEmail = await getMailpitEmailContent(LOGIN_EMAIL, 30_000);
     expect(loginEmail).not.toBeNull();
 
-    const loginFullContent = (loginEmail?.html ?? "") + (loginEmail?.text ?? "");
+    // Check HTML and text bodies INDEPENDENTLY (not concatenated)
+    const loginHtmlBody = loginEmail?.html ?? "";
+    const loginTextBody = loginEmail?.text ?? "";
 
-    // MUST greet with @handle — not @email address
-    expect(loginFullContent).toContain(`@${LOGIN_HANDLE}`);
+    // HTML part MUST greet with @handle
+    expect(loginHtmlBody).toContain(`@${LOGIN_HANDLE}`);
+    // Text part MUST greet with @handle
+    expect(loginTextBody).toContain(`@${LOGIN_HANDLE}`);
 
-    // Regression-lock: email address must NOT appear as the greeting target
-    expect(loginFullContent).not.toMatch(
-      new RegExp(`@${LOGIN_EMAIL.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`, "i")
-    );
+    // Regression-lock: email address must NOT appear as the greeting target in EITHER part
+    const loginEmailPattern = new RegExp(`@${LOGIN_EMAIL.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`, "i");
+    expect(loginHtmlBody).not.toMatch(loginEmailPattern);
+    expect(loginTextBody).not.toMatch(loginEmailPattern);
   });
 });

--- a/e2e/login-redirect-to-app.spec.ts
+++ b/e2e/login-redirect-to-app.spec.ts
@@ -1,0 +1,195 @@
+/**
+ * S4 (issue tadaify-app#190 Bug #3)
+ *
+ * "login OTP success lands on /app dashboard, not 404"
+ *
+ * Before fix:
+ *   - login.tsx:187 had navigate("/dashboard")
+ *   - /dashboard route does not exist → 404 page after OTP verify
+ *
+ * After fix:
+ *   - navigate("/app") — the canonical dashboard route
+ *   - User lands on /app with sidebar visible, no 404
+ *
+ * Prerequisites:
+ *   - `supabase start` (Mailpit at http://localhost:54354)
+ *   - `.dev.vars` configured with Workers env bindings
+ *   - `npm run dev` (App: http://localhost:5173)
+ *
+ * Run: npx playwright test e2e/login-redirect-to-app.spec.ts
+ */
+
+import { test, expect } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MAILPIT_URL = "http://localhost:54354";
+const SUPABASE_URL = process.env.SUPABASE_URL ?? "http://127.0.0.1:54351";
+const SERVICE_ROLE_KEY =
+  process.env.SUPABASE_SERVICE_ROLE_KEY ??
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU";
+
+const HANDLE = "t190s4login";
+const EMAIL = `t190s4login@local.test`;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function clearMailpit(email: string): Promise<void> {
+  try {
+    const listRes = await fetch(
+      `${MAILPIT_URL}/api/v1/messages?query=${encodeURIComponent(`to:${email}`)}`
+    );
+    if (!listRes.ok) return;
+    const data = (await listRes.json()) as { messages?: Array<{ ID: string }> };
+    for (const msg of (data.messages ?? [])) {
+      await fetch(`${MAILPIT_URL}/api/v1/messages`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ IDs: [msg.ID] }),
+      });
+    }
+  } catch { /* best-effort */ }
+}
+
+async function getMailpitOtp(email: string, timeoutMs = 30_000): Promise<string | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const listRes = await fetch(
+        `${MAILPIT_URL}/api/v1/messages?query=${encodeURIComponent(`to:${email}`)}`
+      );
+      if (listRes.ok) {
+        const data = (await listRes.json()) as { messages?: Array<{ ID: string }> };
+        const msgs = data.messages ?? [];
+        if (msgs.length > 0) {
+          const msgRes = await fetch(`${MAILPIT_URL}/api/v1/message/${msgs[0].ID}`);
+          if (msgRes.ok) {
+            const msg = (await msgRes.json()) as { HTML: string; Text: string };
+            const fullContent = (msg.HTML ?? "") + (msg.Text ?? "");
+            const match = fullContent.match(/\b(\d{6})\b/);
+            if (match) return match[1];
+          }
+        }
+      }
+    } catch { /* retry */ }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  return null;
+}
+
+async function deleteHandleReservation(handle: string): Promise<void> {
+  try {
+    await fetch(
+      `${SUPABASE_URL}/rest/v1/handle_reservations?handle=eq.${encodeURIComponent(handle)}`,
+      {
+        method: "DELETE",
+        headers: {
+          apikey: SERVICE_ROLE_KEY,
+          Authorization: `Bearer ${SERVICE_ROLE_KEY}`,
+          Prefer: "return=minimal",
+        },
+      }
+    );
+  } catch { /* best-effort */ }
+}
+
+// ---------------------------------------------------------------------------
+// Hooks
+// ---------------------------------------------------------------------------
+
+test.beforeAll(async () => {
+  await clearMailpit(EMAIL);
+  await deleteHandleReservation(HANDLE);
+});
+
+test.afterAll(async () => {
+  await deleteHandleReservation(HANDLE);
+  await clearMailpit(EMAIL);
+});
+
+// ---------------------------------------------------------------------------
+// S4 — login OTP success lands on /app dashboard, not 404 (Bug #3)
+// Covers: issue tadaify-app#190 Bug #3
+// ---------------------------------------------------------------------------
+
+test(
+  "S4 — login OTP success lands on /app dashboard, not 404",
+  async ({ page }) => {
+    // ── Step 1: Register a new user so login has a valid account ─────────────
+    await page.goto("/register");
+
+    const handleInput = page.locator("#handle-input");
+    await handleInput.fill(HANDLE);
+
+    const availability = page.locator("#handle-availability");
+    await expect(availability).toContainText("Available!", { timeout: 8_000 });
+
+    await page.getByRole("button", { name: /continue/i }).first().click();
+    await page.getByRole("button", { name: /continue with email/i }).click();
+
+    const emailInput = page.locator("#email-input");
+    await emailInput.fill(EMAIL);
+    await page.getByRole("button", { name: /send.*code/i }).click();
+
+    await expect(page.getByRole("heading", { name: /check your email/i })).toBeVisible({ timeout: 15_000 });
+
+    const signupOtp = await getMailpitOtp(EMAIL, 30_000);
+    expect(signupOtp).not.toBeNull();
+
+    // Enter OTP digits
+    const otpInputs = page.getByRole("group", { name: /verification code/i }).getByRole("textbox");
+    for (let i = 0; i < 6; i++) {
+      await otpInputs.nth(i).fill(signupOtp![i]);
+    }
+
+    // Continue through password toggle and/or onboarding
+    await expect(page.getByRole("button", { name: /continue/i }).last()).toBeEnabled({ timeout: 10_000 });
+    await page.getByRole("button", { name: /continue/i }).last().click();
+
+    // Wait until we're past the OTP step
+    await expect(page).toHaveURL(/\/(onboarding|app)/, { timeout: 15_000 });
+
+    // ── Step 2: Navigate to /login (simulate sign-out) ───────────────────────
+    await clearMailpit(EMAIL);
+    await page.goto("/login");
+
+    // ── Step 3: Log in with OTP ───────────────────────────────────────────────
+    await page.locator("#login-email").fill(EMAIL);
+    await page.getByRole("button", { name: /send me a code/i }).click();
+
+    // Wait for OTP entry section
+    await expect(page.getByRole("textbox", { name: /digit 1/i })).toBeVisible({ timeout: 15_000 });
+
+    const loginOtp = await getMailpitOtp(EMAIL, 30_000);
+    expect(loginOtp).not.toBeNull();
+
+    // Enter OTP
+    const loginOtpInputs = page.getByRole("textbox", { name: /digit/i });
+    for (let i = 0; i < 6; i++) {
+      await loginOtpInputs.nth(i).fill(loginOtp![i]);
+    }
+
+    // Verify OTP
+    await page.getByRole("button", { name: /verify code/i }).click();
+
+    // ── Step 4: Assert land on /app, NOT /dashboard (Bug #3 fix) ─────────────
+    await expect(page).toHaveURL(/\/app(\?|$|#)/, { timeout: 10_000 });
+
+    // Assert page has dashboard markers (sidebar or main content)
+    // /app renders <aside class="app-sidebar"> or similar
+    await expect(page.locator("aside")).toBeVisible({ timeout: 5_000 });
+
+    // Regression-lock: must NOT be on /dashboard (which 404s)
+    expect(page.url()).not.toMatch(/\/dashboard/);
+
+    // Regression-lock: page must NOT show "404" or "not found"
+    const bodyText = await page.locator("body").innerText();
+    expect(bodyText).not.toMatch(/404/i);
+    expect(bodyText).not.toMatch(/not found/i);
+    expect(bodyText).not.toMatch(/could not be found/i);
+  }
+);

--- a/e2e/login-redirect-to-app.spec.ts
+++ b/e2e/login-redirect-to-app.spec.ts
@@ -31,8 +31,9 @@ const SERVICE_ROLE_KEY =
   process.env.SUPABASE_SERVICE_ROLE_KEY ??
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU";
 
-const HANDLE = "t190s4login";
-const EMAIL = `t190s4login@local.test`;
+const RUN_ID = Date.now();
+const HANDLE = `t190s4l${RUN_ID}`.slice(0, 30);
+const EMAIL = `t190s4l${RUN_ID}@local.test`;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -97,16 +98,41 @@ async function deleteHandleReservation(handle: string): Promise<void> {
   } catch { /* best-effort */ }
 }
 
+async function cleanupAuthUserByEmail(email: string): Promise<void> {
+  try {
+    const res = await fetch(`${SUPABASE_URL}/auth/v1/admin/users?per_page=100`, {
+      headers: {
+        apikey: SERVICE_ROLE_KEY,
+        Authorization: `Bearer ${SERVICE_ROLE_KEY}`,
+      },
+    });
+    if (!res.ok) return;
+    const data = (await res.json()) as { users?: Array<{ id: string; email?: string }> };
+    const match = (data.users ?? []).find((u) => u.email === email);
+    if (match) {
+      await fetch(`${SUPABASE_URL}/auth/v1/admin/users/${match.id}`, {
+        method: "DELETE",
+        headers: {
+          apikey: SERVICE_ROLE_KEY,
+          Authorization: `Bearer ${SERVICE_ROLE_KEY}`,
+        },
+      });
+    }
+  } catch { /* best-effort */ }
+}
+
 // ---------------------------------------------------------------------------
 // Hooks
 // ---------------------------------------------------------------------------
 
 test.beforeAll(async () => {
+  await cleanupAuthUserByEmail(EMAIL);
   await clearMailpit(EMAIL);
   await deleteHandleReservation(HANDLE);
 });
 
 test.afterAll(async () => {
+  await cleanupAuthUserByEmail(EMAIL);
   await deleteHandleReservation(HANDLE);
   await clearMailpit(EMAIL);
 });

--- a/e2e/post-onboarding-direct-to-dashboard.spec.ts
+++ b/e2e/post-onboarding-direct-to-dashboard.spec.ts
@@ -34,8 +34,9 @@ const SERVICE_ROLE_KEY =
   process.env.SUPABASE_SERVICE_ROLE_KEY ??
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU";
 
-const HANDLE = "t190s5onboard";
-const EMAIL = `t190s5onboard@local.test`;
+const RUN_ID = Date.now();
+const HANDLE = `t190s5o${RUN_ID}`.slice(0, 30);
+const EMAIL = `t190s5o${RUN_ID}@local.test`;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -100,16 +101,41 @@ async function deleteHandleReservation(handle: string): Promise<void> {
   } catch { /* best-effort */ }
 }
 
+async function cleanupAuthUserByEmail(email: string): Promise<void> {
+  try {
+    const res = await fetch(`${SUPABASE_URL}/auth/v1/admin/users?per_page=100`, {
+      headers: {
+        apikey: SERVICE_ROLE_KEY,
+        Authorization: `Bearer ${SERVICE_ROLE_KEY}`,
+      },
+    });
+    if (!res.ok) return;
+    const data = (await res.json()) as { users?: Array<{ id: string; email?: string }> };
+    const match = (data.users ?? []).find((u) => u.email === email);
+    if (match) {
+      await fetch(`${SUPABASE_URL}/auth/v1/admin/users/${match.id}`, {
+        method: "DELETE",
+        headers: {
+          apikey: SERVICE_ROLE_KEY,
+          Authorization: `Bearer ${SERVICE_ROLE_KEY}`,
+        },
+      });
+    }
+  } catch { /* best-effort */ }
+}
+
 // ---------------------------------------------------------------------------
 // Hooks
 // ---------------------------------------------------------------------------
 
 test.beforeAll(async () => {
+  await cleanupAuthUserByEmail(EMAIL);
   await clearMailpit(EMAIL);
   await deleteHandleReservation(HANDLE);
 });
 
 test.afterAll(async () => {
+  await cleanupAuthUserByEmail(EMAIL);
   await deleteHandleReservation(HANDLE);
   await clearMailpit(EMAIL);
 });

--- a/e2e/post-onboarding-direct-to-dashboard.spec.ts
+++ b/e2e/post-onboarding-direct-to-dashboard.spec.ts
@@ -1,0 +1,235 @@
+/**
+ * S5 (issue tadaify-app#190 Bug #4, DEC-366=A)
+ *
+ * "tier step CTA lands directly on /app dashboard, no intermediate UI"
+ *
+ * Before fix:
+ *   - onboarding.tier.tsx action redirected to /onboarding/complete
+ *   - onboarding.complete.tsx rendered a celebration screen ("tada!", "Your page is being set up")
+ *   - Button text was "Take me to my page →"
+ *
+ * After fix (DEC-366=A):
+ *   - onboarding.tier.tsx action redirects directly to /app
+ *   - onboarding.complete.tsx is a pure SSR redirect (no UI)
+ *   - Button text is "Take me to my dashboard →"
+ *   - User lands on /app with sidebar visible, no celebration screen
+ *
+ * Prerequisites:
+ *   - `supabase start` (Mailpit at http://localhost:54354)
+ *   - `.dev.vars` configured with Workers env bindings
+ *   - `npm run dev` (App: http://localhost:5173)
+ *
+ * Run: npx playwright test e2e/post-onboarding-direct-to-dashboard.spec.ts
+ */
+
+import { test, expect } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MAILPIT_URL = "http://localhost:54354";
+const SUPABASE_URL = process.env.SUPABASE_URL ?? "http://127.0.0.1:54351";
+const SERVICE_ROLE_KEY =
+  process.env.SUPABASE_SERVICE_ROLE_KEY ??
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU";
+
+const HANDLE = "t190s5onboard";
+const EMAIL = `t190s5onboard@local.test`;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function clearMailpit(email: string): Promise<void> {
+  try {
+    const listRes = await fetch(
+      `${MAILPIT_URL}/api/v1/messages?query=${encodeURIComponent(`to:${email}`)}`
+    );
+    if (!listRes.ok) return;
+    const data = (await listRes.json()) as { messages?: Array<{ ID: string }> };
+    for (const msg of (data.messages ?? [])) {
+      await fetch(`${MAILPIT_URL}/api/v1/messages`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ IDs: [msg.ID] }),
+      });
+    }
+  } catch { /* best-effort */ }
+}
+
+async function getMailpitOtp(email: string, timeoutMs = 30_000): Promise<string | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const listRes = await fetch(
+        `${MAILPIT_URL}/api/v1/messages?query=${encodeURIComponent(`to:${email}`)}`
+      );
+      if (listRes.ok) {
+        const data = (await listRes.json()) as { messages?: Array<{ ID: string }> };
+        const msgs = data.messages ?? [];
+        if (msgs.length > 0) {
+          const msgRes = await fetch(`${MAILPIT_URL}/api/v1/message/${msgs[0].ID}`);
+          if (msgRes.ok) {
+            const msg = (await msgRes.json()) as { HTML: string; Text: string };
+            const fullContent = (msg.HTML ?? "") + (msg.Text ?? "");
+            const match = fullContent.match(/\b(\d{6})\b/);
+            if (match) return match[1];
+          }
+        }
+      }
+    } catch { /* retry */ }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  return null;
+}
+
+async function deleteHandleReservation(handle: string): Promise<void> {
+  try {
+    await fetch(
+      `${SUPABASE_URL}/rest/v1/handle_reservations?handle=eq.${encodeURIComponent(handle)}`,
+      {
+        method: "DELETE",
+        headers: {
+          apikey: SERVICE_ROLE_KEY,
+          Authorization: `Bearer ${SERVICE_ROLE_KEY}`,
+          Prefer: "return=minimal",
+        },
+      }
+    );
+  } catch { /* best-effort */ }
+}
+
+// ---------------------------------------------------------------------------
+// Hooks
+// ---------------------------------------------------------------------------
+
+test.beforeAll(async () => {
+  await clearMailpit(EMAIL);
+  await deleteHandleReservation(HANDLE);
+});
+
+test.afterAll(async () => {
+  await deleteHandleReservation(HANDLE);
+  await clearMailpit(EMAIL);
+});
+
+// ---------------------------------------------------------------------------
+// S5 — tier step CTA lands directly on /app dashboard, no intermediate UI
+// Covers: issue tadaify-app#190 Bug #4, DEC-366=A
+// ---------------------------------------------------------------------------
+
+test(
+  "S5 — tier step CTA lands directly on /app dashboard, no intermediate UI",
+  async ({ page }) => {
+    // ── Step 1: Register a new user ────────────────────────────────────────
+    await page.goto("/register");
+
+    const handleInput = page.locator("#handle-input");
+    await handleInput.fill(HANDLE);
+
+    const availability = page.locator("#handle-availability");
+    await expect(availability).toContainText("Available!", { timeout: 8_000 });
+
+    await page.getByRole("button", { name: /continue/i }).first().click();
+    await page.getByRole("button", { name: /continue with email/i }).click();
+
+    const emailInput = page.locator("#email-input");
+    await emailInput.fill(EMAIL);
+    await page.getByRole("button", { name: /send.*code/i }).click();
+
+    await expect(page.getByRole("heading", { name: /check your email/i })).toBeVisible({ timeout: 15_000 });
+
+    const signupOtp = await getMailpitOtp(EMAIL, 30_000);
+    expect(signupOtp).not.toBeNull();
+
+    // Enter OTP digits
+    const otpInputs = page.getByRole("group", { name: /verification code/i }).getByRole("textbox");
+    for (let i = 0; i < 6; i++) {
+      await otpInputs.nth(i).fill(signupOtp![i]);
+    }
+
+    // Continue past OTP step → lands on onboarding tier selector
+    await expect(page.getByRole("button", { name: /continue/i }).last()).toBeEnabled({ timeout: 10_000 });
+    await page.getByRole("button", { name: /continue/i }).last().click();
+
+    // Wait for onboarding route
+    await expect(page).toHaveURL(/\/onboarding/, { timeout: 15_000 });
+
+    // ── Step 2: Navigate through onboarding to the tier step ──────────────
+    // The onboarding flow may have multiple steps. Walk through them until
+    // we reach the tier selection step (which has the final CTA button).
+    // We keep clicking "Continue" / "Next" buttons until we see the tier CTA.
+    let reachedTierStep = false;
+    for (let attempt = 0; attempt < 10; attempt++) {
+      const url = page.url();
+
+      // Check if we're on the tier step (has the "Take me to my dashboard" button)
+      const ctaButton = page.getByRole("button", { name: /take me to my dashboard/i });
+      const ctaVisible = await ctaButton.isVisible().catch(() => false);
+      if (ctaVisible) {
+        reachedTierStep = true;
+        break;
+      }
+
+      // Check if we already landed on /app (onboarding skipped or very short)
+      if (/\/app(\?|$|#|\/)/i.test(url)) {
+        // Onboarding was skipped entirely — that's fine for this test
+        // We can't test the button but /app is correct
+        reachedTierStep = false;
+        break;
+      }
+
+      // Try clicking any Continue/Next/Select button to advance
+      const advanceBtn = page
+        .getByRole("button", { name: /continue|next|select|free|starter|creator/i })
+        .first();
+      const btnVisible = await advanceBtn.isVisible({ timeout: 2_000 }).catch(() => false);
+      if (btnVisible) {
+        await advanceBtn.click();
+        await page.waitForTimeout(500);
+      } else {
+        // No advance button found — might already be on tier step or stuck
+        break;
+      }
+    }
+
+    // ── Step 3: If we reached the tier step, click the CTA ─────────────────
+    if (reachedTierStep) {
+      const ctaButton = page.getByRole("button", { name: /take me to my dashboard/i });
+      await expect(ctaButton).toBeVisible({ timeout: 5_000 });
+
+      // Regression-lock: old button texts must NOT be present
+      await expect(
+        page.getByRole("button", { name: /take me to my page/i })
+      ).not.toBeVisible();
+      await expect(
+        page.getByRole("button", { name: /go to dashboard/i })
+      ).not.toBeVisible();
+
+      await ctaButton.click();
+    }
+
+    // ── Step 4: Assert land on /app, NOT /onboarding/complete ──────────────
+    await expect(page).toHaveURL(/\/app(\?|$|#)/, { timeout: 15_000 });
+
+    // Assert page has dashboard markers
+    await expect(page.locator("aside")).toBeVisible({ timeout: 5_000 });
+
+    // Regression-lock: must NOT land on /onboarding/complete (which had celebration UI)
+    expect(page.url()).not.toMatch(/\/onboarding\/complete/);
+
+    // Regression-lock: must NOT show celebration screen copy
+    const bodyText = await page.locator("body").innerText();
+    expect(bodyText).not.toMatch(/tada!/i);
+    expect(bodyText).not.toMatch(/your page is being set up/i);
+
+    // Regression-lock: must NOT show old onboarding complete copy
+    expect(bodyText).not.toMatch(/take me to my page/i);
+    expect(bodyText).not.toMatch(/go to dashboard/i);
+
+    // Regression-lock: must NOT be a 404
+    expect(bodyText).not.toMatch(/404/i);
+    expect(bodyText).not.toMatch(/not found/i);
+  }
+);

--- a/e2e/register-handle-taken-smart-alternatives.spec.ts
+++ b/e2e/register-handle-taken-smart-alternatives.spec.ts
@@ -38,19 +38,22 @@ const TAKEN_HANDLE = "t190s1taken";
 // ---------------------------------------------------------------------------
 
 async function reserveHandle(handle: string): Promise<void> {
-  try {
-    await fetch(`${SUPABASE_URL}/rest/v1/handle_reservations`, {
-      method: "POST",
-      headers: {
-        apikey: SERVICE_ROLE_KEY,
-        Authorization: `Bearer ${SERVICE_ROLE_KEY}`,
-        "Content-Type": "application/json",
-        Prefer: "resolution=merge-duplicates",
-      },
-      body: JSON.stringify({ handle, status: "reserved" }),
-    });
-  } catch {
-    // best-effort
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/handle_reservations`, {
+    method: "POST",
+    headers: {
+      apikey: SERVICE_ROLE_KEY,
+      Authorization: `Bearer ${SERVICE_ROLE_KEY}`,
+      "Content-Type": "application/json",
+      Prefer: "resolution=merge-duplicates",
+    },
+    body: JSON.stringify({
+      handle,
+      expires_at: new Date(Date.now() + 10 * 60_000).toISOString(),
+    }),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`reserveHandle failed (${res.status}): ${body}`);
   }
 }
 

--- a/e2e/register-handle-taken-smart-alternatives.spec.ts
+++ b/e2e/register-handle-taken-smart-alternatives.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * S1 (issue tadaify-app#190 Bug #1, DEC-363=A)
+ *
+ * "taken handle shows new copy + 3 clickable chips that auto-fill handle on click"
+ *
+ * Before fix:
+ *   - Taken handle showed "× Taken — someone beat you to it." (no suggestions)
+ *
+ * After fix (DEC-363=A):
+ *   - Taken handle shows "✦ Already taken. Try: <chip1> <chip2> <chip3>"
+ *   - Chips are clickable — clicking auto-fills the handle input
+ *   - After chip click, availability check re-triggers (green / taken)
+ *
+ * Prerequisites:
+ *   - `supabase start` + seed with a reserved handle for this spec
+ *   - `npm run dev` (App: http://localhost:5173)
+ *
+ * Run: npx playwright test e2e/register-handle-taken-smart-alternatives.spec.ts
+ */
+
+import { test, expect } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const SUPABASE_URL = process.env.SUPABASE_URL ?? "http://127.0.0.1:54351";
+const SERVICE_ROLE_KEY =
+  process.env.SUPABASE_SERVICE_ROLE_KEY ??
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU";
+
+// A handle that is permanently reserved for this test's taken-state scenario.
+// We pre-insert a reservation so the availability check returns taken=true.
+const TAKEN_HANDLE = "t190s1taken";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function reserveHandle(handle: string): Promise<void> {
+  try {
+    await fetch(`${SUPABASE_URL}/rest/v1/handle_reservations`, {
+      method: "POST",
+      headers: {
+        apikey: SERVICE_ROLE_KEY,
+        Authorization: `Bearer ${SERVICE_ROLE_KEY}`,
+        "Content-Type": "application/json",
+        Prefer: "resolution=merge-duplicates",
+      },
+      body: JSON.stringify({ handle, status: "reserved" }),
+    });
+  } catch {
+    // best-effort
+  }
+}
+
+async function deleteHandleReservation(handle: string): Promise<void> {
+  try {
+    await fetch(
+      `${SUPABASE_URL}/rest/v1/handle_reservations?handle=eq.${encodeURIComponent(handle)}`,
+      {
+        method: "DELETE",
+        headers: {
+          apikey: SERVICE_ROLE_KEY,
+          Authorization: `Bearer ${SERVICE_ROLE_KEY}`,
+          Prefer: "return=minimal",
+        },
+      }
+    );
+  } catch {
+    // best-effort
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hooks
+// ---------------------------------------------------------------------------
+
+test.beforeAll(async () => {
+  await reserveHandle(TAKEN_HANDLE);
+});
+
+test.afterAll(async () => {
+  await deleteHandleReservation(TAKEN_HANDLE);
+});
+
+// ---------------------------------------------------------------------------
+// S1 — taken handle shows new copy + 3 clickable chips (DEC-363=A)
+// Covers Bug #1, issue tadaify-app#190
+// ---------------------------------------------------------------------------
+
+test(
+  "S1 — taken handle shows new copy + 3 clickable chips that auto-fill handle on click",
+  async ({ page }) => {
+    await page.goto("/register");
+
+    // Fill a handle that is reserved / taken
+    const handleInput = page.locator("#handle-input");
+    await handleInput.fill(TAKEN_HANDLE);
+
+    // Wait for the availability check to complete
+    const availabilityStatus = page.locator("#handle-availability");
+
+    // Regression-lock: old copy must NOT appear
+    await expect(availabilityStatus).not.toContainText(/someone beat you to it/i, { timeout: 8_000 });
+    await expect(availabilityStatus).not.toContainText(/Taken —/i);
+
+    // New copy MUST appear (DEC-363=A)
+    await expect(availabilityStatus).toContainText("Already taken. Try:", { timeout: 8_000 });
+    await expect(availabilityStatus).toContainText("✦", { timeout: 5_000 });
+
+    // 3 clickable chip buttons MUST be rendered
+    const chips = availabilityStatus.locator("button");
+    await expect(chips).toHaveCount(3, { timeout: 5_000 });
+
+    // Each chip must have non-empty text (alternative handle suggestion)
+    for (const chip of await chips.all()) {
+      const text = await chip.innerText();
+      expect(text.trim().length).toBeGreaterThan(0);
+    }
+
+    // Click first chip → handle input MUST be auto-filled with chip text
+    const firstChip = chips.nth(0);
+    const chipText = (await firstChip.innerText()).trim();
+    await firstChip.click();
+
+    // Handle input value must now equal the chip text
+    await expect(handleInput).toHaveValue(chipText, { timeout: 3_000 });
+
+    // Availability check re-triggers after chip click — "Checking…" or green check
+    // (could be taken or available depending on test environment, but either is
+    // valid — just must not be blank or show the error copy anymore)
+    await expect(availabilityStatus).not.toContainText("Already taken. Try:", { timeout: 8_000 });
+  }
+);

--- a/supabase/templates/auth/identity-linked.html
+++ b/supabase/templates/auth/identity-linked.html
@@ -53,7 +53,8 @@
       <span class="wordmark"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span></span>
     </div>
     <div class="email-body">
-      <h1 class="greeting">Hey @{{ .Email }}</h1>
+      <!-- DEC-364=A: greet with @handle (looked up from profiles where identity-linked is triggered), not @email -->
+      <h1 class="greeting">Hey {{ if .Data.handle }}@{{ .Data.handle }}{{ else }}@creator{{ end }}</h1>
       <p class="sub">we linked your {{ .Provider }} account to your <span class="wordmark" style="font-size:15px;"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span><span class="wm-ify">.com</span></span> profile.</p>
 
       <div class="info-card">

--- a/supabase/templates/auth/identity-linked.txt
+++ b/supabase/templates/auth/identity-linked.txt
@@ -1,4 +1,4 @@
-Hey @{{ .Email }},
+Hey {{ if .Data.handle }}@{{ .Data.handle }}{{ else }}@creator{{ end }},
 
 We linked your {{ .Provider }} account to your tadaify.com profile.
 

--- a/supabase/templates/auth/otp-login.html
+++ b/supabase/templates/auth/otp-login.html
@@ -51,7 +51,8 @@
       <span class="wordmark"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span></span>
     </div>
     <div class="email-body">
-      <h1 class="greeting">Welcome back, @{{ .Email }}</h1>
+      <!-- DEC-364=A: greet with @handle (looked up from profiles in api.auth.login-otp.ts), not @email -->
+      <h1 class="greeting">Welcome back, {{ if .Data.handle }}@{{ .Data.handle }}{{ else }}@creator{{ end }}</h1>
       <p class="sub">signing you in to <span class="wordmark" style="font-size:15px;"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span><span class="wm-ify">.com</span></span> — type the code below to continue.</p>
 
       <div class="otp-card">

--- a/supabase/templates/auth/otp-login.txt
+++ b/supabase/templates/auth/otp-login.txt
@@ -1,4 +1,4 @@
-Welcome back, @{{ .Email }},
+Welcome back, {{ if .Data.handle }}@{{ .Data.handle }}{{ else }}@creator{{ end }},
 
 signing you in to tadaify.com - type the code below to continue.
 

--- a/supabase/templates/auth/otp-signup.html
+++ b/supabase/templates/auth/otp-signup.html
@@ -51,7 +51,8 @@
       <span class="wordmark"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span></span>
     </div>
     <div class="email-body">
-      <h1 class="greeting">Hey @{{ .Email }} 👋</h1>
+      <!-- DEC-364=A: greet with @handle (passed via data.handle in signup), not @email -->
+      <h1 class="greeting">Hey {{ if .Data.handle }}@{{ .Data.handle }}{{ else }}@creator{{ end }} 👋</h1>
       <p class="sub">welcome to <span class="wordmark" style="font-size:15px;"><span class="wm-ta">ta</span><span class="wm-da">da!</span><span class="wm-ify">ify</span><span class="wm-ify">.com</span></span> — one quick step to confirm your email.</p>
 
       <div class="otp-card">

--- a/supabase/templates/auth/otp-signup.txt
+++ b/supabase/templates/auth/otp-signup.txt
@@ -1,4 +1,4 @@
-Hey @{{ .Email }},
+Hey {{ if .Data.handle }}@{{ .Data.handle }}{{ else }}@creator{{ end }},
 
 welcome to tadaify.com - one quick step to confirm your email.
 

--- a/supabase/templates/auth/templates.test.mjs
+++ b/supabase/templates/auth/templates.test.mjs
@@ -174,6 +174,38 @@ describe("TR-tadaify-002 §1+§2 — OTP token present in .txt plain-text files"
   }
 });
 
+// --- DEC-364=A: .txt greeting uses @handle, not @email ---
+
+describe("DEC-364=A — .txt greeting uses handle placeholder, not @{{ .Email }}", () => {
+  const HANDLE_GREETING_TXT = ["otp-signup.txt", "otp-login.txt", "identity-linked.txt"];
+
+  for (const name of HANDLE_GREETING_TXT) {
+    it(`${name} greeting does NOT contain @{{ .Email }}`, () => {
+      const txt = read(name);
+      assert.ok(
+        !txt.includes("@{{ .Email }}"),
+        `${name} greeting must NOT use @{{ .Email }} — DEC-364=A requires @handle`
+      );
+    });
+
+    it(`${name} greeting contains .Data.handle placeholder`, () => {
+      const txt = read(name);
+      assert.ok(
+        txt.includes(".Data.handle"),
+        `${name} must use .Data.handle for greeting — DEC-364=A handle contract`
+      );
+    });
+
+    it(`${name} greeting contains @creator fallback`, () => {
+      const txt = read(name);
+      assert.ok(
+        txt.includes("@creator"),
+        `${name} must contain @creator fallback when handle is empty — DEC-364=A`
+      );
+    });
+  }
+});
+
 // --- welcome.html DEC-332=D semantics ---
 
 describe("DEC-332=D — welcome.html handle-claim semantics", () => {


### PR DESCRIPTION
## Summary

Fixes 4 bugs from the 2026-05-05 verification session (issue tadaify-app#190). Two P1 bugs (post-login/post-onboarding routing) and two P2 bugs (handle-taken UX, email template greetings). All 13 required tests ship in this PR (8 unit + 5 Playwright).

- **Bug #3 (P1):** `login.tsx` navigated to `/dashboard` after OTP verify — `/dashboard` route does not exist → 404. Fixed: `navigate("/app")`.
- **Bug #4 (P1):** Onboarding tier CTA redirected to `/onboarding/complete` (celebration screen). Fixed: `onboarding.tier.tsx` action redirects directly to `/app`; `onboarding.complete.tsx` rewritten as pure SSR redirect with no UI (DEC-366=A).
- **Bug #1 (P2):** Taken handle showed old copy "× Taken — someone beat you to it." with no suggestions. Fixed: shows "✦ Already taken. Try: <chip1> <chip2> <chip3>" via `generateAlternatives()` (DEC-363=A).
- **Bug #2 (P2):** OTP email templates greeted with `@email` instead of `@handle`. Fixed: templates use `{{ if .Data.handle }}@{{ .Data.handle }}{{ else }}@creator{{ end }}`; `api.auth.login-otp.ts` does profiles lookup via service-role key to inject `data.handle` (DEC-364=A).

## Business requirements implemented

- BR-001: Handle reservation and uniqueness — handle-taken UX now suggests alternatives (DEC-363=A)
- BR-011: OTP email personalisation — greet creator by handle, not email address (DEC-364=A)
- BR-015: Post-login routing — login OTP success lands on dashboard `/app` (DEC-307)
- BR-016: Post-onboarding routing — tier CTA lands directly on `/app`, no intermediate screen (DEC-366=A)

## Technical requirements introduced or relied on

- TR-021: React Router 7 resource route pattern — `onboarding.complete.tsx` is now a pure SSR redirect handler (no default export, no UI render)
- TR-015: Test traceability — every new test file carries `// Covers: BR-XXX` comments mapping to the bugs above

## Acceptance criteria from issue

✅ Bug #1: Taken handle shows "✦ Already taken. Try:" copy + 3 clickable chip buttons that auto-fill the handle input on click  
✅ Bug #2: Signup OTP email greets `@{handle}` not `@{email}`; login OTP email greets `@{handle}` looked up from profiles  
✅ Bug #3: Login OTP success navigates to `/app` — `navigate("/dashboard")` is absent from `login.tsx`  
✅ Bug #4: Tier step CTA text is "Take me to my dashboard →"; action redirects directly to `/app`; `onboarding.complete.tsx` renders no UI  

## Test plan

### Unit tests shipped in this PR

- **U1**: `app/routes/register.test.tsx`
  - "source contains generateAlternatives import"
  - "handleAlternatives state is initialized as empty array"
  - "checkHandleAvailability sets handleError to 'Already taken. Try:' on taken"
  - "setHandleAlternatives is called with generateAlternatives result on taken"
  - "handleAlternatives reset to [] on new handle input change"
  - "handle-availability renders chips for each alternative"
  - "chip button onClick calls onAlternativeClick with chip text"

- **U2**: `app/routes/api.auth.signup.test.ts`
  - "signup OTP call includes data.handle from the store when available"
  - "signup OTP call omits data key when no handle in store"

- **U3**: `app/routes/api.auth.login-otp.test.ts`
  - "looks up handle from profiles and passes data.handle in OTP call"
  - "falls back gracefully when profiles lookup fails — still sends OTP"

- **U4**: `app/routes/api.auth.login-otp.test.ts`
  - "identity-linked.html template uses .Data.handle conditional"

- **U5**: `app/routes/login.test.tsx`
  - "source contains navigate('/app') for OTP verify success"
  - "source does NOT contain navigate('/dashboard') (regression-lock — /dashboard 404s)"
  - "DEC-307 comment still present but references /app as canonical route"

- **U6**: `app/routes/onboarding.tier.test.ts`
  - "source contains 'Take me to my dashboard →'"
  - "source does NOT contain 'Take me to my page' (old CTA text — regression-lock)"

- **U7**: `app/routes/onboarding.tier.test.ts`
  - "action() returns a redirect to /app, not /onboarding/complete (DEC-366=A)"

- **U8a/U8b**: `app/routes/onboarding.complete.test.ts`
  - "loader() returns a redirect to /app (302 Response, not page data)"
  - "action() returns a redirect to /app (302 Response)"
  - "no default export — onboarding.complete.tsx renders no UI"

### Playwright specs shipped in this PR

- **S1**: `e2e/register-handle-taken-smart-alternatives.spec.ts`
  - "S1 — taken handle shows new copy + 3 clickable chips that auto-fill handle on click"

- **S2**: `e2e/email-templates-show-handle.spec.ts` (describe: S2)
  - "signup OTP email greets @{handle}, not @{email}"

- **S3**: `e2e/email-templates-show-handle.spec.ts` (describe: S3)
  - "login OTP email greets @{handle} looked up from profile"

- **S4**: `e2e/login-redirect-to-app.spec.ts`
  - "S4 — login OTP success lands on /app dashboard, not 404"

- **S5**: `e2e/post-onboarding-direct-to-dashboard.spec.ts`
  - "S5 — tier step CTA lands directly on /app dashboard, no intermediate UI"

### Coverage cross-reference

Each U<N>/S<N> above maps 1:1 to the same ID in issue tadaify-app#190 `## Unit test plan` / `## Playwright test plan` sections.

### Manual verification

- Run `npx vitest run` in the worktree — 520 tests pass, 0 failures.
- For Playwright: `supabase start` + `npm run dev` + `npx playwright test e2e/`.

## Mockup

No UI change requiring a new mockup — bug fixes only. Handle-taken chips (Bug #1) align with DEC-363=A visual spec already accepted.

## Rollback

```bash
git revert 58bed63
```

No DB migrations in this PR — rollback is a single git revert + redeploy. Email template changes are in `supabase/templates/auth/` and take effect on next `supabase db push` / Edge Function redeploy.
