### PR TITLE
chore: track .claude/launch.json (DEC-384=B cleanup #2)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "tadaify-app",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 5173
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Track `.claude/launch.json` (preview/dev-server registry). Last untracked file in `.claude/` surface — `.claude/{hooks/*, settings.json}` already tracked. Caught by user audit 2026-05-06; DEC-384=B authorized sequential cleanup.

## Business requirements implemented

- No new BR. Cleanup of tracking gap.

## Technical requirements introduced or relied on

- No new TR. Reaffirms shared-registry convention from orchestrator templates (PR claude-project-orchestrator#235).

## Acceptance criteria

- [x] `.claude/launch.json` tracked (content unchanged: port 5173, npm run dev launch)
- [x] `git ls-files .claude/` includes launch.json
- [x] No content modifications

## Test plan

No automated tests — chore PR. Verification:

```bash
git ls-files .claude/launch.json   # must output the file
git status --short                  # no '??' on .claude/
```

### Manual verification
- Open VS Code / launcher with this repo; verify launch.json appears in launch configurations dropdown.

## Mockup

No UI change — mockup not required.

## Rollback

`git revert <merge-sha>` removes file from index. File would remain on disk untracked. No runtime impact.

## Refs

- DEC-384=B (cleanup ownership) — locked 2026-05-06
- Memory rule: `feedback_no_untracked_files_in_repos.md` (locked 2026-05-06)
- Sibling cleanup PR: claude-project-orchestrator#235

🤖 Generated with [Claude Code](https://claude.com/claude-code)
