### PR TITLE
feat(blocks): icon picker — Lucide + Simple Icons (#205, DEC-378=A)

### DIFF
--- a/app/components/blocks/IconPicker.test.tsx
+++ b/app/components/blocks/IconPicker.test.tsx
@@ -4,10 +4,10 @@
  * Tests pure exported logic and component contracts.
  * Runs in Node environment (no JSDOM) — mirrors project pattern.
  * DOM rendering behavior (popover open, search, keyboard nav, onChange) is
- * tested in Playwright (S1–S6).
+ * tested in Playwright (S1–S7).
  *
  * Story: tadaify-app#205 F-BLOCK-INFRA-ICON-PICKER-001
- * Covers: U3 (6 cases)
+ * Covers: U3 (9 cases — 3 new cases for Codex P2 F1 fix)
  */
 
 import { describe, it, expect } from "vitest";
@@ -28,10 +28,11 @@ describe("IconPicker — U3-1: component contract", () => {
     expect(typeof IconPicker).toBe("function");
   });
 
-  it("accepts value=null + onChange without error (prop contract)", () => {
+  it("accepts value=null + onChange(id: string | null) without error (prop contract)", () => {
+    // F1 fix (Codex P2): onChange accepts null — no cast needed
     const props = {
       value: null,
-      onChange: (_id: string) => {},
+      onChange: (_id: string | null) => {},
     };
     expect(() => {
       const { value, onChange } = props;
@@ -43,13 +44,52 @@ describe("IconPicker — U3-1: component contract", () => {
   it("accepts value='lucide:link' + onChange without error", () => {
     const props = {
       value: "lucide:link",
-      onChange: (_id: string) => {},
+      onChange: (_id: string | null) => {},
     };
     expect(() => {
       const { value, onChange } = props;
       void value;
       void onChange;
     }).not.toThrow();
+  });
+
+  // F1 fix (Codex P2): onChange must accept null (clear action) without TypeScript cast
+  it("onChange typed as (id: string | null) => void — null is a valid argument", () => {
+    const received: (string | null)[] = [];
+    const onChange = (id: string | null) => received.push(id);
+
+    // Simulate clear action: call with null — should work without cast
+    onChange(null);
+    expect(received).toEqual([null]);
+
+    // Simulate select action: call with string
+    onChange("lucide:link");
+    expect(received).toEqual([null, "lucide:link"]);
+  });
+
+  // F1 fix (Codex P2): clear button must not be nested inside trigger button
+  it("clear button logic: onChange(null) called, does NOT fire the trigger (DOM contract verified in S7)", () => {
+    // This test verifies the handler function logic — the actual DOM structure
+    // (clear button as sibling of trigger, not nested) is verified in Playwright S7.
+    let lastValue: string | null = "lucide:link";
+    const onChange = (id: string | null) => { lastValue = id; };
+
+    // Simulate clear button click handler
+    const clearHandler = () => onChange(null);
+    clearHandler();
+
+    expect(lastValue).toBeNull();
+  });
+
+  // F1 fix (Codex P2): verify onChange type allows null without TypeScript error at call site
+  it("onChange prop type: (id: string | null) => void — passing null is type-safe", () => {
+    // If this file compiles, the type is correct (no cast needed in component)
+    type OnChange = (id: string | null) => void;
+    const fn: OnChange = (_id) => {};
+    // These must both compile without error:
+    fn(null);
+    fn("lucide:heart");
+    expect(true).toBe(true); // compile-time check
   });
 });
 

--- a/app/components/blocks/IconPicker.test.tsx
+++ b/app/components/blocks/IconPicker.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * Unit tests — IconPicker component (U3)
+ *
+ * Tests pure exported logic and component contracts.
+ * Runs in Node environment (no JSDOM) — mirrors project pattern.
+ * DOM rendering behavior (popover open, search, keyboard nav, onChange) is
+ * tested in Playwright (S1–S6).
+ *
+ * Story: tadaify-app#205 F-BLOCK-INFRA-ICON-PICKER-001
+ * Covers: U3 (6 cases)
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  IconPicker,
+  SEARCH_INPUT_LABEL,
+  TRIGGER_PLACEHOLDER,
+  EMPTY_SEARCH_HINT,
+  EMPTY_SEARCH_SUB,
+} from "./IconPicker";
+
+// ---------------------------------------------------------------------------
+// U3-1: component contract (function signature)
+// ---------------------------------------------------------------------------
+
+describe("IconPicker — U3-1: component contract", () => {
+  it("IconPicker is a callable function (component)", () => {
+    expect(typeof IconPicker).toBe("function");
+  });
+
+  it("accepts value=null + onChange without error (prop contract)", () => {
+    const props = {
+      value: null,
+      onChange: (_id: string) => {},
+    };
+    expect(() => {
+      const { value, onChange } = props;
+      void value;
+      void onChange;
+    }).not.toThrow();
+  });
+
+  it("accepts value='lucide:link' + onChange without error", () => {
+    const props = {
+      value: "lucide:link",
+      onChange: (_id: string) => {},
+    };
+    expect(() => {
+      const { value, onChange } = props;
+      void value;
+      void onChange;
+    }).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// U3-2: exported ARIA/copy constants for open=true state
+// ---------------------------------------------------------------------------
+
+describe("IconPicker — U3-2: exported string constants (ARIA + copy)", () => {
+  it("SEARCH_INPUT_LABEL is 'Search icons…'", () => {
+    expect(SEARCH_INPUT_LABEL).toBe("Search icons…");
+  });
+
+  it("TRIGGER_PLACEHOLDER is 'Pick icon'", () => {
+    expect(TRIGGER_PLACEHOLDER).toBe("Pick icon");
+  });
+
+  it("EMPTY_SEARCH_HINT is 'No icons match'", () => {
+    expect(EMPTY_SEARCH_HINT).toBe("No icons match");
+  });
+
+  it("EMPTY_SEARCH_SUB is a non-empty string", () => {
+    expect(typeof EMPTY_SEARCH_SUB).toBe("string");
+    expect(EMPTY_SEARCH_SUB.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// U3-3: popover closed by default (logic proxy)
+// ---------------------------------------------------------------------------
+
+describe("IconPicker — U3-3: initial closed state contract", () => {
+  it("component is a function (Radix Popover.Root manages open state — DOM assertion in S1)", () => {
+    // Radix Popover.Root renders nothing when open=false (portal guard).
+    // We can't meaningfully test DOM state without jsdom; this test confirms
+    // the component shape exists for Playwright (S1) to validate the DOM.
+    expect(typeof IconPicker).toBe("function");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// U3-4: search filter integration
+// ---------------------------------------------------------------------------
+
+describe("IconPicker — U3-4: filterIcons integration (via icon-search)", () => {
+  it("filterIcons used by IconPicker is importable and callable from same module path", async () => {
+    // Verify the filterIcons import used by IconPicker works correctly
+    const { filterIcons } = await import("~/lib/icon-search");
+    const { ICON_CATALOG } = await import("~/lib/icons-catalog");
+    const result = filterIcons(ICON_CATALOG, "spotify", "all");
+    expect(result.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// U3-5: category tabs config
+// ---------------------------------------------------------------------------
+
+describe("IconPicker — U3-5: 7 category tabs are defined", () => {
+  it("ICON_CATEGORIES has 7 entries", async () => {
+    const { ICON_CATEGORIES } = await import("~/lib/icons-catalog");
+    expect(ICON_CATEGORIES).toHaveLength(7);
+  });
+
+  it("category list matches expected tab values", async () => {
+    const { ICON_CATEGORIES } = await import("~/lib/icons-catalog");
+    expect(ICON_CATEGORIES).toContain("popular");
+    expect(ICON_CATEGORIES).toContain("social");
+    expect(ICON_CATEGORIES).toContain("music-video");
+    expect(ICON_CATEGORIES).toContain("shop");
+    expect(ICON_CATEGORIES).toContain("communication");
+    expect(ICON_CATEGORIES).toContain("content");
+    expect(ICON_CATEGORIES).toContain("generic");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// U3-6: Esc close + keyboard nav (Radix handles Esc; DOM assertions in S5)
+// ---------------------------------------------------------------------------
+
+describe("IconPicker — U3-6: keyboard nav contract (DOM in Playwright S5)", () => {
+  it("SEARCH_INPUT_LABEL is a non-empty string (used as label for a11y)", () => {
+    // Radix Popover handles Esc key natively.
+    // Arrow keys in grid are handled by handleGridKeyDown inside the component.
+    // Actual DOM keyboard assertions live in Playwright S5.
+    expect(SEARCH_INPUT_LABEL.length).toBeGreaterThan(0);
+  });
+});

--- a/app/components/blocks/IconPicker.tsx
+++ b/app/components/blocks/IconPicker.tsx
@@ -105,7 +105,7 @@ interface IconTileProps {
   entry: IconEntry;
   isSelected: boolean;
   onSelect: (id: string) => void;
-  tileRef?: React.RefObject<HTMLButtonElement>;
+  tileRef?: React.RefObject<HTMLButtonElement | null>;
 }
 
 function IconTile({ entry, isSelected, onSelect, tileRef }: IconTileProps) {

--- a/app/components/blocks/IconPicker.tsx
+++ b/app/components/blocks/IconPicker.tsx
@@ -1,0 +1,438 @@
+/**
+ * IconPicker — Searchable icon picker dropdown with category tabs.
+ *
+ * Controlled component:
+ *   <IconPicker value={iconId | null} onChange={(id) => ...} />
+ *
+ * Uses Radix Popover (same vendor family as Radix Dialog per TR-tadaify-008,
+ * DEC-375=B). Popover stacks above modal dialogs (z-index 60).
+ *
+ * Visual contract: mockups/tadaify-mvp/app-block-editor.html — icon picker
+ * section (rendered when icon field is clicked in Link block editor context).
+ *
+ * Responsive grid (3-viewport per TR-tadaify-008):
+ *   - Desktop ≥1024px : 6 columns
+ *   - Tablet 600–1023px: 5 columns (max-[1023px]:grid-cols-5)
+ *   - Mobile <600px    : 4 columns (max-[599px]:grid-cols-4)
+ *   NOTE: DO NOT use max-[860px] — banned per TR-tadaify-008.
+ *
+ * Story: tadaify-app#205 F-BLOCK-INFRA-ICON-PICKER-001
+ * Covers: BR-ICON-PICKER-001..006, AC items 5–10, ECN-ICON-PICKER-01..10
+ * Unit tests: app/components/blocks/IconPicker.test.tsx (U3)
+ */
+
+import * as Popover from "@radix-ui/react-popover";
+import { useMemo, useRef, useState } from "react";
+
+import {
+  ICON_CATALOG,
+  ICON_CATEGORIES,
+  type IconCategory,
+  type IconEntry,
+} from "~/lib/icons-catalog";
+import {
+  filterIcons,
+  ICON_CATEGORY_ALL,
+  type IconCategoryFilterValue,
+} from "~/lib/icon-search";
+import { renderIcon } from "~/lib/icon-resolve";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Search debounce delay in ms (AC item 7: filters within 50ms). */
+const SEARCH_DEBOUNCE_MS = 50;
+
+/** Popover panel dimensions. */
+const PANEL_WIDTH = "360px";
+const PANEL_MAX_HEIGHT = "400px";
+
+/** Exported for unit tests. */
+export const SEARCH_INPUT_LABEL = "Search icons…";
+export const TRIGGER_PLACEHOLDER = "Pick icon";
+export const EMPTY_SEARCH_HINT = "No icons match";
+export const EMPTY_SEARCH_SUB = "Try a different search or request more icons via feedback.";
+
+// ---------------------------------------------------------------------------
+// Tab config
+// ---------------------------------------------------------------------------
+
+const CATEGORY_TABS: { value: IconCategoryFilterValue; label: string }[] = [
+  { value: ICON_CATEGORY_ALL, label: "All" },
+  { value: "popular", label: "Popular" },
+  { value: "social", label: "Social" },
+  { value: "music-video", label: "Music & Video" },
+  { value: "shop", label: "Shop" },
+  { value: "communication", label: "Communication" },
+  { value: "content", label: "Content" },
+  { value: "generic", label: "Generic" },
+] as const;
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface IconPickerProps {
+  /**
+   * Currently selected icon identifier, or null for no selection.
+   * Format: "lucide:<name>" | "simple-icons:<slug>"
+   */
+  value: string | null;
+  /**
+   * Fired when the user clicks an icon tile.
+   * Passes the selected icon identifier string.
+   */
+  onChange: (id: string) => void;
+  /**
+   * Optional: allow clearing the selection.
+   * When true, a "×" button appears on the trigger and onChange(null) is fired.
+   * Default: false
+   */
+  clearable?: boolean;
+  /**
+   * Disable the picker entirely (shows trigger as non-interactive).
+   * Default: false
+   */
+  disabled?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// IconTile sub-component
+// ---------------------------------------------------------------------------
+
+interface IconTileProps {
+  entry: IconEntry;
+  isSelected: boolean;
+  onSelect: (id: string) => void;
+  tileRef?: React.RefObject<HTMLButtonElement>;
+}
+
+function IconTile({ entry, isSelected, onSelect, tileRef }: IconTileProps) {
+  return (
+    <button
+      ref={tileRef}
+      type="button"
+      role="option"
+      aria-selected={isSelected}
+      aria-label={entry.name}
+      data-testid={`icon-tile-${entry.id}`}
+      data-icon-id={entry.id}
+      data-icon-source={entry.source}
+      className={[
+        "icon-tile",
+        "flex flex-col items-center justify-center gap-[4px]",
+        "w-full aspect-square rounded-[8px] p-[6px]",
+        "border transition-colors duration-100 cursor-pointer outline-none",
+        "focus-visible:ring-2 focus-visible:ring-[var(--brand-primary)] focus-visible:ring-offset-1",
+        "text-[9px] leading-tight text-center",
+        isSelected
+          ? "border-[var(--brand-primary)] bg-[color-mix(in_srgb,var(--brand-primary)_10%,transparent)] text-[var(--brand-primary)]"
+          : "border-[var(--border)] bg-[var(--bg-elevated)] text-[var(--fg-muted)] hover:border-[var(--brand-primary)] hover:bg-indigo-50/40",
+      ]
+        .filter(Boolean)
+        .join(" ")}
+      onClick={() => onSelect(entry.id)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onSelect(entry.id);
+        }
+      }}
+    >
+      <span className="flex items-center justify-center w-[20px] h-[20px] flex-shrink-0">
+        {renderIcon(entry.id, { size: 18 })}
+      </span>
+      <span className="w-full truncate">{entry.name}</span>
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// IconPicker component
+// ---------------------------------------------------------------------------
+
+export function IconPicker({ value, onChange, clearable = false, disabled = false }: IconPickerProps) {
+  const [open, setOpen] = useState(false);
+  const [rawQuery, setRawQuery] = useState("");
+  const [selectedCategory, setSelectedCategory] = useState<IconCategoryFilterValue>(ICON_CATEGORY_ALL);
+  const [focusedIndex, setFocusedIndex] = useState(0);
+
+  const searchRef = useRef<HTMLInputElement>(null);
+  const firstTileRef = useRef<HTMLButtonElement>(null);
+
+  // Debounced query (50ms per AC item 7, ECN-ICON-PICKER-02)
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleQueryChange = (q: string) => {
+    setRawQuery(q);
+    if (debounceTimer.current) clearTimeout(debounceTimer.current);
+    debounceTimer.current = setTimeout(() => {
+      setDebouncedQuery(q);
+      setFocusedIndex(0);
+    }, SEARCH_DEBOUNCE_MS);
+  };
+
+  // Filtered catalog (memoized — trivial at ~100 entries per TR perf note)
+  const filtered = useMemo(
+    () => filterIcons(ICON_CATALOG, debouncedQuery, selectedCategory),
+    [debouncedQuery, selectedCategory],
+  );
+
+  // Auto-focus search when popover opens
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (nextOpen) {
+      setRawQuery("");
+      setDebouncedQuery("");
+      setFocusedIndex(0);
+      // Radix Popover triggers focus to content on mount; redirect to search
+      requestAnimationFrame(() => {
+        searchRef.current?.focus();
+      });
+    }
+  };
+
+  const handleSelect = (id: string) => {
+    onChange(id);
+    setOpen(false);
+  };
+
+  // Keyboard nav in grid (arrow keys, Enter)
+  const handleGridKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (filtered.length === 0) return;
+
+    // Determine number of columns based on viewport approximation.
+    // We use a best-effort approach: read from grid style.
+    // Default: 6 cols for desktop
+    const grid = e.currentTarget;
+    const cols = Math.max(1, Math.round(grid.clientWidth / (grid.clientWidth / 6)));
+
+    if (e.key === "ArrowRight") {
+      e.preventDefault();
+      setFocusedIndex((i) => Math.min(i + 1, filtered.length - 1));
+    } else if (e.key === "ArrowLeft") {
+      e.preventDefault();
+      setFocusedIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setFocusedIndex((i) => Math.min(i + cols, filtered.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setFocusedIndex((i) => {
+        const next = i - cols;
+        if (next < 0) {
+          // Move focus back to search
+          searchRef.current?.focus();
+          return 0;
+        }
+        return next;
+      });
+    } else if (e.key === "Enter" && focusedIndex >= 0 && focusedIndex < filtered.length) {
+      e.preventDefault();
+      handleSelect(filtered[focusedIndex].id);
+    }
+  };
+
+  // Find the currently selected entry for trigger display
+  const selectedEntry = value
+    ? ICON_CATALOG.find((e) => e.id === value) ?? null
+    : null;
+
+  return (
+    <Popover.Root open={open} onOpenChange={handleOpenChange}>
+      {/* ---- Trigger ---- */}
+      <Popover.Trigger asChild>
+        <button
+          type="button"
+          aria-label="Open icon picker"
+          data-testid="icon-picker-trigger"
+          disabled={disabled}
+          className={[
+            "icon-picker-trigger",
+            "inline-flex items-center gap-[8px]",
+            "px-[12px] py-[8px] rounded-[8px]",
+            "border border-[var(--border)] bg-[var(--bg-elevated)]",
+            "text-sm font-medium transition-colors duration-100",
+            "outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-primary)]",
+            disabled
+              ? "opacity-50 cursor-not-allowed"
+              : "cursor-pointer hover:border-[var(--brand-primary)]",
+            open ? "border-[var(--brand-primary)]" : "",
+          ]
+            .filter(Boolean)
+            .join(" ")}
+        >
+          {/* Selected icon preview or placeholder */}
+          {selectedEntry ? (
+            <>
+              <span className="flex items-center justify-center w-[18px] h-[18px]" data-testid="icon-picker-selected-preview">
+                {renderIcon(selectedEntry.id, { size: 18 })}
+              </span>
+              <span className="text-[var(--fg)] truncate max-w-[140px]" data-testid="icon-picker-selected-name">
+                {selectedEntry.name}
+              </span>
+            </>
+          ) : (
+            <span className="text-[var(--fg-muted)]" data-testid="icon-picker-placeholder">
+              {TRIGGER_PLACEHOLDER}
+            </span>
+          )}
+
+          {/* Caret */}
+          <svg
+            className={[
+              "ml-auto w-[14px] h-[14px] text-[var(--fg-muted)] flex-shrink-0 transition-transform duration-150",
+              open ? "rotate-180" : "",
+            ].join(" ")}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            aria-hidden="true"
+          >
+            <path d="M6 9l6 6 6-6" />
+          </svg>
+
+          {/* Clear button (when clearable + value set) */}
+          {clearable && value && (
+            <button
+              type="button"
+              aria-label="Clear icon"
+              data-testid="icon-picker-clear"
+              className="ml-[2px] w-[16px] h-[16px] rounded-full flex items-center justify-center text-[var(--fg-muted)] hover:text-[var(--fg)] transition-colors"
+              onClick={(e) => {
+                e.stopPropagation();
+                onChange(null as unknown as string); // Clear: pass null to parent
+              }}
+            >
+              ×
+            </button>
+          )}
+        </button>
+      </Popover.Trigger>
+
+      {/* ---- Popover panel ---- */}
+      <Popover.Portal>
+        <Popover.Content
+          sideOffset={6}
+          align="start"
+          avoidCollisions
+          data-testid="icon-picker-panel"
+          className="icon-picker-panel z-[60] rounded-[12px] border border-[var(--border)] bg-[var(--bg-elevated)] shadow-xl outline-none"
+          style={{ width: PANEL_WIDTH }}
+          onOpenAutoFocus={(e) => {
+            // Prevent Radix from auto-focusing the first button; we focus search instead
+            e.preventDefault();
+          }}
+        >
+          {/* ---- Search input ---- */}
+          <div className="p-[10px] border-b border-[var(--border)]">
+            <label className="sr-only" htmlFor="icon-picker-search">
+              {SEARCH_INPUT_LABEL}
+            </label>
+            <div className="relative">
+              <span className="absolute left-[10px] top-1/2 -translate-y-1/2 text-[var(--fg-muted)] pointer-events-none">
+                {/* Search icon */}
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+                  <circle cx="11" cy="11" r="8" />
+                  <path d="M21 21l-4.35-4.35" />
+                </svg>
+              </span>
+              <input
+                ref={searchRef}
+                id="icon-picker-search"
+                type="text"
+                autoComplete="off"
+                placeholder={SEARCH_INPUT_LABEL}
+                value={rawQuery}
+                onChange={(e) => handleQueryChange(e.target.value)}
+                data-testid="icon-picker-search"
+                className="w-full pl-[32px] pr-[10px] py-[7px] rounded-[6px] border border-[var(--border)] bg-[var(--bg)] text-sm text-[var(--fg)] placeholder:text-[var(--fg-muted)] outline-none focus:border-[var(--brand-primary)] focus:ring-1 focus:ring-[var(--brand-primary)]"
+                onKeyDown={(e) => {
+                  if (e.key === "ArrowDown") {
+                    e.preventDefault();
+                    // Move focus into the grid
+                    firstTileRef.current?.focus();
+                    setFocusedIndex(0);
+                  }
+                }}
+              />
+            </div>
+          </div>
+
+          {/* ---- Category tabs ---- */}
+          <div
+            role="tablist"
+            aria-label="Icon categories"
+            className="flex gap-[2px] p-[8px] pb-0 overflow-x-auto scrollbar-hide"
+            data-testid="icon-picker-tabs"
+          >
+            {CATEGORY_TABS.map((tab) => (
+              <button
+                key={tab.value}
+                type="button"
+                role="tab"
+                aria-selected={selectedCategory === tab.value}
+                data-testid={`icon-picker-tab-${tab.value}`}
+                onClick={() => {
+                  setSelectedCategory(tab.value);
+                  setFocusedIndex(0);
+                }}
+                className={[
+                  "px-[8px] py-[5px] rounded-[6px] text-[11px] font-medium whitespace-nowrap transition-colors duration-100 outline-none",
+                  "focus-visible:ring-2 focus-visible:ring-[var(--brand-primary)]",
+                  selectedCategory === tab.value
+                    ? "bg-[var(--brand-primary)] text-white"
+                    : "text-[var(--fg-muted)] hover:bg-[var(--bg-muted)] hover:text-[var(--fg)]",
+                ].join(" ")}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+
+          {/* ---- Icon grid ---- */}
+          <div
+            role="listbox"
+            aria-label="Icons"
+            data-testid="icon-picker-grid"
+            style={{ maxHeight: PANEL_MAX_HEIGHT, overflowY: "auto" }}
+            className="p-[8px] @container"
+            onKeyDown={handleGridKeyDown}
+          >
+            {filtered.length === 0 ? (
+              // Empty state (ECN-ICON-PICKER-03)
+              <div
+                className="flex flex-col items-center justify-center py-[40px] gap-[6px] text-center"
+                data-testid="icon-picker-empty"
+              >
+                <span className="text-[var(--fg-muted)] text-sm font-medium">{EMPTY_SEARCH_HINT}</span>
+                <span className="text-[var(--fg-muted)] text-[11px] max-w-[240px]">{EMPTY_SEARCH_SUB}</span>
+              </div>
+            ) : (
+              <div
+                className={[
+                  "grid gap-[4px]",
+                  // 6 cols desktop ≥1024, 5 cols tablet 600-1023, 4 cols mobile <600
+                  "grid-cols-6 max-[1023px]:grid-cols-5 max-[599px]:grid-cols-4",
+                ].join(" ")}
+              >
+                {filtered.map((entry, idx) => (
+                  <IconTile
+                    key={entry.id}
+                    entry={entry}
+                    isSelected={entry.id === value}
+                    onSelect={handleSelect}
+                    tileRef={idx === focusedIndex ? firstTileRef : undefined}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}

--- a/app/components/blocks/IconPicker.tsx
+++ b/app/components/blocks/IconPicker.tsx
@@ -22,7 +22,7 @@
  */
 
 import * as Popover from "@radix-ui/react-popover";
-import { useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 
 import {
   ICON_CATALOG,
@@ -80,10 +80,10 @@ export interface IconPickerProps {
    */
   value: string | null;
   /**
-   * Fired when the user clicks an icon tile.
-   * Passes the selected icon identifier string.
+   * Fired when the user clicks an icon tile, or null when the clear button is clicked.
+   * Passes the selected icon identifier string, or null to clear the selection.
    */
-  onChange: (id: string) => void;
+  onChange: (id: string | null) => void;
   /**
    * Optional: allow clearing the selection.
    * When true, a "×" button appears on the trigger and onChange(null) is fired.
@@ -105,7 +105,7 @@ interface IconTileProps {
   entry: IconEntry;
   isSelected: boolean;
   onSelect: (id: string) => void;
-  tileRef?: React.RefObject<HTMLButtonElement | null>;
+  tileRef?: (el: HTMLButtonElement | null) => void;
 }
 
 function IconTile({ entry, isSelected, onSelect, tileRef }: IconTileProps) {
@@ -159,7 +159,16 @@ export function IconPicker({ value, onChange, clearable = false, disabled = fals
   const [focusedIndex, setFocusedIndex] = useState(0);
 
   const searchRef = useRef<HTMLInputElement>(null);
-  const firstTileRef = useRef<HTMLButtonElement>(null);
+  // Array of tile button refs for roving focus (F2 fix — Codex P2)
+  const tileRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  // Stable callback-ref factory so each tile gets a stable ref assignment
+  const setTileRef = useCallback(
+    (idx: number) => (el: HTMLButtonElement | null) => {
+      tileRefs.current[idx] = el;
+    },
+    [],
+  );
 
   // Debounced query (50ms per AC item 7, ECN-ICON-PICKER-02)
   const [debouncedQuery, setDebouncedQuery] = useState("");
@@ -200,35 +209,45 @@ export function IconPicker({ value, onChange, clearable = false, disabled = fals
   };
 
   // Keyboard nav in grid (arrow keys, Enter)
+  // F2 fix (Codex P2): roving focus — after updating focusedIndex, call .focus()
+  // on the target tile. Column count derived from actual CSS grid layout, not
+  // fixed arithmetic (fixes tablet/mobile column mismatch).
   const handleGridKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (filtered.length === 0) return;
 
-    // Determine number of columns based on viewport approximation.
-    // We use a best-effort approach: read from grid style.
-    // Default: 6 cols for desktop
-    const grid = e.currentTarget;
-    const cols = Math.max(1, Math.round(grid.clientWidth / (grid.clientWidth / 6)));
+    // Derive actual column count from computed grid style (F2 fix — Codex P2).
+    // getComputedStyle(grid).gridTemplateColumns returns space-separated track
+    // sizes like "60px 60px 60px 60px 60px 60px"; splitting by " " gives the count.
+    const gridEl = e.currentTarget.querySelector<HTMLElement>(".grid");
+    const cols = gridEl
+      ? window.getComputedStyle(gridEl).gridTemplateColumns.split(" ").length
+      : 6; // fallback for test envs without layout
+
+    const moveFocus = (newIndex: number) => {
+      setFocusedIndex(newIndex);
+      // Roving focus: call .focus() on the target tile (F2 fix — Codex P2)
+      tileRefs.current[newIndex]?.focus();
+    };
 
     if (e.key === "ArrowRight") {
       e.preventDefault();
-      setFocusedIndex((i) => Math.min(i + 1, filtered.length - 1));
+      moveFocus(Math.min(focusedIndex + 1, filtered.length - 1));
     } else if (e.key === "ArrowLeft") {
       e.preventDefault();
-      setFocusedIndex((i) => Math.max(i - 1, 0));
+      moveFocus(Math.max(focusedIndex - 1, 0));
     } else if (e.key === "ArrowDown") {
       e.preventDefault();
-      setFocusedIndex((i) => Math.min(i + cols, filtered.length - 1));
+      moveFocus(Math.min(focusedIndex + cols, filtered.length - 1));
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
-      setFocusedIndex((i) => {
-        const next = i - cols;
-        if (next < 0) {
-          // Move focus back to search
-          searchRef.current?.focus();
-          return 0;
-        }
-        return next;
-      });
+      const next = focusedIndex - cols;
+      if (next < 0) {
+        // Move focus back to search
+        searchRef.current?.focus();
+        setFocusedIndex(0);
+      } else {
+        moveFocus(next);
+      }
     } else if (e.key === "Enter" && focusedIndex >= 0 && focusedIndex < filtered.length) {
       e.preventDefault();
       handleSelect(filtered[focusedIndex].id);
@@ -242,76 +261,82 @@ export function IconPicker({ value, onChange, clearable = false, disabled = fals
 
   return (
     <Popover.Root open={open} onOpenChange={handleOpenChange}>
-      {/* ---- Trigger ---- */}
-      <Popover.Trigger asChild>
-        <button
-          type="button"
-          aria-label="Open icon picker"
-          data-testid="icon-picker-trigger"
-          disabled={disabled}
-          className={[
-            "icon-picker-trigger",
-            "inline-flex items-center gap-[8px]",
-            "px-[12px] py-[8px] rounded-[8px]",
-            "border border-[var(--border)] bg-[var(--bg-elevated)]",
-            "text-sm font-medium transition-colors duration-100",
-            "outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-primary)]",
-            disabled
-              ? "opacity-50 cursor-not-allowed"
-              : "cursor-pointer hover:border-[var(--brand-primary)]",
-            open ? "border-[var(--brand-primary)]" : "",
-          ]
-            .filter(Boolean)
-            .join(" ")}
-        >
-          {/* Selected icon preview or placeholder */}
-          {selectedEntry ? (
-            <>
-              <span className="flex items-center justify-center w-[18px] h-[18px]" data-testid="icon-picker-selected-preview">
-                {renderIcon(selectedEntry.id, { size: 18 })}
-              </span>
-              <span className="text-[var(--fg)] truncate max-w-[140px]" data-testid="icon-picker-selected-name">
-                {selectedEntry.name}
-              </span>
-            </>
-          ) : (
-            <span className="text-[var(--fg-muted)]" data-testid="icon-picker-placeholder">
-              {TRIGGER_PLACEHOLDER}
-            </span>
-          )}
-
-          {/* Caret */}
-          <svg
+      {/* ---- Trigger row: picker trigger + optional clear button (sibling, not nested) ---- */}
+      {/* F1 fix (Codex P2): clear button is a SIBLING of Popover.Trigger, not nested inside it.
+          Nested interactive controls (<button> inside <button>) violate HTML spec.
+          The clear button calls onChange(null) — no cast needed with updated prop type. */}
+      <div className="inline-flex items-center gap-[4px]">
+        <Popover.Trigger asChild>
+          <button
+            type="button"
+            aria-label="Open icon picker"
+            data-testid="icon-picker-trigger"
+            disabled={disabled}
             className={[
-              "ml-auto w-[14px] h-[14px] text-[var(--fg-muted)] flex-shrink-0 transition-transform duration-150",
-              open ? "rotate-180" : "",
-            ].join(" ")}
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            aria-hidden="true"
+              "icon-picker-trigger",
+              "inline-flex items-center gap-[8px]",
+              "px-[12px] py-[8px] rounded-[8px]",
+              "border border-[var(--border)] bg-[var(--bg-elevated)]",
+              "text-sm font-medium transition-colors duration-100",
+              "outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-primary)]",
+              disabled
+                ? "opacity-50 cursor-not-allowed"
+                : "cursor-pointer hover:border-[var(--brand-primary)]",
+              open ? "border-[var(--brand-primary)]" : "",
+            ]
+              .filter(Boolean)
+              .join(" ")}
           >
-            <path d="M6 9l6 6 6-6" />
-          </svg>
+            {/* Selected icon preview or placeholder */}
+            {selectedEntry ? (
+              <>
+                <span className="flex items-center justify-center w-[18px] h-[18px]" data-testid="icon-picker-selected-preview">
+                  {renderIcon(selectedEntry.id, { size: 18 })}
+                </span>
+                <span className="text-[var(--fg)] truncate max-w-[140px]" data-testid="icon-picker-selected-name">
+                  {selectedEntry.name}
+                </span>
+              </>
+            ) : (
+              <span className="text-[var(--fg-muted)]" data-testid="icon-picker-placeholder">
+                {TRIGGER_PLACEHOLDER}
+              </span>
+            )}
 
-          {/* Clear button (when clearable + value set) */}
-          {clearable && value && (
-            <button
-              type="button"
-              aria-label="Clear icon"
-              data-testid="icon-picker-clear"
-              className="ml-[2px] w-[16px] h-[16px] rounded-full flex items-center justify-center text-[var(--fg-muted)] hover:text-[var(--fg)] transition-colors"
-              onClick={(e) => {
-                e.stopPropagation();
-                onChange(null as unknown as string); // Clear: pass null to parent
-              }}
+            {/* Caret */}
+            <svg
+              className={[
+                "ml-auto w-[14px] h-[14px] text-[var(--fg-muted)] flex-shrink-0 transition-transform duration-150",
+                open ? "rotate-180" : "",
+              ].join(" ")}
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              aria-hidden="true"
             >
-              ×
-            </button>
-          )}
-        </button>
-      </Popover.Trigger>
+              <path d="M6 9l6 6 6-6" />
+            </svg>
+          </button>
+        </Popover.Trigger>
+
+        {/* Clear button — outside Popover.Trigger to avoid nested interactive controls (F1 fix) */}
+        {clearable && value !== null && (
+          <button
+            type="button"
+            aria-label="Clear icon"
+            data-testid="icon-picker-clear"
+            className="w-[20px] h-[20px] rounded-full flex items-center justify-center text-[var(--fg-muted)] hover:text-[var(--fg)] hover:bg-[var(--bg-muted)] transition-colors outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-primary)]"
+            onClick={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+              onChange(null); // F1 fix: null typed correctly, no cast needed
+            }}
+          >
+            ×
+          </button>
+        )}
+      </div>
 
       {/* ---- Popover panel ---- */}
       <Popover.Portal>
@@ -353,8 +378,8 @@ export function IconPicker({ value, onChange, clearable = false, disabled = fals
                 onKeyDown={(e) => {
                   if (e.key === "ArrowDown") {
                     e.preventDefault();
-                    // Move focus into the grid
-                    firstTileRef.current?.focus();
+                    // Move focus into the grid — roving focus to tile[0] (F2 fix — Codex P2)
+                    tileRefs.current[0]?.focus();
                     setFocusedIndex(0);
                   }
                 }}
@@ -425,7 +450,7 @@ export function IconPicker({ value, onChange, clearable = false, disabled = fals
                     entry={entry}
                     isSelected={entry.id === value}
                     onSelect={handleSelect}
-                    tileRef={idx === focusedIndex ? firstTileRef : undefined}
+                    tileRef={setTileRef(idx)}
                   />
                 ))}
               </div>

--- a/app/lib/icon-resolve.test.ts
+++ b/app/lib/icon-resolve.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Unit tests — icon resolver (U2)
+ *
+ * Tests renderIcon() behavior: known IDs, unknown IDs, fallback, props.
+ * Runs in Node environment (no JSDOM) — no React rendering, only
+ * structural/contract assertions.
+ *
+ * Story: tadaify-app#205 F-BLOCK-INFRA-ICON-PICKER-001
+ * Covers: U2 (6 cases), TR-tadaify-014 (resolver), AC items 4, 9, 11
+ */
+
+import { describe, it, expect } from "vitest";
+import React from "react";
+import { renderIcon, FALLBACK_ICON_ID, DEFAULT_ICON_SIZE } from "./icon-resolve";
+
+// ---------------------------------------------------------------------------
+// U2-1: known lucide ID resolves to a React element
+// ---------------------------------------------------------------------------
+
+describe("renderIcon — U2-1: known lucide ID resolves", () => {
+  it("renderIcon('lucide:link') returns a React element (not null)", () => {
+    const el = renderIcon("lucide:link");
+    expect(el).not.toBeNull();
+    expect(React.isValidElement(el)).toBe(true);
+  });
+
+  it("renderIcon('lucide:heart') returns a React element", () => {
+    const el = renderIcon("lucide:heart");
+    expect(el).not.toBeNull();
+    expect(React.isValidElement(el)).toBe(true);
+  });
+
+  it("renderIcon('lucide:spotify') — non-lucide name still handled (fallback)", () => {
+    // 'spotify' is not in the lucide registry — should return fallback element
+    const el = renderIcon("lucide:spotify");
+    expect(React.isValidElement(el)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// U2-2: known simple-icons ID resolves to inline SVG element
+// ---------------------------------------------------------------------------
+
+describe("renderIcon — U2-2: known simple-icons ID resolves to SVG", () => {
+  it("renderIcon('simple-icons:spotify') returns a React element", () => {
+    const el = renderIcon("simple-icons:spotify");
+    expect(el).not.toBeNull();
+    expect(React.isValidElement(el)).toBe(true);
+  });
+
+  it("simple-icons SVG element has type 'svg'", () => {
+    const el = renderIcon("simple-icons:spotify");
+    expect(React.isValidElement(el)).toBe(true);
+    if (React.isValidElement(el)) {
+      expect(el.type).toBe("svg");
+    }
+  });
+
+  it("simple-icons SVG element has brand-color fill (non-empty string)", () => {
+    const el = renderIcon("simple-icons:spotify");
+    if (React.isValidElement(el)) {
+      const props = el.props as Record<string, unknown>;
+      // fill should be "#1ED760" (spotify green)
+      expect(typeof props.fill).toBe("string");
+      expect((props.fill as string).startsWith("#")).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// U2-3: unknown ID returns fallback (HelpCircle)
+// ---------------------------------------------------------------------------
+
+describe("renderIcon — U2-3: unknown ID returns fallback element", () => {
+  it("unknown lucide ID returns fallback React element", () => {
+    const el = renderIcon("lucide:nonexistentIconXyz");
+    expect(el).not.toBeNull();
+    expect(React.isValidElement(el)).toBe(true);
+  });
+
+  it("unknown simple-icons ID returns fallback React element", () => {
+    const el = renderIcon("simple-icons:nonexistent-brand-xyz");
+    expect(el).not.toBeNull();
+    expect(React.isValidElement(el)).toBe(true);
+  });
+
+  it("completely malformed ID returns fallback React element", () => {
+    const el = renderIcon("not-a-real:prefix:anything");
+    expect(el).not.toBeNull();
+    expect(React.isValidElement(el)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// U2-4: null/undefined/empty ID returns null
+// ---------------------------------------------------------------------------
+
+describe("renderIcon — U2-4: null/undefined/empty ID returns null", () => {
+  it("renderIcon(null) returns null", () => {
+    expect(renderIcon(null)).toBeNull();
+  });
+
+  it("renderIcon(undefined) returns null", () => {
+    expect(renderIcon(undefined)).toBeNull();
+  });
+
+  it("renderIcon('') returns null", () => {
+    expect(renderIcon("")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// U2-5: props.size is passed to the rendered element
+// ---------------------------------------------------------------------------
+
+describe("renderIcon — U2-5: size prop is respected", () => {
+  it("renderIcon with size=32 produces element with size=32", () => {
+    const el = renderIcon("lucide:link", { size: 32 });
+    if (React.isValidElement(el)) {
+      const props = el.props as Record<string, unknown>;
+      expect(props.size).toBe(32);
+    }
+  });
+
+  it("renderIcon with size=32 for simple-icons produces SVG width=32", () => {
+    const el = renderIcon("simple-icons:spotify", { size: 32 });
+    if (React.isValidElement(el)) {
+      const props = el.props as Record<string, unknown>;
+      expect(props.width).toBe(32);
+      expect(props.height).toBe(32);
+    }
+  });
+
+  it("FALLBACK_ICON_ID is a non-empty string", () => {
+    expect(typeof FALLBACK_ICON_ID).toBe("string");
+    expect(FALLBACK_ICON_ID.length).toBeGreaterThan(0);
+  });
+
+  it("DEFAULT_ICON_SIZE is a positive number", () => {
+    expect(typeof DEFAULT_ICON_SIZE).toBe("number");
+    expect(DEFAULT_ICON_SIZE).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// U2-6: className prop is threaded through
+// ---------------------------------------------------------------------------
+
+describe("renderIcon — U2-6: className prop is respected", () => {
+  it("renderIcon with className passes it to element", () => {
+    const el = renderIcon("lucide:link", { className: "my-icon-class" });
+    if (React.isValidElement(el)) {
+      const props = el.props as Record<string, unknown>;
+      expect(props.className).toBe("my-icon-class");
+    }
+  });
+
+  it("renderIcon simple-icons with className passes it to SVG element", () => {
+    const el = renderIcon("simple-icons:spotify", { className: "brand-icon" });
+    if (React.isValidElement(el)) {
+      const props = el.props as Record<string, unknown>;
+      expect(props.className).toBe("brand-icon");
+    }
+  });
+});

--- a/app/lib/icon-resolve.ts
+++ b/app/lib/icon-resolve.ts
@@ -1,0 +1,346 @@
+/**
+ * Icon resolver — converts a catalog identifier string to a JSX element.
+ *
+ * SSR-safe: no browser globals (no `window`, `document`).
+ * Works in Cloudflare Workers SSR context (same code path as creator preview).
+ *
+ * Usage:
+ *   renderIcon("lucide:link")
+ *   renderIcon("simple-icons:spotify", { size: 24 })
+ *   renderIcon(null)  // → null
+ *   renderIcon("lucide:unknown-icon") // → fallback HelpCircle
+ *
+ * Story: tadaify-app#205 F-BLOCK-INFRA-ICON-PICKER-001
+ * Covers: BR-ICON-PICKER-004, BR-ICON-PICKER-005, TR-tadaify-014 (resolver), AC items 4, 9, 11
+ * Unit tests: app/lib/icon-resolve.test.ts (U2)
+ */
+
+import type { JSX } from "react";
+import React from "react";
+
+// ---------------------------------------------------------------------------
+// Lucide icon imports (tree-shaken — only icons in the catalog are imported)
+// ---------------------------------------------------------------------------
+
+import {
+  // Popular
+  Link,
+  Heart,
+  Star,
+  Bookmark,
+  Share2,
+  Mail,
+  Calendar,
+  Image,
+  Video,
+  File,
+  Globe,
+  ShoppingCart,
+  Music,
+  Rss,
+  Podcast,
+  MapPin,
+  Phone,
+  User,
+  Gift,
+  Coffee,
+  // Music & Video
+  Music2,
+  Mic,
+  Headphones,
+  Radio,
+  Tv,
+  Clapperboard,
+  PlayCircle,
+  Disc3,
+  // Shop
+  ShoppingBag,
+  Tag,
+  CreditCard,
+  PackageOpen,
+  // Communication
+  MessageCircle,
+  Send,
+  MailOpen,
+  Bell,
+  MonitorPlay,
+  AtSign,
+  MessageSquare,
+  Users,
+  // Content
+  BookOpen,
+  FileText,
+  PenLine,
+  LayoutDashboard,
+  GraduationCap,
+  Lightbulb,
+  Camera,
+  Palette,
+  Code2,
+  Trophy,
+  BarChart2,
+  Briefcase,
+  Clock,
+  Zap,
+  Sparkles,
+  // Generic
+  ExternalLink,
+  ArrowRight,
+  Plus,
+  Check,
+  Search,
+  Settings,
+  HelpCircle,
+  Info,
+  Download,
+  Upload,
+  // Fallback
+} from "lucide-react";
+
+// ---------------------------------------------------------------------------
+// Lucide icon registry — maps catalog ID suffix to component
+// ---------------------------------------------------------------------------
+
+/** Maps lucide:<name> → Lucide React component. */
+const LUCIDE_REGISTRY: Record<string, React.ComponentType<{ size?: number; strokeWidth?: number; className?: string; color?: string }>> = {
+  // Popular
+  link: Link,
+  heart: Heart,
+  star: Star,
+  bookmark: Bookmark,
+  share2: Share2,
+  mail: Mail,
+  calendar: Calendar,
+  image: Image,
+  video: Video,
+  file: File,
+  globe: Globe,
+  shoppingCart: ShoppingCart,
+  music: Music,
+  rss: Rss,
+  podcast: Podcast,
+  mapPin: MapPin,
+  phone: Phone,
+  user: User,
+  gift: Gift,
+  coffee: Coffee,
+  // Music & Video
+  music2: Music2,
+  mic: Mic,
+  headphones: Headphones,
+  radio: Radio,
+  tv: Tv,
+  clapperboard: Clapperboard,
+  playCircle: PlayCircle,
+  disc3: Disc3,
+  // Shop
+  shoppingBag: ShoppingBag,
+  tag: Tag,
+  creditCard: CreditCard,
+  packageOpen: PackageOpen,
+  // Communication
+  messageCircle: MessageCircle,
+  send: Send,
+  mailOpen: MailOpen,
+  bell: Bell,
+  monitorPlay: MonitorPlay,
+  atSign: AtSign,
+  messageSquare: MessageSquare,
+  users: Users,
+  // Content
+  bookOpen: BookOpen,
+  fileText: FileText,
+  penLine: PenLine,
+  layoutDashboard: LayoutDashboard,
+  graduationCap: GraduationCap,
+  lightbulb: Lightbulb,
+  camera: Camera,
+  palette: Palette,
+  code2: Code2,
+  trophy: Trophy,
+  barChart2: BarChart2,
+  briefcase: Briefcase,
+  clock: Clock,
+  zap: Zap,
+  sparkles: Sparkles,
+  // Generic
+  externalLink: ExternalLink,
+  arrowRight: ArrowRight,
+  plus: Plus,
+  check: Check,
+  search: Search,
+  settings: Settings,
+  helpCircle: HelpCircle,
+  info: Info,
+  download: Download,
+  upload: Upload,
+};
+
+// ---------------------------------------------------------------------------
+// Simple Icons path data (inlined for SSR + tree-shaking)
+// Only import the icons actually in ICON_CATALOG to keep bundle small.
+// ---------------------------------------------------------------------------
+
+// We use a lazy approach: import the named exports from simple-icons.
+// Vite tree-shakes this to only what we reference.
+import {
+  siInstagram,
+  siX,
+  siTiktok,
+  siYoutube,
+  siFacebook,
+  siReddit,
+  siPinterest,
+  siDiscord,
+  siTwitch,
+  siSnapchat,
+  siThreads,
+  siBluesky,
+  siMastodon,
+  siGithub,
+  siLinktree,
+  siMedium,
+  siSubstack,
+  siPatreon,
+  siKofi,
+  siBuymeacoffee,
+  siSpotify,
+  siApplemusic,
+  siYoutubemusic,
+  siSoundcloud,
+  siBandcamp,
+  siVimeo,
+  siApplepodcasts,
+  siShopify,
+  siEtsy,
+  siGumroad,
+  siStripe,
+  siPaypal,
+  siWoocommerce,
+  siWhatsapp,
+  siTelegram,
+} from "simple-icons";
+
+/** Maps simple-icons:<slug> → simple-icons metadata object. */
+const SIMPLE_ICONS_REGISTRY: Record<string, { path: string; hex: string; title: string }> = {
+  instagram: siInstagram,
+  x: siX,
+  tiktok: siTiktok,
+  youtube: siYoutube,
+  facebook: siFacebook,
+  reddit: siReddit,
+  pinterest: siPinterest,
+  discord: siDiscord,
+  twitch: siTwitch,
+  snapchat: siSnapchat,
+  threads: siThreads,
+  bluesky: siBluesky,
+  mastodon: siMastodon,
+  github: siGithub,
+  linktree: siLinktree,
+  medium: siMedium,
+  substack: siSubstack,
+  patreon: siPatreon,
+  kofi: siKofi,
+  buymeacoffee: siBuymeacoffee,
+  spotify: siSpotify,
+  applemusic: siApplemusic,
+  youtubemusic: siYoutubemusic,
+  soundcloud: siSoundcloud,
+  bandcamp: siBandcamp,
+  vimeo: siVimeo,
+  applepodcasts: siApplepodcasts,
+  shopify: siShopify,
+  etsy: siEtsy,
+  gumroad: siGumroad,
+  stripe: siStripe,
+  paypal: siPaypal,
+  woocommerce: siWoocommerce,
+  whatsapp: siWhatsapp,
+  telegram: siTelegram,
+};
+
+// ---------------------------------------------------------------------------
+// Props + render function
+// ---------------------------------------------------------------------------
+
+export interface RenderIconProps {
+  /** Icon size in px. Default: 20. */
+  size?: number;
+  /** Tailwind / CSS class to add to the SVG element. */
+  className?: string;
+}
+
+/**
+ * Resolves an icon identifier string to a JSX element.
+ *
+ * - `lucide:<name>` → Lucide React component (monochrome, `stroke="currentColor"`)
+ * - `simple-icons:<slug>` → Inline SVG with brand hex color
+ * - `null` or unknown → returns `null` (null id) or HelpCircle fallback (unknown)
+ *
+ * SSR-safe: pure synchronous computation, no browser APIs.
+ *
+ * @param id - Icon identifier from ICON_CATALOG (or stored in block meta.icon)
+ * @param props - Optional size + className overrides
+ * @returns JSX element or null
+ */
+export function renderIcon(id: string | null | undefined, props?: RenderIconProps): JSX.Element | null {
+  const size = props?.size ?? 20;
+  const className = props?.className;
+
+  if (!id) return null;
+
+  const [source, ...nameParts] = id.split(":");
+  const name = nameParts.join(":");  // handles slugs that contain colons (unlikely but safe)
+
+  // ---- Lucide ----
+  if (source === "lucide") {
+    const Component = LUCIDE_REGISTRY[name];
+    if (!Component) {
+      if (typeof console !== "undefined") {
+        console.warn(`[renderIcon] Unknown lucide icon: "${id}" — using fallback HelpCircle`);
+      }
+      return React.createElement(HelpCircle, { size, strokeWidth: 1.5, className, "aria-hidden": true } as React.ComponentProps<typeof HelpCircle>);
+    }
+    return React.createElement(Component, { size, strokeWidth: 1.5, className, "aria-hidden": true } as React.ComponentProps<typeof Component>);
+  }
+
+  // ---- Simple Icons ----
+  if (source === "simple-icons") {
+    const iconData = SIMPLE_ICONS_REGISTRY[name];
+    if (!iconData) {
+      if (typeof console !== "undefined") {
+        console.warn(`[renderIcon] Unknown simple-icons icon: "${id}" — using fallback HelpCircle`);
+      }
+      return React.createElement(HelpCircle, { size, strokeWidth: 1.5, className, "aria-hidden": true } as React.ComponentProps<typeof HelpCircle>);
+    }
+    // Render inline SVG with brand color
+    return React.createElement("svg", {
+      width: size,
+      height: size,
+      viewBox: "0 0 24 24",
+      fill: `#${iconData.hex}`,
+      "aria-hidden": true,
+      className,
+      role: "img",
+      "aria-label": iconData.title,
+      xmlns: "http://www.w3.org/2000/svg",
+    }, React.createElement("path", { d: iconData.path }));
+  }
+
+  // ---- Unknown source prefix ----
+  if (typeof console !== "undefined") {
+    console.warn(`[renderIcon] Unknown icon source prefix: "${id}" — using fallback HelpCircle`);
+  }
+  return React.createElement(HelpCircle, { size, strokeWidth: 1.5, className, "aria-hidden": true } as React.ComponentProps<typeof HelpCircle>);
+}
+
+// ---------------------------------------------------------------------------
+// Exported constants (for tests + downstream consumers)
+// ---------------------------------------------------------------------------
+
+/** Identifier used for the fallback icon (unknown/removed catalog entries). */
+export const FALLBACK_ICON_ID = "lucide:helpCircle" as const;
+
+/** Default icon render size in px. */
+export const DEFAULT_ICON_SIZE = 20;

--- a/app/lib/icon-search.ts
+++ b/app/lib/icon-search.ts
@@ -1,0 +1,71 @@
+/**
+ * icon-search — Pure filter helpers for the icon picker.
+ *
+ * Intentionally free of React + browser globals so tests run in Node/vitest
+ * without a DOM environment. Mirrors the block-search.ts pattern.
+ *
+ * Story: tadaify-app#205 F-BLOCK-INFRA-ICON-PICKER-001
+ * Covers: BR-ICON-PICKER-002, BR-ICON-PICKER-003, TR (search)
+ * Unit tests: app/lib/icons-catalog.test.ts (U1)
+ */
+
+import type { IconEntry, IconCategory } from "./icons-catalog";
+
+// ---------------------------------------------------------------------------
+// Category filter sentinel
+// ---------------------------------------------------------------------------
+
+/** The "All" sentinel — when selectedCategory equals this, no category filter applied. */
+export const ICON_CATEGORY_ALL = "all" as const;
+export type IconCategoryFilterValue = IconCategory | typeof ICON_CATEGORY_ALL;
+
+// ---------------------------------------------------------------------------
+// Core filter function
+// ---------------------------------------------------------------------------
+
+/**
+ * Filter the icon catalog by a free-text query and/or category.
+ *
+ * - `query`: substring match on `name + tags` (case-insensitive, escaped for regex safety).
+ *   Empty string = no text filter.
+ * - `category`: when `ICON_CATEGORY_ALL`, category filter is skipped.
+ *   Otherwise only entries with `category === category` pass.
+ * - Filters are AND-combined: both must pass when both are non-trivial.
+ *
+ * Special chars in `query` are escaped before matching (ECN-ICON-PICKER-02).
+ * Returns a new array; the original catalog is never mutated.
+ *
+ * @param catalog - The full ICON_CATALOG array (or any subset)
+ * @param query - Free-text search string (may contain special chars)
+ * @param category - Category filter value or ICON_CATEGORY_ALL
+ * @returns Filtered array of IconEntry objects
+ */
+export function filterIcons(
+  catalog: IconEntry[],
+  query: string,
+  category: IconCategoryFilterValue = ICON_CATEGORY_ALL,
+): IconEntry[] {
+  const trimmedQuery = query.trim();
+  const hasQuery = trimmedQuery.length > 0;
+  const hasCategoryFilter = category !== ICON_CATEGORY_ALL;
+
+  // Escape special regex characters so "+", "-", "(", ")" etc don't throw
+  // (ECN-ICON-PICKER-02: special chars in query)
+  const escapedQuery = trimmedQuery.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const queryLower = escapedQuery.toLowerCase();
+
+  return catalog.filter((entry) => {
+    // Category filter
+    if (hasCategoryFilter && entry.category !== category) return false;
+
+    // Text filter
+    if (hasQuery) {
+      const nameLower = entry.name.toLowerCase();
+      const tagsLower = entry.tags.join(" ").toLowerCase();
+      const haystack = `${nameLower} ${tagsLower}`;
+      if (!haystack.includes(queryLower)) return false;
+    }
+
+    return true;
+  });
+}

--- a/app/lib/icons-catalog.test.ts
+++ b/app/lib/icons-catalog.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Unit tests — icon catalog + icon search (U1)
+ *
+ * Tests ICON_CATALOG registry shape + integrity.
+ * Runs in Node environment (no JSDOM).
+ *
+ * Story: tadaify-app#205 F-BLOCK-INFRA-ICON-PICKER-001
+ * Covers: U1 (6 cases), TR-tadaify-014 (registry)
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  ICON_CATALOG,
+  ICON_CATALOG_COUNT,
+  ICON_CATEGORIES,
+  type IconEntry,
+  type IconSource,
+} from "./icons-catalog";
+import { filterIcons, ICON_CATEGORY_ALL } from "./icon-search";
+
+// ---------------------------------------------------------------------------
+// U1-1: catalog has ≥100 entries
+// ---------------------------------------------------------------------------
+
+describe("ICON_CATALOG — U1-1: catalog size ≥ 100", () => {
+  it("exports at least 100 icon entries", () => {
+    expect(ICON_CATALOG.length).toBeGreaterThanOrEqual(100);
+  });
+
+  it("ICON_CATALOG_COUNT matches actual array length", () => {
+    expect(ICON_CATALOG_COUNT).toBe(ICON_CATALOG.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// U1-2: every entry has required fields
+// ---------------------------------------------------------------------------
+
+describe("ICON_CATALOG — U1-2: every entry has required fields", () => {
+  for (const entry of ICON_CATALOG) {
+    it(`entry '${entry.id}' has id, source, name, category, tags`, () => {
+      // id
+      expect(typeof entry.id).toBe("string");
+      expect(entry.id.trim().length).toBeGreaterThan(0);
+      // source
+      expect(["lucide", "simple-icons"] as IconSource[]).toContain(entry.source);
+      // name
+      expect(typeof entry.name).toBe("string");
+      expect(entry.name.trim().length).toBeGreaterThan(0);
+      // category
+      expect(ICON_CATEGORIES as readonly string[]).toContain(entry.category);
+      // tags — ≥2 tags per entry (AC item 3 spec quality)
+      expect(Array.isArray(entry.tags)).toBe(true);
+      expect(entry.tags.length).toBeGreaterThanOrEqual(2);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// U1-3: no duplicate IDs
+// ---------------------------------------------------------------------------
+
+describe("ICON_CATALOG — U1-3: no duplicate IDs", () => {
+  it("all entry IDs are unique", () => {
+    const ids = ICON_CATALOG.map((e) => e.id);
+    const unique = new Set(ids);
+    expect(unique.size).toBe(ids.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// U1-4: ID format matches source
+// ---------------------------------------------------------------------------
+
+describe("ICON_CATALOG — U1-4: ID format matches declared source", () => {
+  for (const entry of ICON_CATALOG) {
+    it(`entry '${entry.id}' ID prefix matches source`, () => {
+      if (entry.source === "lucide") {
+        expect(entry.id.startsWith("lucide:")).toBe(true);
+      } else if (entry.source === "simple-icons") {
+        expect(entry.id.startsWith("simple-icons:")).toBe(true);
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// U1-5: valid categories across all 7
+// ---------------------------------------------------------------------------
+
+describe("ICON_CATALOG — U1-5: all 7 categories have at least 5 entries", () => {
+  for (const cat of ICON_CATEGORIES) {
+    it(`category '${cat}' has at least 5 entries`, () => {
+      const count = ICON_CATALOG.filter((e) => e.category === cat).length;
+      expect(count).toBeGreaterThanOrEqual(5);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// U1-6: filterIcons behaves correctly
+// ---------------------------------------------------------------------------
+
+describe("filterIcons — U1-6: search + category filter logic", () => {
+  it("empty query + ALL returns full catalog", () => {
+    const result = filterIcons(ICON_CATALOG, "", ICON_CATEGORY_ALL);
+    expect(result.length).toBe(ICON_CATALOG.length);
+  });
+
+  it("'spotify' query returns Spotify entry", () => {
+    const result = filterIcons(ICON_CATALOG, "spotify", ICON_CATEGORY_ALL);
+    expect(result.length).toBeGreaterThanOrEqual(1);
+    expect(result.some((e) => e.id === "simple-icons:spotify")).toBe(true);
+  });
+
+  it("category 'social' with empty query returns only social entries", () => {
+    const result = filterIcons(ICON_CATALOG, "", "social");
+    expect(result.every((e) => e.category === "social")).toBe(true);
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it("query that matches nothing in category returns empty array", () => {
+    const result = filterIcons(ICON_CATALOG, "zzznonexistent", ICON_CATEGORY_ALL);
+    expect(result).toHaveLength(0);
+  });
+
+  it("special char '+' in query does not throw (ECN-ICON-PICKER-02)", () => {
+    expect(() => filterIcons(ICON_CATALOG, "a+b", ICON_CATEGORY_ALL)).not.toThrow();
+  });
+
+  it("special char '-' in query does not throw (ECN-ICON-PICKER-02)", () => {
+    expect(() => filterIcons(ICON_CATALOG, "buy-me", ICON_CATEGORY_ALL)).not.toThrow();
+  });
+
+  it("filter is AND-combined: category + query must both match", () => {
+    // 'spotify' is in music-video — it should appear when filtering by music-video
+    const resultMatch = filterIcons(ICON_CATALOG, "spotify", "music-video");
+    expect(resultMatch.some((e) => e.id === "simple-icons:spotify")).toBe(true);
+
+    // 'spotify' should NOT appear when filtering by 'shop'
+    const resultMiss = filterIcons(ICON_CATALOG, "spotify", "shop");
+    expect(resultMiss.some((e) => e.id === "simple-icons:spotify")).toBe(false);
+  });
+
+  it("case-insensitive search for 'SPOTIFY' matches spotify", () => {
+    const result = filterIcons(ICON_CATALOG, "SPOTIFY", ICON_CATEGORY_ALL);
+    expect(result.some((e) => e.id === "simple-icons:spotify")).toBe(true);
+  });
+
+  it("does not mutate the original catalog array", () => {
+    const originalLength = ICON_CATALOG.length;
+    filterIcons(ICON_CATALOG, "link", "popular");
+    expect(ICON_CATALOG.length).toBe(originalLength);
+  });
+});

--- a/app/lib/icons-catalog.ts
+++ b/app/lib/icons-catalog.ts
@@ -1,0 +1,820 @@
+/**
+ * Icon catalog — curated registry of ~100 icons across 7 categories.
+ *
+ * Design philosophy mirrors block-types.ts: static array, no async loading,
+ * SSR-safe (Cloudflare Workers can call renderIcon() without DOM).
+ *
+ * Icon identifier format:
+ *   - Lucide (monochrome): "lucide:<camelCase-name>"  e.g. "lucide:link"
+ *   - Simple Icons (brand): "simple-icons:<slug>"     e.g. "simple-icons:spotify"
+ *
+ * Story: tadaify-app#205 F-BLOCK-INFRA-ICON-PICKER-001
+ * Covers: BR-ICON-PICKER-001..006, TR-tadaify-014, AC item 3
+ * Unit tests: app/lib/icons-catalog.test.ts (U1)
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Which npm library provides this icon. */
+export type IconSource = "lucide" | "simple-icons";
+
+/**
+ * Category keys — mirrors BlockCategory from block-types.ts.
+ * Identical set so the same category tabs drive both pickers.
+ */
+export const ICON_CATEGORIES = [
+  "popular",
+  "social",
+  "music-video",
+  "shop",
+  "communication",
+  "content",
+  "generic",
+] as const;
+export type IconCategory = (typeof ICON_CATEGORIES)[number];
+
+/**
+ * Single entry in the curated icon catalog.
+ */
+export interface IconEntry {
+  /**
+   * Unique identifier stored in block metadata.
+   * Format: "lucide:<camelCase>" | "simple-icons:<slug>"
+   * e.g. "lucide:link" | "simple-icons:spotify"
+   */
+  id: string;
+  /** Which library provides this icon. */
+  source: IconSource;
+  /**
+   * Human-readable display name shown in the picker grid.
+   * Title-cased, short (max ~20 chars).
+   */
+  name: string;
+  /** Primary category — determines which tab this icon appears under. */
+  category: IconCategory;
+  /**
+   * Search tags (lowercase, space-separated or array).
+   * Searched alongside the name field.
+   * Minimum 2 tags per entry.
+   */
+  tags: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Catalog (≥100 entries across 7 categories)
+// Ordered: popular → social → music-video → shop → communication → content → generic
+// ---------------------------------------------------------------------------
+
+/**
+ * Curated icon catalog.
+ *
+ * Category balance per AC item 3:
+ *   Popular       ~20  (mixed sources)
+ *   Social        ~20  (simple-icons brand)
+ *   Music & Video ~15  (simple-icons brand)
+ *   Shop          ~10  (simple-icons brand)
+ *   Communication ~10  (mixed)
+ *   Content       ~15  (lucide-react)
+ *   Generic       ~10  (lucide-react)
+ */
+export const ICON_CATALOG: IconEntry[] = [
+  // -------------------------------------------------------------------------
+  // Popular (~20)
+  // -------------------------------------------------------------------------
+  {
+    id: "lucide:link",
+    source: "lucide",
+    name: "Link",
+    category: "popular",
+    tags: ["url", "href", "external", "chain"],
+  },
+  {
+    id: "lucide:heart",
+    source: "lucide",
+    name: "Heart",
+    category: "popular",
+    tags: ["like", "love", "favorite", "favourite"],
+  },
+  {
+    id: "lucide:star",
+    source: "lucide",
+    name: "Star",
+    category: "popular",
+    tags: ["favorite", "favourite", "rate", "rating"],
+  },
+  {
+    id: "lucide:bookmark",
+    source: "lucide",
+    name: "Bookmark",
+    category: "popular",
+    tags: ["save", "read-later", "pin"],
+  },
+  {
+    id: "lucide:share2",
+    source: "lucide",
+    name: "Share",
+    category: "popular",
+    tags: ["share", "share2", "send", "distribute"],
+  },
+  {
+    id: "lucide:mail",
+    source: "lucide",
+    name: "Email",
+    category: "popular",
+    tags: ["mail", "email", "message", "envelope"],
+  },
+  {
+    id: "lucide:calendar",
+    source: "lucide",
+    name: "Calendar",
+    category: "popular",
+    tags: ["date", "schedule", "booking", "event"],
+  },
+  {
+    id: "lucide:image",
+    source: "lucide",
+    name: "Image",
+    category: "popular",
+    tags: ["photo", "picture", "gallery", "img"],
+  },
+  {
+    id: "lucide:video",
+    source: "lucide",
+    name: "Video",
+    category: "popular",
+    tags: ["film", "movie", "media", "play"],
+  },
+  {
+    id: "lucide:file",
+    source: "lucide",
+    name: "File",
+    category: "popular",
+    tags: ["document", "doc", "attachment", "page"],
+  },
+  {
+    id: "lucide:globe",
+    source: "lucide",
+    name: "Website",
+    category: "popular",
+    tags: ["website", "world", "internet", "web", "globe"],
+  },
+  {
+    id: "lucide:shoppingCart",
+    source: "lucide",
+    name: "Shop",
+    category: "popular",
+    tags: ["cart", "buy", "purchase", "store", "shop", "ecommerce"],
+  },
+  {
+    id: "lucide:music",
+    source: "lucide",
+    name: "Music",
+    category: "popular",
+    tags: ["audio", "song", "track", "note"],
+  },
+  {
+    id: "lucide:rss",
+    source: "lucide",
+    name: "RSS / Blog",
+    category: "popular",
+    tags: ["rss", "feed", "blog", "newsletter", "subscribe"],
+  },
+  {
+    id: "lucide:podcast",
+    source: "lucide",
+    name: "Podcast",
+    category: "popular",
+    tags: ["podcast", "radio", "audio", "broadcast"],
+  },
+  {
+    id: "lucide:mapPin",
+    source: "lucide",
+    name: "Location",
+    category: "popular",
+    tags: ["map", "pin", "location", "place", "address"],
+  },
+  {
+    id: "lucide:phone",
+    source: "lucide",
+    name: "Phone",
+    category: "popular",
+    tags: ["call", "telephone", "contact"],
+  },
+  {
+    id: "lucide:user",
+    source: "lucide",
+    name: "Profile",
+    category: "popular",
+    tags: ["user", "person", "account", "profile", "avatar"],
+  },
+  {
+    id: "lucide:gift",
+    source: "lucide",
+    name: "Gift",
+    category: "popular",
+    tags: ["present", "gift", "support", "donation"],
+  },
+  {
+    id: "lucide:coffee",
+    source: "lucide",
+    name: "Tip",
+    category: "popular",
+    tags: ["coffee", "tip", "support", "donate", "buy me a coffee"],
+  },
+
+  // -------------------------------------------------------------------------
+  // Social (~20)
+  // -------------------------------------------------------------------------
+  {
+    id: "simple-icons:instagram",
+    source: "simple-icons",
+    name: "Instagram",
+    category: "social",
+    tags: ["instagram", "photos", "reels", "stories"],
+  },
+  {
+    id: "simple-icons:x",
+    source: "simple-icons",
+    name: "X / Twitter",
+    category: "social",
+    tags: ["x", "twitter", "tweets", "social"],
+  },
+  {
+    id: "simple-icons:tiktok",
+    source: "simple-icons",
+    name: "TikTok",
+    category: "social",
+    tags: ["tiktok", "videos", "short-form"],
+  },
+  {
+    id: "simple-icons:youtube",
+    source: "simple-icons",
+    name: "YouTube",
+    category: "social",
+    tags: ["youtube", "video", "channel", "subscribe"],
+  },
+  {
+    id: "simple-icons:facebook",
+    source: "simple-icons",
+    name: "Facebook",
+    category: "social",
+    tags: ["facebook", "fb", "social"],
+  },
+  {
+    id: "simple-icons:reddit",
+    source: "simple-icons",
+    name: "Reddit",
+    category: "social",
+    tags: ["reddit", "community", "subreddit"],
+  },
+  {
+    id: "simple-icons:pinterest",
+    source: "simple-icons",
+    name: "Pinterest",
+    category: "social",
+    tags: ["pinterest", "pins", "boards", "ideas"],
+  },
+  {
+    id: "simple-icons:discord",
+    source: "simple-icons",
+    name: "Discord",
+    category: "social",
+    tags: ["discord", "community", "server", "chat", "gaming"],
+  },
+  {
+    id: "simple-icons:twitch",
+    source: "simple-icons",
+    name: "Twitch",
+    category: "social",
+    tags: ["twitch", "stream", "live", "gaming"],
+  },
+  {
+    id: "simple-icons:snapchat",
+    source: "simple-icons",
+    name: "Snapchat",
+    category: "social",
+    tags: ["snapchat", "stories", "snaps"],
+  },
+  {
+    id: "simple-icons:threads",
+    source: "simple-icons",
+    name: "Threads",
+    category: "social",
+    tags: ["threads", "meta", "social"],
+  },
+  {
+    id: "simple-icons:bluesky",
+    source: "simple-icons",
+    name: "Bluesky",
+    category: "social",
+    tags: ["bluesky", "at protocol", "social"],
+  },
+  {
+    id: "simple-icons:mastodon",
+    source: "simple-icons",
+    name: "Mastodon",
+    category: "social",
+    tags: ["mastodon", "fediverse", "social"],
+  },
+  {
+    id: "simple-icons:github",
+    source: "simple-icons",
+    name: "GitHub",
+    category: "social",
+    tags: ["github", "code", "repos", "developers"],
+  },
+  {
+    id: "simple-icons:linktree",
+    source: "simple-icons",
+    name: "Linktree",
+    category: "social",
+    tags: ["linktree", "links", "bio"],
+  },
+  {
+    id: "simple-icons:medium",
+    source: "simple-icons",
+    name: "Medium",
+    category: "social",
+    tags: ["medium", "blog", "articles", "writing"],
+  },
+  {
+    id: "simple-icons:substack",
+    source: "simple-icons",
+    name: "Substack",
+    category: "social",
+    tags: ["substack", "newsletter", "writing", "blog"],
+  },
+  {
+    id: "simple-icons:patreon",
+    source: "simple-icons",
+    name: "Patreon",
+    category: "social",
+    tags: ["patreon", "membership", "support", "subscription"],
+  },
+  {
+    id: "simple-icons:kofi",
+    source: "simple-icons",
+    name: "Ko-fi",
+    category: "social",
+    tags: ["kofi", "ko-fi", "donation", "support", "tip"],
+  },
+  {
+    id: "simple-icons:buymeacoffee",
+    source: "simple-icons",
+    name: "Buy Me a Coffee",
+    category: "social",
+    tags: ["buymeacoffee", "buy me a coffee", "tip", "support", "donation"],
+  },
+
+  // -------------------------------------------------------------------------
+  // Music & Video (~15)
+  // -------------------------------------------------------------------------
+  {
+    id: "simple-icons:spotify",
+    source: "simple-icons",
+    name: "Spotify",
+    category: "music-video",
+    tags: ["spotify", "music", "podcast", "streaming"],
+  },
+  {
+    id: "simple-icons:applemusic",
+    source: "simple-icons",
+    name: "Apple Music",
+    category: "music-video",
+    tags: ["apple music", "applemusic", "music", "streaming"],
+  },
+  {
+    id: "simple-icons:youtubemusic",
+    source: "simple-icons",
+    name: "YouTube Music",
+    category: "music-video",
+    tags: ["youtube music", "youtubemusic", "music", "streaming"],
+  },
+  {
+    id: "simple-icons:soundcloud",
+    source: "simple-icons",
+    name: "SoundCloud",
+    category: "music-video",
+    tags: ["soundcloud", "music", "tracks", "audio"],
+  },
+  {
+    id: "simple-icons:bandcamp",
+    source: "simple-icons",
+    name: "Bandcamp",
+    category: "music-video",
+    tags: ["bandcamp", "music", "albums", "indie"],
+  },
+  {
+    id: "simple-icons:vimeo",
+    source: "simple-icons",
+    name: "Vimeo",
+    category: "music-video",
+    tags: ["vimeo", "video", "films", "portfolio"],
+  },
+  {
+    id: "simple-icons:applepodcasts",
+    source: "simple-icons",
+    name: "Apple Podcasts",
+    category: "music-video",
+    tags: ["apple podcasts", "applepodcasts", "podcast", "audio"],
+  },
+  {
+    id: "lucide:music2",
+    source: "lucide",
+    name: "Track",
+    category: "music-video",
+    tags: ["track", "song", "music", "audio"],
+  },
+  {
+    id: "lucide:mic",
+    source: "lucide",
+    name: "Microphone",
+    category: "music-video",
+    tags: ["mic", "microphone", "record", "podcast", "voice"],
+  },
+  {
+    id: "lucide:headphones",
+    source: "lucide",
+    name: "Headphones",
+    category: "music-video",
+    tags: ["headphones", "listen", "audio", "music"],
+  },
+  {
+    id: "lucide:radio",
+    source: "lucide",
+    name: "Radio",
+    category: "music-video",
+    tags: ["radio", "broadcast", "live", "stream"],
+  },
+  {
+    id: "lucide:tv",
+    source: "lucide",
+    name: "TV / Channel",
+    category: "music-video",
+    tags: ["tv", "television", "channel", "broadcast"],
+  },
+  {
+    id: "lucide:clapperboard",
+    source: "lucide",
+    name: "Film",
+    category: "music-video",
+    tags: ["film", "movie", "video", "clapper", "production"],
+  },
+  {
+    id: "lucide:playCircle",
+    source: "lucide",
+    name: "Play",
+    category: "music-video",
+    tags: ["play", "video", "watch", "stream"],
+  },
+  {
+    id: "lucide:disc3",
+    source: "lucide",
+    name: "Vinyl",
+    category: "music-video",
+    tags: ["vinyl", "disc3", "record", "music", "disc", "album"],
+  },
+
+  // -------------------------------------------------------------------------
+  // Shop (~10)
+  // -------------------------------------------------------------------------
+  {
+    id: "simple-icons:shopify",
+    source: "simple-icons",
+    name: "Shopify",
+    category: "shop",
+    tags: ["shopify", "store", "ecommerce", "shop"],
+  },
+  {
+    id: "simple-icons:etsy",
+    source: "simple-icons",
+    name: "Etsy",
+    category: "shop",
+    tags: ["etsy", "handmade", "crafts", "shop"],
+  },
+  {
+    id: "simple-icons:gumroad",
+    source: "simple-icons",
+    name: "Gumroad",
+    category: "shop",
+    tags: ["gumroad", "digital", "downloads", "products"],
+  },
+  {
+    id: "simple-icons:stripe",
+    source: "simple-icons",
+    name: "Stripe",
+    category: "shop",
+    tags: ["stripe", "payments", "checkout"],
+  },
+  {
+    id: "simple-icons:paypal",
+    source: "simple-icons",
+    name: "PayPal",
+    category: "shop",
+    tags: ["paypal", "payment", "money", "checkout"],
+  },
+  {
+    id: "simple-icons:woocommerce",
+    source: "simple-icons",
+    name: "WooCommerce",
+    category: "shop",
+    tags: ["woocommerce", "wordpress", "store", "ecommerce"],
+  },
+  {
+    id: "lucide:shoppingBag",
+    source: "lucide",
+    name: "Shopping Bag",
+    category: "shop",
+    tags: ["shop", "bag", "purchase", "buy"],
+  },
+  {
+    id: "lucide:tag",
+    source: "lucide",
+    name: "Price Tag",
+    category: "shop",
+    tags: ["price", "tag", "label", "deal"],
+  },
+  {
+    id: "lucide:creditCard",
+    source: "lucide",
+    name: "Payment",
+    category: "shop",
+    tags: ["credit card", "payment", "billing", "checkout"],
+  },
+  {
+    id: "lucide:packageOpen",
+    source: "lucide",
+    name: "Product",
+    category: "shop",
+    tags: ["product", "package", "order", "delivery"],
+  },
+
+  // -------------------------------------------------------------------------
+  // Communication (~10)
+  // -------------------------------------------------------------------------
+  {
+    id: "lucide:messageCircle",
+    source: "lucide",
+    name: "Message",
+    category: "communication",
+    tags: ["message", "chat", "comment", "reply"],
+  },
+  {
+    id: "lucide:send",
+    source: "lucide",
+    name: "Send",
+    category: "communication",
+    tags: ["send", "submit", "contact", "message"],
+  },
+  {
+    id: "simple-icons:whatsapp",
+    source: "simple-icons",
+    name: "WhatsApp",
+    category: "communication",
+    tags: ["whatsapp", "message", "chat", "mobile"],
+  },
+  {
+    id: "simple-icons:telegram",
+    source: "simple-icons",
+    name: "Telegram",
+    category: "communication",
+    tags: ["telegram", "channel", "message", "chat"],
+  },
+  {
+    id: "lucide:mailOpen",
+    source: "lucide",
+    name: "Newsletter",
+    category: "communication",
+    tags: ["newsletter", "email", "subscribe", "mail"],
+  },
+  {
+    id: "lucide:bell",
+    source: "lucide",
+    name: "Notify",
+    category: "communication",
+    tags: ["bell", "notify", "alert", "notification"],
+  },
+  {
+    id: "lucide:monitorPlay",
+    source: "lucide",
+    name: "Video Call",
+    category: "communication",
+    tags: ["video call", "meeting", "zoom", "webinar", "monitor"],
+  },
+  {
+    id: "lucide:atSign",
+    source: "lucide",
+    name: "Mention / @",
+    category: "communication",
+    tags: ["at", "mention", "email", "handle"],
+  },
+  {
+    id: "lucide:messageSquare",
+    source: "lucide",
+    name: "Chat",
+    category: "communication",
+    tags: ["chat", "message", "support", "help"],
+  },
+  {
+    id: "lucide:users",
+    source: "lucide",
+    name: "Community",
+    category: "communication",
+    tags: ["community", "group", "members", "team"],
+  },
+
+  // -------------------------------------------------------------------------
+  // Content (~15)
+  // -------------------------------------------------------------------------
+  {
+    id: "lucide:bookOpen",
+    source: "lucide",
+    name: "Read / Blog",
+    category: "content",
+    tags: ["book", "blog", "article", "read", "writing"],
+  },
+  {
+    id: "lucide:fileText",
+    source: "lucide",
+    name: "Article",
+    category: "content",
+    tags: ["article", "text", "document", "writing"],
+  },
+  {
+    id: "lucide:penLine",
+    source: "lucide",
+    name: "Writing",
+    category: "content",
+    tags: ["write", "pen", "author", "blog", "essay"],
+  },
+  {
+    id: "lucide:layoutDashboard",
+    source: "lucide",
+    name: "Course",
+    category: "content",
+    tags: ["course", "curriculum", "lessons", "education"],
+  },
+  {
+    id: "lucide:graduationCap",
+    source: "lucide",
+    name: "Education",
+    category: "content",
+    tags: ["education", "learn", "course", "school", "tutorial"],
+  },
+  {
+    id: "lucide:lightbulb",
+    source: "lucide",
+    name: "Ideas",
+    category: "content",
+    tags: ["idea", "tip", "insight", "advice"],
+  },
+  {
+    id: "lucide:camera",
+    source: "lucide",
+    name: "Photography",
+    category: "content",
+    tags: ["camera", "photo", "photography", "shoot"],
+  },
+  {
+    id: "lucide:palette",
+    source: "lucide",
+    name: "Art / Design",
+    category: "content",
+    tags: ["palette", "art", "design", "creative"],
+  },
+  {
+    id: "lucide:code2",
+    source: "lucide",
+    name: "Code",
+    category: "content",
+    tags: ["code", "developer", "programming", "github"],
+  },
+  {
+    id: "lucide:trophy",
+    source: "lucide",
+    name: "Achievement",
+    category: "content",
+    tags: ["trophy", "award", "achievement", "win"],
+  },
+  {
+    id: "lucide:barChart2",
+    source: "lucide",
+    name: "Analytics",
+    category: "content",
+    tags: ["analytics", "stats", "data", "chart"],
+  },
+  {
+    id: "lucide:briefcase",
+    source: "lucide",
+    name: "Portfolio",
+    category: "content",
+    tags: ["portfolio", "work", "projects", "professional"],
+  },
+  {
+    id: "lucide:clock",
+    source: "lucide",
+    name: "Schedule",
+    category: "content",
+    tags: ["schedule", "time", "hours", "availability"],
+  },
+  {
+    id: "lucide:zap",
+    source: "lucide",
+    name: "Action",
+    category: "content",
+    tags: ["action", "fast", "cta", "energy", "boost"],
+  },
+  {
+    id: "lucide:sparkles",
+    source: "lucide",
+    name: "Featured",
+    category: "content",
+    tags: ["featured", "sparkles", "highlight", "special", "ai"],
+  },
+
+  // -------------------------------------------------------------------------
+  // Generic (~10)
+  // -------------------------------------------------------------------------
+  {
+    id: "lucide:externalLink",
+    source: "lucide",
+    name: "External Link",
+    category: "generic",
+    tags: ["external", "link", "open", "url"],
+  },
+  {
+    id: "lucide:arrowRight",
+    source: "lucide",
+    name: "Arrow Right",
+    category: "generic",
+    tags: ["arrow", "next", "forward", "go"],
+  },
+  {
+    id: "lucide:plus",
+    source: "lucide",
+    name: "Add",
+    category: "generic",
+    tags: ["add", "plus", "new", "create"],
+  },
+  {
+    id: "lucide:check",
+    source: "lucide",
+    name: "Check",
+    category: "generic",
+    tags: ["check", "done", "confirm", "verified"],
+  },
+  {
+    id: "lucide:search",
+    source: "lucide",
+    name: "Search",
+    category: "generic",
+    tags: ["search", "find", "discover", "lookup"],
+  },
+  {
+    id: "lucide:settings",
+    source: "lucide",
+    name: "Settings",
+    category: "generic",
+    tags: ["settings", "config", "preferences"],
+  },
+  {
+    id: "lucide:helpCircle",
+    source: "lucide",
+    name: "Help / FAQ",
+    category: "generic",
+    tags: ["help", "faq", "question", "support"],
+  },
+  {
+    id: "lucide:info",
+    source: "lucide",
+    name: "Info",
+    category: "generic",
+    tags: ["info", "information", "about"],
+  },
+  {
+    id: "lucide:download",
+    source: "lucide",
+    name: "Download",
+    category: "generic",
+    tags: ["download", "save", "file", "get"],
+  },
+  {
+    id: "lucide:upload",
+    source: "lucide",
+    name: "Upload",
+    category: "generic",
+    tags: ["upload", "share", "file", "submit"],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the total number of entries in the catalog.
+ * Used in tests to assert ≥100.
+ */
+export const ICON_CATALOG_COUNT = ICON_CATALOG.length;

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -43,4 +43,7 @@ export default [
 
   // Test harness — BlockEditorModal (Playwright S1–S7, tadaify-app#211)
   route("/test-block-editor-modal", "routes/test-block-editor-modal.tsx"),
+
+  // Test harness — IconPicker (Playwright S1–S6, tadaify-app#205)
+  route("/test-icon-picker", "routes/test-icon-picker.tsx"),
 ] satisfies RouteConfig;

--- a/app/routes/test-icon-picker.tsx
+++ b/app/routes/test-icon-picker.tsx
@@ -14,7 +14,7 @@
  * No auth required — test harness mounts component directly.
  *
  * Story: tadaify-app#205 F-BLOCK-INFRA-ICON-PICKER-001
- * Covers: Playwright S1–S6
+ * Covers: Playwright S1–S7
  */
 
 import { useState } from "react";
@@ -24,7 +24,8 @@ export default function TestIconPicker() {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [changeCount, setChangeCount] = useState(0);
 
-  const handleChange = (id: string) => {
+  // F1 fix (Codex P2): onChange now accepts null (clear action) — update handler type
+  const handleChange = (id: string | null) => {
     setSelectedId(id);
     setChangeCount((c) => c + 1);
   };

--- a/app/routes/test-icon-picker.tsx
+++ b/app/routes/test-icon-picker.tsx
@@ -1,0 +1,111 @@
+/**
+ * Test harness page for IconPicker Playwright tests (S1–S6).
+ *
+ * Route: /test-icon-picker
+ *
+ * This page exists ONLY for automated testing — it mounts IconPicker directly
+ * so Playwright can exercise it without requiring the full block-editor flow.
+ *
+ * The page provides:
+ *   - An IconPicker mounted with current value state
+ *   - A [data-selected-id] element reflecting the last selected iconId
+ *   - A clearable="true" variant for ECN-ICON-PICKER-09 testing
+ *
+ * No auth required — test harness mounts component directly.
+ *
+ * Story: tadaify-app#205 F-BLOCK-INFRA-ICON-PICKER-001
+ * Covers: Playwright S1–S6
+ */
+
+import { useState } from "react";
+import { IconPicker } from "~/components/blocks/IconPicker";
+
+export default function TestIconPicker() {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [changeCount, setChangeCount] = useState(0);
+
+  const handleChange = (id: string) => {
+    setSelectedId(id);
+    setChangeCount((c) => c + 1);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-8 font-sans">
+      {/* Page title */}
+      <h1 className="text-2xl font-semibold text-gray-900 mb-6">
+        IconPicker Test Harness
+      </h1>
+
+      <p className="text-sm text-gray-500 mb-6">
+        Test harness for Playwright S1–S6. No auth required.
+      </p>
+
+      {/* Primary icon picker (S1–S5) */}
+      <div className="mb-8">
+        <h2 className="text-sm font-semibold text-gray-700 mb-2">
+          Primary picker (clearable)
+        </h2>
+        <IconPicker
+          value={selectedId}
+          onChange={handleChange}
+          clearable
+        />
+      </div>
+
+      {/* Selected icon indicator — Playwright spy */}
+      <div
+        data-selected-id={selectedId ?? ""}
+        data-testid="icon-picker-selected-output"
+        data-change-count={changeCount}
+        className={[
+          "mb-6 px-3 py-2 rounded-lg text-sm font-mono border",
+          selectedId
+            ? "bg-green-50 border-green-200 text-green-800"
+            : "bg-gray-100 border-gray-200 text-gray-500",
+        ].join(" ")}
+      >
+        {selectedId ? (
+          <>
+            <span>onChange called with: </span>
+            <b>{selectedId}</b>
+            <span className="ml-2 text-gray-400">(×{changeCount})</span>
+          </>
+        ) : (
+          <span>No icon selected yet</span>
+        )}
+      </div>
+
+      {/* Second independent picker (ECN-ICON-PICKER-10: two independent pickers) */}
+      <div className="mb-8">
+        <h2 className="text-sm font-semibold text-gray-700 mb-2">
+          Secondary picker (independent state — ECN-ICON-PICKER-10)
+        </h2>
+        <SecondPicker />
+      </div>
+
+      {/* Scroll content — background noise */}
+      <div className="mt-8 space-y-3">
+        {Array.from({ length: 10 }, (_, i) => (
+          <div
+            key={i}
+            className="p-3 bg-white rounded-md border border-gray-200 text-sm text-gray-500"
+          >
+            Page content row {i + 1}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** Second isolated picker — proves ECN-ICON-PICKER-10 (independent state). */
+function SecondPicker() {
+  const [value, setValue] = useState<string | null>(null);
+  return (
+    <IconPicker
+      value={value}
+      onChange={setValue}
+      clearable
+    />
+  );
+}

--- a/docs/requirements/technical/0027-tr-tadaify-014-icon-libraries-lucide-react-simple-icons.md
+++ b/docs/requirements/technical/0027-tr-tadaify-014-icon-libraries-lucide-react-simple-icons.md
@@ -1,0 +1,121 @@
+# TR-tadaify-014 — Icon libraries: lucide-react + simple-icons (DEC-378=A)
+
+**ID:** TR-tadaify-014  
+**Status:** LOCKED (DEC-378=A, 2026-05-06)  
+**Introduced by:** tadaify-app#205 F-BLOCK-INFRA-ICON-PICKER-001  
+
+---
+
+## Decision
+
+`lucide-react` and `simple-icons` are the **canonical icon library dependencies**
+for all tadaify icon usage. Icon identifiers stored in the DB and rendered at
+runtime use the format `lucide:<name>` or `simple-icons:<slug>`.
+
+## Rationale
+
+**DEC-378=A (locked 2026-05-06):** Explicit product decision after evaluating four
+alternatives:
+
+| Option | Verdict |
+|--------|---------|
+| A — lucide-react + simple-icons npm, tree-shaken per icon | **CHOSEN** |
+| B — curated subset bundled as local SVG files | Rejected — maintenance burden |
+| C — Iconify CDN runtime fetch | Rejected — runtime CDN dep, SSR complexity |
+| D — full icon bundle (no tree-shake) | Rejected — bundle too large |
+
+## Canonical icon libraries
+
+### lucide-react (monochrome icons)
+
+- **Package:** `lucide-react`
+- **Usage:** Generic, content, communication, and popular icons
+- **Render:** `stroke="currentColor"` — color controlled by CSS
+- **Identifier format:** `lucide:<camelCase-name>` (e.g. `lucide:link`, `lucide:heart`)
+- **Import pattern (tree-shaken):**
+  ```ts
+  import { Link } from 'lucide-react';
+  ```
+
+### simple-icons (brand icons)
+
+- **Package:** `simple-icons`
+- **Usage:** Social media, music platforms, shop platforms
+- **Render:** Inline SVG with brand hex color from `icon.hex` metadata
+- **Identifier format:** `simple-icons:<slug>` (e.g. `simple-icons:spotify`, `simple-icons:instagram`)
+- **Access pattern:**
+  ```ts
+  import * as SimpleIcons from 'simple-icons';
+  const icon = SimpleIcons[`si${capitalizedSlug}`];
+  // icon.path  — SVG path data
+  // icon.hex   — brand color (no leading #)
+  // icon.slug  — canonical slug
+  // icon.title — display name
+  ```
+
+## Icon registry
+
+Icons are curated in `app/lib/icons-catalog.ts` — a static array of `IconEntry`
+objects across 7 categories:
+
+| Category | Count target | Source |
+|----------|-------------|--------|
+| popular | ~20 | Mixed |
+| social | ~20 | simple-icons |
+| music-video | ~15 | simple-icons |
+| shop | ~10 | simple-icons |
+| communication | ~10 | Mixed |
+| content | ~15 | lucide-react |
+| generic | ~10 | lucide-react |
+
+Total: ≥100 entries.
+
+## Icon resolver
+
+`app/lib/icon-resolve.ts` exports `renderIcon(id, props?)` — resolves any
+catalog identifier to a JSX element. Handles unknown IDs via `HelpCircle`
+fallback (Lucide). SSR-safe (no DOM APIs; Lucide components are SSR-safe by
+design; simple-icons path data is static).
+
+## Bundle target
+
+Tree-shaken icon bundle addition: **≤ 100KB** (Vite tree-shakes unused Lucide
+exports automatically; simple-icons are accessed as named exports so unused
+icons are pruned by the bundler).
+
+## Banned alternatives
+
+- **Iconify CDN** — runtime fetch dependency; fails in Worker SSR without polyfills
+- **Font Awesome** — licensing complications; CSS-based icon fonts conflict with
+  Tailwind v4's utility-first approach
+- **Material Icons** — Google CDN dependency; not SSR-friendly
+- **Full bundles without tree-shaking** — violates the ≤100KB bundle target
+
+## Identifier storage contract
+
+Block metadata stores icon identifiers as plain strings in the `meta.icon` field:
+
+```json
+{ "icon": "simple-icons:spotify" }
+{ "icon": "lucide:link" }
+```
+
+This allows the icon catalog to be updated (add/rename/remove entries) without
+requiring DB migrations. Unknown identifiers render as fallback via `renderIcon()`.
+
+## SSR contract
+
+`renderIcon()` MUST work in both React client and Cloudflare Workers SSR contexts:
+
+- No `window`, `document`, or other browser-only globals
+- No dynamic imports with `await` (synchronous resolution from catalog)
+- Returns a JSX element that serializes cleanly to HTML via `renderToString`
+
+## Related
+
+- DEC-378=A — locked icon library decision (2026-05-06)
+- `app/lib/icons-catalog.ts` — curated icon catalog (source of truth)
+- `app/lib/icon-resolve.ts` — runtime resolver + fallback
+- `app/components/blocks/IconPicker.tsx` — consumer component
+- TR-tadaify-008 — Radix Dialog (IconPicker uses Radix Popover from same vendor)
+- tadaify-app#205 — story that introduced this TR

--- a/e2e/icon-picker.spec.ts
+++ b/e2e/icon-picker.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Playwright test suite — IconPicker component (S1–S6)
+ * Playwright test suite — IconPicker component (S1–S7)
  *
  * Covers: BR-ICON-PICKER-001..006, TR-tadaify-014 (picker component)
  * Story: tadaify-app#205 F-BLOCK-INFRA-ICON-PICKER-001
@@ -19,6 +19,12 @@
  *   - Desktop: ≥1024px (6-col grid)
  *
  * Run: npx playwright test e2e/icon-picker.spec.ts
+ *
+ * S7 covers Codex P2 findings:
+ *   F1: clear button is a sibling of trigger (not nested), clicking it sets value=null
+ *       and does NOT open the picker popover.
+ *   F2: ArrowRight/ArrowDown move actual DOM focus (not just visual state); column
+ *       count correctly computed from CSS grid at desktop (1280px) and mobile (375px).
  */
 
 import { test, expect } from "@playwright/test";
@@ -221,6 +227,126 @@ test("S5: keyboard navigation — arrow keys move focus, Enter selects, Esc clos
 // S6: Mobile viewport — 4-col grid + ≥44px touch targets
 // Covers: ECN-ICON-PICKER-04
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// S7: Codex P2 F1 — clear button is sibling (not nested), sets null, no open
+// Codex P2 F2 — arrow keys move actual DOM focus; column count correct at desktop+mobile
+// Covers: ECN-ICON-PICKER-04 (keyboard), F1/F2 Codex P2 findings
+// ---------------------------------------------------------------------------
+
+test("S7-F1: clear button sets value to null and does NOT open popover (clearable=true)", async ({ page }) => {
+  await page.goto(TEST_PAGE);
+
+  // Pre-requisite: select an icon so clear button is shown (harness needs clearable=true)
+  // Select Spotify first
+  await page.click('[data-testid="icon-picker-trigger"]');
+  await expect(page.locator('[data-testid="icon-picker-panel"]')).toBeVisible();
+  await page.click('[data-testid="icon-tile-simple-icons:spotify"]');
+  await expect(page.locator('[data-testid="icon-picker-panel"]')).not.toBeVisible();
+
+  // Output spy: value is set
+  const output = page.locator('[data-testid="icon-picker-selected-output"]');
+  await expect(output).toHaveAttribute("data-selected-id", "simple-icons:spotify");
+
+  // Clear button should now be visible (test harness must pass clearable=true)
+  const clearBtn = page.locator('[data-testid="icon-picker-clear"]');
+  await expect(clearBtn).toBeVisible();
+
+  // F1 fix: clear button must NOT be inside the trigger button — verify DOM structure
+  // The trigger button should not contain the clear button as a descendant
+  const triggerContainsClear = await page.locator('[data-testid="icon-picker-trigger"]')
+    .locator('[data-testid="icon-picker-clear"]')
+    .count();
+  expect(triggerContainsClear).toBe(0); // clear button is a sibling, not nested
+
+  // Click clear button
+  await clearBtn.click();
+
+  // Popover must NOT open (clear doesn't trigger the picker open)
+  await expect(page.locator('[data-testid="icon-picker-panel"]')).not.toBeVisible();
+
+  // Value cleared: output spy should show empty / null
+  await expect(output).toHaveAttribute("data-selected-id", "");
+});
+
+test("S7-F2a: desktop (1280px) — ArrowRight/ArrowDown move actual DOM focus to correct tile", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto(TEST_PAGE);
+
+  // Open picker
+  await page.click('[data-testid="icon-picker-trigger"]');
+  await expect(page.locator('[data-testid="icon-picker-panel"]')).toBeVisible();
+
+  // Focus search and move into grid
+  await page.waitForTimeout(100);
+  const searchInput = page.locator('[data-testid="icon-picker-search"]');
+  await expect(searchInput).toBeFocused();
+
+  // ArrowDown from search: focus moves to tile[0]
+  await page.keyboard.press("ArrowDown");
+  await page.waitForTimeout(50);
+
+  const tiles = page.locator('[data-testid="icon-picker-grid"] [role="option"]');
+  const firstTile = tiles.nth(0);
+  await expect(firstTile).toBeFocused();
+
+  // Get first tile's data-icon-id
+  const firstId = await firstTile.getAttribute("data-icon-id");
+
+  // ArrowRight: focus moves to tile[1]
+  await page.keyboard.press("ArrowRight");
+  await page.waitForTimeout(50);
+
+  const secondTile = tiles.nth(1);
+  await expect(secondTile).toBeFocused();
+  const secondId = await secondTile.getAttribute("data-icon-id");
+
+  // Focus must have actually moved (different tile)
+  expect(secondId).not.toBe(firstId);
+
+  // ArrowDown from tile[1] at desktop (6-col grid): should land on tile[7]
+  // (1-indexed row 2, same column position)
+  await page.keyboard.press("ArrowDown");
+  await page.waitForTimeout(50);
+
+  // The focused element should be neither tile[0] nor tile[1]
+  const focusedAfterDown = await page.evaluate(() => {
+    const el = document.activeElement;
+    return el?.getAttribute("data-icon-id") ?? null;
+  });
+  expect(focusedAfterDown).not.toBeNull();
+  expect(focusedAfterDown).not.toBe(firstId);
+  expect(focusedAfterDown).not.toBe(secondId);
+});
+
+test("S7-F2b: mobile viewport (375px) — ArrowDown uses 4-col count (not 6)", async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 812 });
+  await page.goto(TEST_PAGE);
+
+  // Open picker
+  await page.click('[data-testid="icon-picker-trigger"]');
+  await expect(page.locator('[data-testid="icon-picker-panel"]')).toBeVisible();
+  await page.waitForTimeout(100);
+
+  const searchInput = page.locator('[data-testid="icon-picker-search"]');
+  await expect(searchInput).toBeFocused();
+
+  // Move into grid: focus tile[0]
+  await page.keyboard.press("ArrowDown");
+  await page.waitForTimeout(50);
+
+  const tiles = page.locator('[data-testid="icon-picker-grid"] [role="option"]');
+  const tile0 = tiles.nth(0);
+  await expect(tile0).toBeFocused();
+
+  // ArrowDown from tile[0] at mobile (4-col): should land on tile[4], not tile[6]
+  await page.keyboard.press("ArrowDown");
+  await page.waitForTimeout(50);
+
+  // The focused tile should be tile[4] (row 2, col 1 of 4-col grid)
+  const tile4 = tiles.nth(4);
+  await expect(tile4).toBeFocused();
+});
 
 test("S6: mobile viewport (375px) — 4-col grid + tap targets ≥44px", async ({ page }) => {
   await page.setViewportSize({ width: 375, height: 812 });

--- a/e2e/icon-picker.spec.ts
+++ b/e2e/icon-picker.spec.ts
@@ -1,0 +1,248 @@
+/**
+ * Playwright test suite — IconPicker component (S1–S6)
+ *
+ * Covers: BR-ICON-PICKER-001..006, TR-tadaify-014 (picker component)
+ * Story: tadaify-app#205 F-BLOCK-INFRA-ICON-PICKER-001
+ *
+ * Prerequisites:
+ *   - `npm run dev` (App: http://localhost:5173)
+ *   - No auth required — test harness mounts picker directly
+ *
+ * Test harness: /test-icon-picker (app/routes/test-icon-picker.tsx)
+ *
+ * Per `feedback_tadaify_per_playwright_test_authorization.md`:
+ * every test must be individually approved during local click-test before commit.
+ *
+ * Responsive breakpoints (locked rule feedback_tadaify_three_viewport_support.md):
+ *   - Mobile: <600px   (4-col grid)
+ *   - Tablet: 600–1023px (5-col grid)
+ *   - Desktop: ≥1024px (6-col grid)
+ *
+ * Run: npx playwright test e2e/icon-picker.spec.ts
+ */
+
+import { test, expect } from "@playwright/test";
+
+const TEST_PAGE = "/test-icon-picker";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Open the icon picker from the test harness. */
+async function openPicker(page: import("@playwright/test").Page) {
+  await page.goto(TEST_PAGE);
+  await page.click('[data-testid="icon-picker-trigger"]');
+  await expect(page.locator('[data-testid="icon-picker-panel"]')).toBeVisible();
+}
+
+// ---------------------------------------------------------------------------
+// S1: Open picker → search auto-focused → search filters
+// Covers: BR-ICON-PICKER-001, BR-ICON-PICKER-002
+// ---------------------------------------------------------------------------
+
+test("S1: open picker → search auto-focused → search filters live", async ({ page }) => {
+  await page.goto(TEST_PAGE);
+
+  // Panel not present initially
+  await expect(page.locator('[data-testid="icon-picker-panel"]')).not.toBeVisible();
+
+  // Open picker via trigger
+  await page.click('[data-testid="icon-picker-trigger"]');
+
+  // Panel visible
+  const panel = page.locator('[data-testid="icon-picker-panel"]');
+  await expect(panel).toBeVisible();
+
+  // Trigger shows placeholder before selection
+  const trigger = page.locator('[data-testid="icon-picker-trigger"]');
+  await expect(trigger).toBeVisible();
+
+  // Search auto-focused (requestAnimationFrame on open → slight delay)
+  await page.waitForTimeout(100);
+  const searchInput = page.locator('[data-testid="icon-picker-search"]');
+  await expect(searchInput).toBeFocused();
+
+  // Count all initial icons
+  const allTiles = page.locator('[data-testid="icon-picker-grid"] [role="option"]');
+  const totalCount = await allTiles.count();
+  expect(totalCount).toBeGreaterThan(10);
+
+  // Type "spotify" → filter to Spotify
+  await searchInput.fill("spotify");
+  await page.waitForTimeout(100); // debounce
+
+  const filtered = page.locator('[data-testid="icon-picker-grid"] [role="option"]');
+  const filteredCount = await filtered.count();
+  expect(filteredCount).toBeGreaterThanOrEqual(1);
+  expect(filteredCount).toBeLessThan(totalCount);
+
+  // Spotify tile is visible
+  await expect(page.locator('[data-testid="icon-tile-simple-icons:spotify"]')).toBeVisible();
+
+  // Clear search → all icons restored (ECN-ICON-PICKER-01 proxy)
+  await searchInput.fill("");
+  await page.waitForTimeout(100);
+  await expect(allTiles).toHaveCount(totalCount);
+});
+
+// ---------------------------------------------------------------------------
+// S2: Category tab switches
+// Covers: BR-ICON-PICKER-003
+// ---------------------------------------------------------------------------
+
+test("S2: category tab switches filter grid to that category", async ({ page }) => {
+  await openPicker(page);
+
+  // Initial: all icons visible
+  const allTiles = page.locator('[data-testid="icon-picker-grid"] [role="option"]');
+  const allCount = await allTiles.count();
+
+  // Click "Social" tab
+  await page.click('[data-testid="icon-picker-tab-social"]');
+  await page.waitForTimeout(50);
+
+  const socialTiles = page.locator('[data-testid="icon-picker-grid"] [role="option"]');
+  const socialCount = await socialTiles.count();
+
+  // Social tab should show fewer icons than All
+  expect(socialCount).toBeGreaterThan(0);
+  expect(socialCount).toBeLessThan(allCount);
+
+  // Instagram tile should be visible in Social
+  await expect(page.locator('[data-testid="icon-tile-simple-icons:instagram"]')).toBeVisible();
+
+  // Switch to "All" tab → all icons back
+  await page.click('[data-testid="icon-picker-tab-all"]');
+  await page.waitForTimeout(50);
+  await expect(allTiles).toHaveCount(allCount);
+});
+
+// ---------------------------------------------------------------------------
+// S3: Click tile selects + closes + form value set
+// Covers: BR-ICON-PICKER-004
+// ---------------------------------------------------------------------------
+
+test("S3: click tile selects icon → dropdown closes → form value updated", async ({ page }) => {
+  await page.goto(TEST_PAGE);
+
+  // Initially no selection
+  const output = page.locator('[data-testid="icon-picker-selected-output"]');
+  await expect(output).toHaveAttribute("data-selected-id", "");
+
+  // Open picker + select Spotify
+  await page.click('[data-testid="icon-picker-trigger"]');
+  await expect(page.locator('[data-testid="icon-picker-panel"]')).toBeVisible();
+
+  // Click Spotify tile
+  await page.click('[data-testid="icon-tile-simple-icons:spotify"]');
+
+  // Dropdown closes
+  await expect(page.locator('[data-testid="icon-picker-panel"]')).not.toBeVisible();
+
+  // Trigger now shows selected icon name
+  await expect(page.locator('[data-testid="icon-picker-selected-name"]')).toBeVisible();
+  await expect(page.locator('[data-testid="icon-picker-selected-name"]')).toContainText("Spotify");
+
+  // Output spy: onChange called with 'simple-icons:spotify'
+  await expect(output).toHaveAttribute("data-selected-id", "simple-icons:spotify");
+});
+
+// ---------------------------------------------------------------------------
+// S4: Brand vs monochrome rendering
+// Covers: BR-ICON-PICKER-005
+// ---------------------------------------------------------------------------
+
+test("S4: simple-icons render with brand color fill; Lucide icons render with stroke=currentColor", async ({ page }) => {
+  await openPicker(page);
+
+  // Check Spotify tile (simple-icons — brand color)
+  const spotifyTile = page.locator('[data-testid="icon-tile-simple-icons:spotify"]');
+  await expect(spotifyTile).toBeVisible();
+  // The SVG inside should have fill with brand hex
+  const svgFill = await spotifyTile.locator("svg").getAttribute("fill");
+  expect(svgFill).toBeTruthy();
+  expect(svgFill).toMatch(/^#[0-9A-Fa-f]{6}$/);
+
+  // Check Link tile (lucide — monochrome)
+  const linkTile = page.locator('[data-testid="icon-tile-lucide:link"]');
+  await expect(linkTile).toBeVisible();
+  // data-icon-source = lucide
+  await expect(linkTile).toHaveAttribute("data-icon-source", "lucide");
+});
+
+// ---------------------------------------------------------------------------
+// S5: Keyboard navigation
+// Covers: BR-ICON-PICKER-006, ECN-ICON-PICKER-04 (keyboard), ECN-ICON-PICKER-05
+// ---------------------------------------------------------------------------
+
+test("S5: keyboard navigation — arrow keys move focus, Enter selects, Esc closes", async ({ page }) => {
+  await page.goto(TEST_PAGE);
+
+  // Open picker via keyboard (Tab + Enter)
+  await page.click('[data-testid="icon-picker-trigger"]');
+  await expect(page.locator('[data-testid="icon-picker-panel"]')).toBeVisible();
+
+  // Search is auto-focused
+  await page.waitForTimeout(100);
+  const searchInput = page.locator('[data-testid="icon-picker-search"]');
+  await expect(searchInput).toBeFocused();
+
+  // Narrow down to one icon via search so keyboard nav is deterministic
+  await searchInput.fill("spotify");
+  await page.waitForTimeout(100);
+
+  // ArrowDown from search moves into grid
+  await page.keyboard.press("ArrowDown");
+  await page.waitForTimeout(50);
+
+  // The first tile should be focused
+  const firstTile = page.locator('[data-testid="icon-picker-grid"] [role="option"]').first();
+  await expect(firstTile).toBeFocused();
+
+  // Enter selects the focused tile
+  await page.keyboard.press("Enter");
+
+  // Dropdown closes
+  await expect(page.locator('[data-testid="icon-picker-panel"]')).not.toBeVisible();
+
+  // Value is set to Spotify
+  const output = page.locator('[data-testid="icon-picker-selected-output"]');
+  await expect(output).toHaveAttribute("data-selected-id", "simple-icons:spotify");
+
+  // Re-open and test Esc closes without selecting
+  await page.click('[data-testid="icon-picker-trigger"]');
+  await expect(page.locator('[data-testid="icon-picker-panel"]')).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(page.locator('[data-testid="icon-picker-panel"]')).not.toBeVisible();
+});
+
+// ---------------------------------------------------------------------------
+// S6: Mobile viewport — 4-col grid + ≥44px touch targets
+// Covers: ECN-ICON-PICKER-04
+// ---------------------------------------------------------------------------
+
+test("S6: mobile viewport (375px) — 4-col grid + tap targets ≥44px", async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 812 });
+  await openPicker(page);
+
+  // Grid should be visible
+  const grid = page.locator('[data-testid="icon-picker-grid"]');
+  await expect(grid).toBeVisible();
+
+  // Icon tiles should be present
+  const tiles = page.locator('[data-testid="icon-picker-grid"] [role="option"]');
+  const count = await tiles.count();
+  expect(count).toBeGreaterThan(0);
+
+  // Measure the first tile's height — should be ≥44px for mobile tap targets
+  const firstTile = tiles.first();
+  const box = await firstTile.boundingBox();
+  expect(box).not.toBeNull();
+  if (box) {
+    // Tiles use aspect-square — width ≈ height; min 44px
+    // Panel is 360px wide; 4 cols → ~84px per tile (minus gaps)
+    expect(box.width).toBeGreaterThanOrEqual(44);
+    expect(box.height).toBeGreaterThanOrEqual(44);
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,13 @@
       "hasInstallScript": true,
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",
+        "@radix-ui/react-popover": "^1.1.15",
         "isbot": "^5.1.36",
+        "lucide-react": "^1.14.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
-        "react-router": "7.14.0"
+        "react-router": "7.14.0",
+        "simple-icons": "^16.18.1"
       },
       "devDependencies": {
         "@cloudflare/vite-plugin": "^1.29.1",
@@ -1120,6 +1123,44 @@
         "node": ">=18"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
     "node_modules/@img/colour": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
@@ -1795,6 +1836,29 @@
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
     },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+      "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
@@ -1942,6 +2006,75 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
+      "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -2119,6 +2252,48 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
+      "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
+      "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+      "license": "MIT"
     },
     "node_modules/@react-router/dev": {
       "version": "7.14.0",
@@ -4170,6 +4345,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.14.0.tgz",
+      "integrity": "sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -4694,6 +4878,25 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/simple-icons": {
+      "version": "16.18.1",
+      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-16.18.1.tgz",
+      "integrity": "sha512-+AS16pmdVHFdKrzYuTGfNGW6RRJ7eubpRhh2wipqPD5nglXKKIbAoEFhdxuweR1AV63+TuLXVJ+NEqlJpXXa2A==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/simple-icons"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/simple-icons"
+        }
+      ],
+      "license": "CC0-1.0",
+      "engines": {
+        "node": ">=0.12.18"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -19,10 +19,13 @@
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-popover": "^1.1.15",
     "isbot": "^5.1.36",
+    "lucide-react": "^1.14.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-router": "7.14.0"
+    "react-router": "7.14.0",
+    "simple-icons": "^16.18.1"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.29.1",


### PR DESCRIPTION
## Summary

Reusable `IconPicker` dropdown component for tadaify block editors (BR-ICON-PICKER-001..006, DEC-378=A). Provides:
- Searchable dropdown of 100 curated icons across 7 categories (Popular / Social / Music & Video / Shop / Communication / Content / Generic)
- Radix Popover shell (same vendor family as Radix Dialog per DEC-375=B)
- Lucide React icons (monochrome, `stroke="currentColor"`) + Simple Icons (brand-colored SVG)
- SSR-safe `renderIcon()` resolver — Worker SSR can embed icons in public HTML without JS
- Keyboard navigation (arrow keys, Enter, Esc) per WAI-ARIA combobox pattern
- 3-viewport responsive grid (6/5/4 cols desktop/tablet/mobile per TR-tadaify-008)

## Business requirements implemented

- **BR-ICON-PICKER-001** — Creator opens dropdown; search auto-focused (`requestAnimationFrame` on popover open)
- **BR-ICON-PICKER-002** — Search filters within 50ms; debounced via `setTimeout(50ms)` + `useMemo`
- **BR-ICON-PICKER-003** — Category tabs filter grid (`filterIcons()` pure helper)
- **BR-ICON-PICKER-004** — Click tile → `onChange(id)` fired → dropdown closes → trigger updates with icon + name
- **BR-ICON-PICKER-005** — Brand icons (Simple Icons) render with `fill="#HEX"`; generic icons (Lucide) render `stroke="currentColor"`
- **BR-ICON-PICKER-006** — Keyboard: ArrowDown from search → grid; ArrowRight/Left/Up/Down in grid; Enter selects; Esc closes (Radix Popover native)

## Technical requirements introduced or relied on

- **TR-tadaify-014 NEW** — Icon libraries: `lucide-react` + `simple-icons` npm packages, tree-shaken per icon, identifier format `lucide:<name>` | `simple-icons:<slug>`, bundle target ≤100KB. See `docs/requirements/technical/0027-tr-tadaify-014-icon-libraries-lucide-react-simple-icons.md`. Per DEC-378=A (2026-05-06).
- **TR-tadaify-008** — Radix UI canonical: `@radix-ui/react-popover` used (same vendor family as Dialog; popover stacks at z-index 60 above modals at 50). Breakpoints: `max-[1023px]:grid-cols-5 max-[599px]:grid-cols-4` per 3-viewport contract. `max-[860px]` NOT used (banned).
- **TR-tadaify-003** — Tailwind v4 utilities throughout; `var(--brand-primary)` tokens used for selected state + focus rings.

## Acceptance criteria from issue (verbatim)

1. ✅ `lucide-react` + `simple-icons` added to package.json
2. ✅ TR-tadaify-014 record added (`docs/requirements/technical/0027-tr-tadaify-014-icon-libraries-lucide-react-simple-icons.md`)
3. ✅ `app/lib/icons-catalog.ts` shipped with 100 entries across 7 categories (Popular 20, Social 20, Music&Video 15, Shop 10, Communication 10, Content 15, Generic 10)
4. ✅ `app/lib/icon-resolve.ts` resolver shipped (catalog lookup + fallback HelpCircle)
5. ✅ `app/components/blocks/IconPicker.tsx` component shipped using Radix Popover
6. ✅ All 10 visual checklist items verified (trigger button, dropdown panel, search, category tabs, icon grid, selected state, Lucide monochrome, Simple Icons brand color, empty state, keyboard nav)
7. ✅ Search filters within 50ms; debounced
8. ✅ Category tabs filter grid
9. ✅ Brand icons render with original colors; generic icons monochrome
10. ✅ Keyboard navigation: arrows, Enter, Esc
11. ✅ Worker SSR can call `renderIcon(id)` — SSR-safe (no DOM APIs, synchronous, pure)
12. ✅ Bundle impact 97.3KB raw / ~41KB gzip (≤100KB target met)

## Test plan

### Unit tests shipped in this PR

- **U1**: `app/lib/icons-catalog.test.ts` (+ `app/lib/icon-search.ts` covered)
  - "exports at least 100 icon entries"
  - "ICON_CATALOG_COUNT matches actual array length"
  - "entry '<id>' has id, source, name, category, tags" (×100 entries)
  - "entry '<id>' ID prefix matches declared source" (×100 entries)
  - "all entry IDs are unique"
  - "category '<cat>' has at least 5 entries" (×7 categories)
  - "empty query + ALL returns full catalog"
  - "'spotify' query returns Spotify entry"
  - "category 'social' with empty query returns only social entries"
  - "query that matches nothing in category returns empty array"
  - "special char '+' in query does not throw (ECN-ICON-PICKER-02)"
  - "special char '-' in query does not throw (ECN-ICON-PICKER-02)"
  - "filter is AND-combined: category + query must both match"
  - "case-insensitive search for 'SPOTIFY' matches spotify"
  - "does not mutate the original catalog array"

- **U2**: `app/lib/icon-resolve.test.ts`
  - "renderIcon('lucide:link') returns a React element (not null)"
  - "renderIcon('lucide:heart') returns a React element"
  - "renderIcon('lucide:spotify') — non-lucide name still handled (fallback)"
  - "renderIcon('simple-icons:spotify') returns a React element"
  - "simple-icons SVG element has type 'svg'"
  - "simple-icons SVG element has brand-color fill (non-empty string)"
  - "unknown lucide ID returns fallback React element"
  - "unknown simple-icons ID returns fallback React element"
  - "completely malformed ID returns fallback React element"
  - "renderIcon(null) returns null"
  - "renderIcon(undefined) returns null"
  - "renderIcon('') returns null"
  - "renderIcon with size=32 produces element with size=32"
  - "renderIcon with size=32 for simple-icons produces SVG width=32"
  - "FALLBACK_ICON_ID is a non-empty string"
  - "DEFAULT_ICON_SIZE is a positive number"
  - "renderIcon with className passes it to element"
  - "renderIcon simple-icons with className passes it to SVG element"

- **U3**: `app/components/blocks/IconPicker.test.tsx`
  - "IconPicker is a callable function (component)"
  - "accepts value=null + onChange without error (prop contract)"
  - "accepts value='lucide:link' + onChange without error"
  - "SEARCH_INPUT_LABEL is 'Search icons…'"
  - "TRIGGER_PLACEHOLDER is 'Pick icon'"
  - "EMPTY_SEARCH_HINT is 'No icons match'"
  - "EMPTY_SEARCH_SUB is a non-empty string"
  - "component is a function (Radix Popover.Root manages open state)"
  - "filterIcons used by IconPicker is importable and callable from same module path"
  - "ICON_CATEGORIES has 7 entries"
  - "category list matches expected tab values"
  - "SEARCH_INPUT_LABEL is a non-empty string (used as label for a11y)"

### Playwright specs shipped in this PR

- **S1**: `e2e/icon-picker.spec.ts`
  - "S1: open picker → search auto-focused → search filters live"
- **S2**: `e2e/icon-picker.spec.ts`
  - "S2: category tab switches filter grid to that category"
- **S3**: `e2e/icon-picker.spec.ts`
  - "S3: click tile selects icon → dropdown closes → form value updated"
- **S4**: `e2e/icon-picker.spec.ts`
  - "S4: simple-icons render with brand color fill; Lucide icons render with stroke=currentColor"
- **S5**: `e2e/icon-picker.spec.ts`
  - "S5: keyboard navigation — arrow keys move focus, Enter selects, Esc closes"
- **S6**: `e2e/icon-picker.spec.ts`
  - "S6: mobile viewport (375px) — 4-col grid + tap targets ≥44px"

### Coverage cross-reference

Each U<N>/S<N> above maps 1:1 to the same ID in issue #205 `## Playwright test plan` / `## Unit test plan` sections.

### Manual verification

- Open `/test-icon-picker` → verify trigger renders "Pick icon" placeholder
- Click trigger → verify dropdown opens with search auto-focused
- Type "spot" → Spotify tile appears
- Click Spotify tile → dropdown closes → trigger shows "Spotify" + brand green SVG
- Click trigger → "Social" tab → verify Instagram, TikTok, etc. visible
- Keyboard: open → ArrowDown → Enter selects first icon
- Keyboard: open → Esc → dropdown closes without selection

## Mockup

No dedicated mockup — IconPicker is a reusable primitive component. Visual contract follows the tadaify design tokens (`var(--brand-primary)`, `var(--border)`, `var(--bg-elevated)`) used throughout existing modals. The block-editor mockup at `mockups/tadaify-mvp/app-block-editor.html` shows the icon field in context (Link block editor). All 10 visual checklist items in issue #205 serve as the visual acceptance gate.

## Rollback

```bash
git revert 295381d
```

No DB migrations — this is a pure frontend component with static data. No SSM parameters added. No Supabase schema changes.

Bundle rollback: `npm uninstall lucide-react simple-icons @radix-ui/react-popover` removes all new icon library code.
